### PR TITLE
Toggle read notifications via check

### DIFF
--- a/frontend/app/css/notifications.less
+++ b/frontend/app/css/notifications.less
@@ -47,6 +47,14 @@ li.notification {
   list-style: none;
   padding: 1em;
   margin-bottom: .125em;
+  .check {
+    cursor: pointer;
+    margin-right: .25em;
+  }
+}
+
+.check:after {
+  content: '✔';
 }
 
 li.new-notification {

--- a/frontend/app/js/views/notification.js
+++ b/frontend/app/js/views/notification.js
@@ -6,7 +6,7 @@ exercism.views.Notification = Backbone.View.extend({
   className: "notification message",
 
   events: {
-    "click a": "read"
+    "click .check": "toggleRead"
   },
 
   initialize: function(options) {
@@ -20,11 +20,9 @@ exercism.views.Notification = Backbone.View.extend({
     return this;
   },
 
-  read: function() {
+  toggleRead: function() {
     console.log("model marked read");
-    if (!(this.model.get("read"))) {
-      this.model.save("read", true);
-    }
+      this.model.save("read", !(this.model.get("read")));
   },
 
   readStatus: function() {

--- a/frontend/app/templates/notification.us
+++ b/frontend/app/templates/notification.us
@@ -1,2 +1,2 @@
-New <a href="<%= link %>"><%= regarding %></a> from <%= from %>.
+<span class="check"></span><a href="<%= link %>"><%= regarding %></a> from <%= from %>.
 <div class="notifation date"><%= humanReadableDate %></div>


### PR DESCRIPTION
This fixes #260

Moved the control of marking notifcations as read
to the user. They now toggle read state via a
unicode checkbox.

Prior to this commit, I was attempting to mark
notifications as read when the link was clicked.
This failed whenever
- somebody right clicked a link
- the navigation occured before a post could happen
