### PR TITLE
Add `rake` gem to Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "http://rubygems.org"
 
 ruby "1.9.3"
 
+gem 'rake'
 gem 'faraday'
 gem 'mongoid'
 gem 'petroglyph'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rake (10.1.0)
     redcarpet (2.3.0)
     rouge (0.3.2)
       thor
@@ -107,6 +108,7 @@ DEPENDENCIES
   puma
   rack-flash3
   rack-test
+  rake
   redcarpet
   rouge
   sinatra


### PR DESCRIPTION
Before this commit typing `rake test` leads to this error:

```
$ rake test
/home/peter/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/rake/ext/module.rb:36:in `const_missing': uninitialized constant Sinatra::Base (NameError)
  from /home/peter/.rvm/gems/ruby-1.9.3-p194@pg/gems/mongoid-3.1.4/lib/mongoid/config/environment.rb:23:in
`env_name'
  from /home/peter/.rvm/gems/ruby-1.9.3-p194@pg/gems/mongoid-3.1.4/lib/mongoid/config/environment.rb:39:in
`load_yaml'
```

Running `bundle exec rake test` fails too with:

```
$ bundle exec rake test
/home/peter/.rvm/gems/ruby-1.9.3-p194@global/gems/bundler-1.3.5/lib/bundler/rubygems_integration.rb:214:in `block in replace_gem': rake is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
  from /home/peter/.rvm/gems/ruby-1.9.3-p194@pg/bin/rake:18:in `<main>'
  from /home/peter/.rvm/gems/ruby-1.9.3-p194@pg/bin/ruby_noexec_wrapper:14:in
`eval'
  from /home/peter/.rvm/gems/ruby-1.9.3-p194@pg/bin/ruby_noexec_wrapper:14:in
`<main>'
```

Adding `rake` to Gemfile fixes this issue.
