### PR TITLE
Use CDNs instead of ruby served assets (Line number fix?)

### DIFF
--- a/lib/app/views/layout.erb
+++ b/lib/app/views/layout.erb
@@ -7,7 +7,7 @@
     <meta content='' name='description'>
     <meta content='' name='author'>
     <link href='/ico/favicon.png' rel='shortcut icon'>
-    <link href='/css/bootstrap.min.css' rel='stylesheet'>
+    <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
     <link href='/css/pygments.css' rel='stylesheet'>
   </head>
   <body>
@@ -49,7 +49,7 @@
         <p>&copy; Katrina Owen</p>
       </footer>
     </div>
-    <script src='/js/jquery.js'></script>
-    <script src='/js/bootstrap.min.js'></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I noticed that exercism isn't serving jQuery which might be causing the line number issue. I threw CDN script tags in there instead which should triple the download speeds in production in addition to making sure that our friend, $ works as expected. 
