### PR TITLE
disable form submit buttons on click to prevent duplicate submissions

### DIFF
--- a/lib/app/public/js/script.js
+++ b/lib/app/public/js/script.js
@@ -86,4 +86,9 @@ $(function() {
     $(event.target).toggleClass("selected");
     $('#revision-' + revisionId).toggle();
   });
+
+  $('form input[type=submit], form button[type=submit]').on('click', function() {
+    var $this = $(this);
+    window.setTimeout(function() { $this.attr('disabled', true); }, 1);
+  });
 });


### PR DESCRIPTION
When I was trying to participate in a discussion from my phone's browser, I wasn't sure if I had successfully submitted the form, so I ended up sending the comment twice.  :flushed:

I believe this should be fairly safe, unless we're doing anything special with form buttons and javascript anywhere in the app.  What does everyone think?
