### PR TITLE
prevent code line numbers from wrapping

### DIFF
--- a/lib/app/public/css/pygments.css
+++ b/lib/app/public/css/pygments.css
@@ -20,6 +20,10 @@
   overflow:auto;
 }
 
+td.gutter {
+    white-space: nowrap;
+}
+
 .highlight .lineno { padding-right: 10px; color: #999; }
 
 /* Pygments coloring */


### PR DESCRIPTION
This prevents triple digit line numbers from wrapping. There will continue to be a slight missmatch when the code wraps. 

Would it be easier to just push directly to master for these niggly 1 line changes? 
