### PR TITLE
Deprecate the /user/submissions/:id url

### DIFF
--- a/lib/app/submissions.rb
+++ b/lib/app/submissions.rb
@@ -49,14 +49,7 @@ class ExercismApp < Sinatra::Base
   end
 
   get '/user/submissions/:id' do |id|
-    submission = Submission.find(id)
-    if current_user.guest?
-      redirect login_url("/user/submissions/#{id}")
-    elsif current_user != submission.user
-      flash[:error] = 'That is not your submission.'
-      redirect '/'
-    end
-    erb :submission, locals: {submission: Submission.find(id)}
+    redirect "/submissions/#{id}"
   end
 
   get '/submissions/:id' do |id|
@@ -66,12 +59,16 @@ class ExercismApp < Sinatra::Base
 
     submission = Submission.find(id)
 
-    unless current_user.may_nitpick?(submission.exercise)
-      flash[:error] = "You do not have permission to nitpick that exercise."
-      redirect '/'
-    end
+    if current_user == submission.user
+      erb :submission, locals: {submission: submission}
+    else
+      unless current_user.may_nitpick?(submission.exercise)
+        flash[:error] = "You do not have permission to nitpick that exercise."
+        redirect '/'
+      end
 
-    erb :nitpick, locals: {submission: submission}
+      erb :nitpick, locals: {submission: submission}
+    end
   end
 
   # TODO: Write javascript to submit form here
@@ -118,11 +115,7 @@ class ExercismApp < Sinatra::Base
       submission = argument.submission
     end
 
-    if submission.user == current_user
-      redirect "/user/submissions/#{id}"
-    else
-      redirect "/submissions/#{id}"
-    end
+    redirect "/submissions/#{id}"
   end
 
   get '/submissions/:language/:assignment' do |language, assignment|

--- a/lib/app/views/code/submission.erb
+++ b/lib/app/views/code/submission.erb
@@ -2,15 +2,9 @@
   <%= "style='#{html[:style]}'" if html[:style] %>
   class="code span6">
   <h2>
-    <% if current_user.is?(submission.user.username) %>
-      <a href="/user/submissions/<%= submission.id %>">
-        <%= title %>
-      </a>
-    <% else %>
-      <a href="/submissions/<%= submission.id %>">
-        <%= title %>
-      </a>
-    <% end %>
+    <a href="/submissions/<%= submission.id %>">
+      <%= title %>
+    </a>
     <div style="float: right;">
     <span class="badge badge-important"><%= submission.nits.count %>
     </span>

--- a/lib/app/views/work.erb
+++ b/lib/app/views/work.erb
@@ -1,7 +1,7 @@
 <div>
   <%= language_icon(work.language) %>
   <% if work.submitted? %>
-    <a href="/user/submissions/<%= work.id %>">
+    <a href="/submissions/<%= work.id %>">
       <h4 style="display: inline"><%= work.slug %></h4></a>
     <div class="nits circle"><%= work.nits.count %></div>
     <div class="arguments circle"><%= work.argument_count %></div>

--- a/lib/services/email/nitpick.erb
+++ b/lib/services/email/nitpick.erb
@@ -2,4 +2,4 @@ Hi <%= name %>,
 
 Your submission on <%= exercise.name %> in <%= exercise.language %> has received feedback from <%= from %>!
 
-Visit <%= site_root %>/user/submissions/<%= submission.id %> to find out more.
+Visit <%= site_root %>/submissions/<%= submission.id %> to find out more.

--- a/test/fixtures/approvals/nitpick_email_body.approved.txt
+++ b/test/fixtures/approvals/nitpick_email_body.approved.txt
@@ -2,4 +2,4 @@ Hi bob,
 
 Your submission on Word Count in ruby has received feedback from alice!
 
-Visit http://example.com/user/submissions/ID to find out more.
+Visit http://example.com/submissions/ID to find out more.


### PR DESCRIPTION
For now, redirect to /submissions/:id and render the user-specific
version if it's the user. I'm guessing we'll end up rendering the same
page eventually.

We were doing a bit too much switching all over the place. At least here it collects it into one place. I _think_ I got all the links changed, but our view code is somewhat haphazard, and I don't trust myself entirely.

@theotherzach Would you mind sanity-checking this?
