### PR TITLE
Refactor example in ruby/point-mutations.

### DIFF
--- a/assignments/ruby/point-mutations/example.rb
+++ b/assignments/ruby/point-mutations/example.rb
@@ -6,8 +6,8 @@ class DNA
   end
 
   def hamming_distance(other_strand)
-    strand.chars.zip(other_strand.chars).reject do |a, b|
-      a == b || b.nil?
-    end.size
+    strand.chars.zip(other_strand.chars).count do |a, b|
+      b && a != b
+    end
   end
 end


### PR DESCRIPTION
Use `count` instead of `reject` and `size`.

Suggestion was made at http://exercism.io/user/submissions/51c853d32f2157ecbe000004
