### PR TITLE
Fix test_admin_may_nitpick_stuff.

### DIFF
--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -64,7 +64,7 @@ class UserTest < MiniTest::Unit::TestCase
   end
 
   def test_admin_may_nitpick_stuff
-    admin = User.new(username: 'burtlo')
+    admin = User.new(username: 'burtlo', is_admin: true)
     assert admin.may_nitpick?(Exercise.new('lang', 'exercise'))
   end
 


### PR DESCRIPTION
Setup user to be an admin so he may nitpick stuff.

Before this commit I saw this failure:

```
$ bundle exec ruby -Ilib:test test/exercism/user_test.rb  -n
test_admin_may_nitpick_stuff
Run options: -n test_admin_may_nitpick_stuff --seed 42383

# Running tests:

F

Fabulous tests in 0.020076s, 49.8119 tests/s, 49.8119 assertions/s.

  1) Failure:
UserTest#test_admin_may_nitpick_stuff [test/exercism/user_test.rb:68]:
Failed assertion, no message given.

1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
```

After the change the test passes again:

```
$ bundle exec ruby -Ilib:test test/exercism/user_test.rb  -n
test_admin_may_nitpick_stuff
Run options: -n test_admin_may_nitpick_stuff --seed 3942

# Running tests:

.

Fabulous tests in 0.019833s, 50.4200 tests/s, 50.4200 assertions/s.

1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
```

Am I missing something or is this test wrong?
