### PR TITLE
Source Code Style

### DIFF
--- a/lib/app/public/css/pygments.css
+++ b/lib/app/public/css/pygments.css
@@ -1,23 +1,15 @@
-.highlight {
-  -moz-border-radius:3px;
-  -webkit-border-radius:3px;
-  background:transparent;
-}
-
-.highlight pre {
+pre.highlight  {
   background-color:#f8f8f8;
   border-radius:3px;
   border:1px solid #ccc;
 
-  padding:6px 10px;
-  margin-bottom: 20px;
-
   font: 'Bitstream Vera Sans Mono','Courier', monospace;
   font-size:14px;
-  color: black;
 
+  overflow-x: scroll;
+  overflow-y: hidden;
+  white-space: pre;
   line-height:26px;
-  overflow:auto;
 }
 
 td.gutter {


### PR DESCRIPTION
Original pygments style was not being applied because the class/element is different in this implementation. Also added overflow hidden and scrolling for the x and y.

So now the source code will not auto-wrap and you now scroll the div horizontally to see more of the source. In this example you'll notice that if a user composes a comment that runs long it will not automatically line break it.

I think this will ultimately make the source code more readable.

![screen shot 2013-06-23 at 2 37 00 pm](https://f.cloud.github.com/assets/244426/692743/03263dfc-dc45-11e2-8eec-a90aa756eaad.png)
