### PR TITLE
Add simplecov to test process.

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,3 @@
+SimpleCov.start do
+  add_filter "/test/"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ group :test, :development do
   gem 'rack-test', require: false
   gem 'mocha', require: false
   gem 'mailcatcher'
+  gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,10 @@ GEM
       rack (>= 1.0)
     rake (10.1.0)
     redcarpet (2.3.0)
+    simplecov (0.7.1)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.7.1)
+    simplecov-html (0.7.1)
     sinatra (1.4.2)
       rack (~> 1.5, >= 1.5.2)
       rack-protection (~> 1.4)
@@ -117,4 +121,5 @@ DEPENDENCIES
   rake
   redcarpet
   rouge!
+  simplecov
   sinatra

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Run tests with: `rake test`
 
 Make sure that `mailcatcher` is running.
 
+### Code coverage
+
+To enable code coverage run:
+
+    COVERAGE=1 rake test
+
+Browser the results located in `coverage/index.html`
+
 ## Deployment
 
 Let Heroku know that Lineman will be building our assets. From the command line:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 $:.unshift File.expand_path("../../lib", __FILE__)
 
 ENV['RACK_ENV'] = 'test'
+require 'simplecov' if ENV['COVERAGE']
 
 require 'minitest/autorun'
 require 'minitest/pride'


### PR DESCRIPTION
By running

```
COVERAGE=1 rake test
```

you enable code coverage provided by simplecov.

Browser the results located in `coverage/index.html`.
