### PR TITLE
Fix startup failure in development mode.

### DIFF
--- a/lib/app/auth.rb
+++ b/lib/app/auth.rb
@@ -6,11 +6,12 @@ class ExercismApp < Sinatra::Base
   end
 
   if ENV['RACK_ENV'] == 'development'
-    if User.count == 0
-      flash[:error] = "You'll want to run the seed script: `ruby scripts/seed.rb``"
-      redirect '/'
-    end
     get '/backdoor' do
+      if User.count == 0
+        flash[:error] = "You'll want to run the seed script: `ruby scripts/seed.rb``"
+        redirect '/'
+      end
+
       session[:github_id] = params[:id]
 
       if !current_user.admin? && current_user.submissions.count == 0


### PR DESCRIPTION
Having an empty database and starting server
via `rackup -p 4567` fails with:

```
$ be rackup -p 4567
/home/peter/devel/exercism.io/lib/app/auth.rb:10:in
`<class:ExercismApp>': undefined local variable or method `flash' for ExercismApp:Class (NameError)
```
