### PR TITLE
Move language-specific curricula definitions

### DIFF
--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -21,51 +21,25 @@ require 'exercism/use_cases/argument'
 require 'exercism/use_cases/assignments'
 require 'exercism/use_cases/launch'
 
+require 'exercism/curriculum/ruby'
+require 'exercism/curriculum/javascript'
+require 'exercism/curriculum/coffeescript'
+require 'exercism/curriculum/elixir'
+require 'exercism/curriculum/clojure'
+require 'exercism/curriculum/go'
+
 Mongoid.load!("./config/mongoid.yml")
 
 class Exercism
-  class UnknownLanguage < StandardError; end
 
   def self.current_curriculum
     unless @curriculum
       @curriculum = Curriculum.new('./assignments')
 
-      rb = Locale.new('ruby', 'rb', 'rb')
-      rb_slugs = %w(
-        bob word-count anagram beer-song nucleotide-count
-        rna-transcription point-mutations phone-number
-        grade-school robot-name leap etl meetup space-age grains
-        gigasecond triangle scrabble-score roman-numerals
-        binary prime-factors raindrops allergies strain
-        atbash-cipher accumulate crypto-square trinary
-        sieve simple-cipher octal luhn pig-latin pythagorean-triplet
-        series difference-of-squares secret-handshake linked-list wordy
-        hexadecimal largest-series-product kindergarden-garden
-        binary-search-tree matrix robot nth-prime
-        palindrome-products pascals-triangle say
-        sum-of-multiples queen-attack saddle-points ocr-numbers
-      )
-      @curriculum.add(rb, rb_slugs)
-
-      js = Locale.new('javascript', 'js', 'spec.js')
-      js_slugs = %w(
-        bob anagram
-      )
-      @curriculum.add(js, js_slugs)
-
-      elixir = Locale.new('elixir', 'exs', 'exs')
-      elixir_slugs = %w(
-        bob word-count anagram beer-song nucleotide-count
-        rna-transcription point-mutations phone-number
-        grade-school leap
-      )
-      @curriculum.add(elixir, elixir_slugs)
-
-      clojure = Locale.new('clojure', 'clj', 'clj')
-      clojure_slugs = %w(
-        kindergarden-garden queen-attack robot-simulator
-      )
-      @curriculum.add(clojure, clojure_slugs)
+      @curriculum.add RubyCurriculum.new
+      @curriculum.add JavascriptCurriculum.new
+      @curriculum.add ElixirCurriculum.new
+      @curriculum.add ClojureCurriculum.new
     end
 
     @curriculum

--- a/lib/exercism/curriculum.rb
+++ b/lib/exercism/curriculum.rb
@@ -1,3 +1,7 @@
+class Exercism
+  class UnknownLanguage < StandardError; end
+end
+
 class Curriculum
 
   attr_reader :path, :trails, :locales
@@ -7,9 +11,9 @@ class Curriculum
     @trails = {}
   end
 
-  def add(locale, slugs)
-    @trails[locale.to_sym] = Trail.new(locale, slugs, path)
-    @locales << locale
+  def add(curriculum)
+    @trails[curriculum.locale.to_sym] = Trail.new(curriculum.locale, curriculum.slugs, path)
+    @locales << curriculum.locale
   end
 
   def in(language)

--- a/lib/exercism/curriculum/clojure.rb
+++ b/lib/exercism/curriculum/clojure.rb
@@ -1,0 +1,13 @@
+class Exercism
+  class ClojureCurriculum
+    def slugs
+      %w(
+        kindergarden-garden queen-attack robot-simulator
+      )
+    end
+
+    def locale
+      Locale.new('clojure', 'clj', 'clj')
+    end
+  end
+end

--- a/lib/exercism/curriculum/coffeescript.rb
+++ b/lib/exercism/curriculum/coffeescript.rb
@@ -1,0 +1,9 @@
+class Exercism
+  class CoffeescriptCurriculum
+    def slugs
+    end
+
+    def locale
+    end
+  end
+end

--- a/lib/exercism/curriculum/elixir.rb
+++ b/lib/exercism/curriculum/elixir.rb
@@ -1,0 +1,15 @@
+class Exercism
+  class ElixirCurriculum
+    def slugs
+      %w(
+        bob word-count anagram beer-song nucleotide-count
+        rna-transcription point-mutations phone-number
+        grade-school leap
+      )
+    end
+
+    def locale
+      Locale.new('elixir', 'exs', 'exs')
+    end
+  end
+end

--- a/lib/exercism/curriculum/go.rb
+++ b/lib/exercism/curriculum/go.rb
@@ -1,0 +1,14 @@
+class Exercism
+  class GoCurriculum
+    def slugs
+      %(
+        bob word-count anagram nucleotide-count
+        binary
+      )
+    end
+
+    def locale
+      Locale.new('go', 'go', 'go')
+    end
+  end
+end

--- a/lib/exercism/curriculum/javascript.rb
+++ b/lib/exercism/curriculum/javascript.rb
@@ -1,0 +1,13 @@
+class Exercism
+  class JavascriptCurriculum
+    def slugs
+      %w(
+        bob anagram
+      )
+    end
+
+    def locale
+      Locale.new('javascript', 'js', 'spec.js')
+    end
+  end
+end

