### PR TITLE
Make the language icon consistent across all cases

### DIFF
--- a/lib/app/views/work.erb
+++ b/lib/app/views/work.erb
@@ -1,16 +1,14 @@
 <div>
+  <%= language_icon(work.language) %>
   <% if work.submitted? %>
-    <%= language_icon(work.language) %>
     <a href="/user/submissions/<%= work.id %>">
       <h4 style="display: inline"><%= work.slug %></h4></a>
     <div class="nits circle"><%= work.nits.count %></div>
     <div class="arguments circle"><%= work.argument_count %></div>
   <% elsif work.slug == 'congratulations' %>
-    <%= language_icon(work.language) %>
     <span class="label label-info">No more Assignments</span>
   <% else %>
     <h4 style="display: inline"><%= work.slug %></h4>
-    <%= language_icon(work.language) %>
     <span class="label label-info">Not Started</span>
   <% end %>
 </div>


### PR DESCRIPTION
I like the new placement of the language icon, but it's on the left side for submitted assignments (and presumably finished tracks), but switches back to the right for unstarted assignments.  This makes it consistent.
![screen shot 2013-07-09 at 7 58 31 am](https://f.cloud.github.com/assets/1642/768444/b1780c4e-e89f-11e2-9ad4-96167639a323.png)
