### PR TITLE
Refer to admin field on user. Fixes #107.

### DIFF
--- a/lib/app/auth.rb
+++ b/lib/app/auth.rb
@@ -6,6 +6,10 @@ class ExercismApp < Sinatra::Base
   end
 
   if ENV['RACK_ENV'] == 'development'
+    if User.count == 0
+      flash[:error] = "You'll want to run the seed script: `ruby scripts/seed.rb``"
+      redirect '/'
+    end
     get '/backdoor' do
       session[:github_id] = params[:id]
 

--- a/lib/app/views/backdoor.erb
+++ b/lib/app/views/backdoor.erb
@@ -1,4 +1,4 @@
 <% if ENV['RACK_ENV'].to_sym == :development %>
-<li><a href="/backdoor?id=<%= ENV.fetch('EXERCISM_ADMIN_ID') { 276834 } %>">be admin</a></li>
+  <li><a href="/backdoor?id=0">be admin</a></li>
   <li><a href="/backdoor?id=-1">be alice</a></li>
 <% end %>

--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -12,6 +12,8 @@ class User
   field :j_at, type: Time, default: ->{ Time.now.utc }
   field :adm, as: :is_admin, type: Boolean, default: false
 
+  alias_method :admin?, :is_admin
+
   has_many :submissions
 
   def self.from_github(id, username, email, avatar_url)
@@ -113,19 +115,11 @@ class User
     admin? || completed.size > 0
   end
 
-  def admin?
-    admin_users.include?(username)
-  end
-
   def new?
     !admin? && submissions.count == 0
   end
 
   private
-
-  def admin_users
-    %w(burtlo jcasimir kytrinyx vosechu theotherzach steveklabnik rubysolo seeflanigan splattael)
-  end
 
   def create_key
     Digest::SHA1.hexdigest(secret)

--- a/scripts/seed.rb
+++ b/scripts/seed.rb
@@ -15,13 +15,12 @@ end
 reset
 
 admin_data = {
-  username: 'kytrinyx',
-  github_id: 276834,
-  email: "katrina.owen@gmail.com",
-  current: {'ruby' => 'bob'}
+  username: 'admin',
+  github_id: 0,
+  email: "admin@example.com",
+  is_admin: true
 }
 admin = User.create(admin_data)
-attempt = Attempt.new(admin, "class Bob\nend", "bob.rb").save
 
 alice_data = {
   username: 'alice',


### PR DESCRIPTION
This is more scalable than having a hard-coded list of admins lying
around somewhere.

I've already migrated the existing admin list onto a field in user so that when this goes live, all previous admins will still be admins.

I was going to put the list in an environment variable, but that made setup more complicated if you are going to do any work on the codebase.

@vosechu Would you sanity check this?