--- a/lib/exercism/curriculum/ruby.rb
+++ b/lib/exercism/curriculum/ruby.rb
@@ -1,0 +1,24 @@
+class Exercism
+  class RubyCurriculum
+    def slugs
+      %w(
+        bob word-count anagram beer-song nucleotide-count
+        rna-transcription point-mutations phone-number
+        grade-school robot-name leap etl meetup space-age grains
+        gigasecond triangle scrabble-score roman-numerals
+        binary prime-factors raindrops allergies strain
+        atbash-cipher accumulate crypto-square trinary
+        sieve simple-cipher octal luhn pig-latin pythagorean-triplet
+        series difference-of-squares secret-handshake linked-list wordy
+        hexadecimal largest-series-product kindergarden-garden
+        binary-search-tree matrix robot nth-prime
+        palindrome-products pascals-triangle say
+        sum-of-multiples queen-attack saddle-points ocr-numbers
+      )
+    end
+
+    def locale
+      Locale.new('ruby', 'rb', 'rb')
+    end
+  end
+end

--- a/test/exercism/curriculum_test.rb
+++ b/test/exercism/curriculum_test.rb
@@ -6,6 +6,26 @@ require 'exercism/trail'
 require 'exercism/exercise'
 require 'exercism/assignment'
 
+class NongCurriculum
+  def slugs
+    %w(one two)
+  end
+
+  def locale
+    Locale.new('nong', 'no', 'not')
+  end
+end
+
+class FempCurriculum
+  def slugs
+    %w(one two)
+  end
+
+  def locale
+    Locale.new('femp', 'fp', 'fpt')
+  end
+end
+
 # Integration tests.
 # This is the entry point into the app.
 class CurriculumTest < MiniTest::Unit::TestCase
@@ -13,8 +33,7 @@ class CurriculumTest < MiniTest::Unit::TestCase
   attr_reader :curriculum
   def setup
     @curriculum = Curriculum.new('./test/fixtures')
-    nong = Locale.new('nong', 'no', 'not')
-    curriculum.add(nong, %w(one two))
+    curriculum.add NongCurriculum.new
   end
 
   def test_curriculum_takes_a_path
@@ -40,10 +59,8 @@ class CurriculumTest < MiniTest::Unit::TestCase
 
   # Do I want an actual locale object, or just the language?
   def test_identify_language_from_filename
-    filename = 'one.fp'
-    femp = Locale.new('femp', 'fp', 'fpt')
-    curriculum.add(femp, %w(one two))
-    assert_equal 'femp', curriculum.identify_language('femp.fp')
+    curriculum.add FempCurriculum.new
+    assert_equal 'femp', curriculum.identify_language('one.fp')
   end
 
   def test_unknown_language
@@ -53,12 +70,9 @@ class CurriculumTest < MiniTest::Unit::TestCase
   end
 
   def test_unstarted_trails
-    femp = Locale.new('femp', 'fp', 'fpt')
-    turq = Locale.new('turq', 'tq', 'tqt')
-    curriculum.add(femp, %w(one two))
-    curriculum.add(turq, %w(one two))
+    curriculum.add FempCurriculum.new
     languages = curriculum.unstarted_trails(['femp'])
-    assert_equal %w(nong turq), languages
+    assert_equal ['nong'], languages
   end
 
 end

--- a/test/exercism/use_cases/approval_test.rb
+++ b/test/exercism/use_cases/approval_test.rb
@@ -1,12 +1,21 @@
 require './test/integration_helper'
 
+class NongCurriculum
+  def slugs
+    %w(one two)
+  end
+
+  def locale
+    Locale.new('nong', 'no', 'not')
+  end
+end
+
 class ApprovalTest < MiniTest::Unit::TestCase
 
   attr_reader :submission, :admin, :user, :curriculum
   def setup
     @curriculum = Curriculum.new('/tmp')
-    nong = Locale.new('nong', 'no', 'not')
-    @curriculum.add(nong, ['one', 'two'])
+    @curriculum.add NongCurriculum.new
     @user = User.create(username: 'allison', current: {'nong' => 'one'})
 
     attempt = Attempt.new(user, 'CODE', 'one.no', curriculum).save

--- a/test/exercism/use_cases/attempt_test.rb
+++ b/test/exercism/use_cases/attempt_test.rb
@@ -1,15 +1,33 @@
 require './test/integration_helper'
 
+class NongCurriculum
+  def slugs
+    %w(one two)
+  end
+
+  def locale
+    Locale.new('nong', 'no', 'not')
+  end
+end
+
+class FempCurriculum
+  def slugs
+    %w(one two)
+  end
+
+  def locale
+    Locale.new('femp', 'fp', 'fpt')
+  end
+end
+
 class AttemptTest < MiniTest::Unit::TestCase
 
   attr_reader :user, :curriculum
   def setup
     @user = User.create(current: {'nong' => 'one', 'femp' => 'one'})
     @curriculum = Curriculum.new('/tmp')
-    nong = Locale.new('nong', 'no', 'not')
-    femp = Locale.new('femp', 'fp', 'fpt')
-    @curriculum.add(nong, ['one'])
-    @curriculum.add(femp, ['one'])
+    @curriculum.add NongCurriculum.new
+    @curriculum.add FempCurriculum.new
   end
 
   def teardown


### PR DESCRIPTION
They don't need to be specified in-your-face style in the main exercism class.

I added empty slots for coffeescript and go, even though we haven't officially opened those trails yet.

@rubysolo Would you mind sanity-checking this?
