### PR TITLE
Remember previous filters

### DIFF
--- a/frontend/app/js/models/select_filter.js
+++ b/frontend/app/js/models/select_filter.js
@@ -9,5 +9,24 @@ exercism.models.SelectFilter = Backbone.Model.extend({
 
   setCheck: function (attribute, value) {
     this.set(attribute, value ? "0" : "All" );
+  },
+
+  setElementFromRoute: function (element, index, list)  {
+    this.set(element.split("=")[0], element.split("=")[1]);
+  },
+
+  setFromRoute: function (route) {
+    var pairs = route.split("&");
+    _.each(pairs, this.setElementFromRoute, this);
+  },
+
+  getRoute: function () {
+    return _.reduce(this.attributes, this.routeSegment, "", this);
+  },
+
+  routeSegment: function (memo, element, index) {
+    var segment = (index !== "user") ? "&" : "";
+    return memo + segment + index + "=" + element;
   }
+
 });

--- a/frontend/app/js/namespace.js
+++ b/frontend/app/js/namespace.js
@@ -1,4 +1,5 @@
 window.exercism = {
   views: {},
-  models: {}
+  models: {},
+  routers: {}
 };

--- a/frontend/app/js/routers/application.js
+++ b/frontend/app/js/routers/application.js
@@ -1,0 +1,10 @@
+exercism.routers.Application = Backbone.Router.extend({
+  routes: {
+    "*filters" : "applyFilters"
+  },
+
+  applyFilters: function(filters) {
+    if (filters !== null) { exercism.views.selectFilter.model.setFromRoute(filters); }
+    exercism.views.selectFilter.render();
+  }
+});

--- a/frontend/app/js/script.js
+++ b/frontend/app/js/script.js
@@ -2,6 +2,9 @@ $(function() {
   $('.dropdown-toggle').dropdown();
   exercism.models.selectFilter = new exercism.models.SelectFilter();
   exercism.views.selectFilter = new exercism.views.SelectFilter({ model: exercism.models.selectFilter });
+
+  exercism.routers.application = new exercism.routers.Application();
+  Backbone.history.start();
 });
 
 //TODO move all variable declaration to the tops of functions.

--- a/frontend/app/js/views/select_filter.js
+++ b/frontend/app/js/views/select_filter.js
@@ -4,6 +4,9 @@ exercism.views.SelectFilter = Backbone.View.extend({
     "click a[data-action=set-filter]": "filterClick",
     "click input[data-action=set-filter]": "checkClick"
   },
+  initialize: function() {
+    this.render();
+  },
   filter: function (filter, value) {
     $('div[data-' + filter + '][' + 'data-' + filter + '!=' + value + ']').hide();
     $('a#all-' + filter).show();
@@ -24,22 +27,41 @@ exercism.views.SelectFilter = Backbone.View.extend({
       this.filter(index, element);
     }
   },
+
   renderFilters: function () {
     this.showAll();
     _.each(this.model.attributes, this.filters, this);
   },
+
+  renderComponents: function() {
+    $('button[data-filter=user]>span').first().html((this.model.get('user') === "All") ? "User" : this.model.get('user'));
+    $('button[data-filter=exercise]>span').first().html((this.model.get('exercise') === "All") ? "Exercise" : this.model.get('exercise'));
+    $('button[data-filter=language]>span').first().html((this.model.get('language') === "All") ? "Language" : this.model.get('language'));
+    if (this.model.get('nits') !== 'All') {
+      $('input[data-filter=nits]').prop('checked', true);
+    }
+    if (this.model.get('arguments') !== 'All') {
+      $('input[data-filter=arguments]').prop('checked', true);
+    }
+
+  },
+
+  render: function() {
+    this.renderFilters();
+    this.renderComponents();
+  },
   filterClick: function (event) {
+    event.preventDefault();
     var value = $(event.currentTarget).html().trim();
     var target = $(event.currentTarget).attr('data-target');
     var filter = $(target).attr('data-filter');
     this.model.set(filter, value);
-    $(target + '>span').first().html(value);
-    this.renderFilters();
+    exercism.routers.application.navigate(this.model.getRoute(), {trigger: true} );
   },
   checkClick: function (event) {
     var filter = $(event.currentTarget).attr('data-filter');
     this.model.setCheck(filter, $(event.currentTarget).is(':checked'));
-    this.renderFilters();
+    exercism.routers.application.navigate(this.model.getRoute(), {trigger: true} );
   }
 });
 


### PR DESCRIPTION
This fixes issue #221 (and as a side-effect fixes issue #131).

A small usability note.  This remembers every filter click individually in history and consequently creates a long back button chain if you want to get to the actual previous page.  That might be okay; I'm not really sure.  For me personally, I think I would prefer it only to remember the final state of your filters for the single back click when returning to the page.  Backbone has a mechanism for this, but in the code's current state it completely hijacks the history in a undesirably destructive way.  If this is something that is desired, then I can work on the refactor that will allow for it (there is needed refactor work in there anyway).
