### PR TITLE
Convert assignments to Rust

### DIFF
--- a/assignments/rust/bob_test.rs
+++ b/assignments/rust/bob_test.rs
@@ -1,0 +1,60 @@
+#[link(name = "bob", vers = "1.0")];
+#[crate_type = "lib"];
+
+extern mod std;
+
+mod bob;
+
+#[test]
+fn test_statement() {
+    assert_eq!("Whatever.", bob::reply("Tom-ay-to, tom-aaaah-to."));
+}
+
+#[test]
+#[should_fail]
+fn test_shouting() {
+    assert_eq!("Woah, chill out!", bob::reply("WATCH OUT!"));
+}
+
+#[test]
+#[should_fail]
+fn test_exclaiming() {
+    assert_eq!("Whatever.", bob::reply("Let's go make out behind the gym!"));
+}
+
+#[test]
+#[should_fail]
+fn test_asking() {
+    assert_eq!("Sure.", bob::reply("Does this cryogenic chamber make me look fat?"));
+}
+
+#[test]
+#[should_fail]
+fn test_shout_numbers() {
+    assert_eq!("Woah, chill out!", bob::reply("1, 2, 3 GO!"));
+}
+
+#[test]
+#[should_fail]
+fn test_shout_weird_characters() {
+    assert_eq!("Woah, chill out!", bob::reply("ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!"));
+}
+
+#[test]
+#[should_fail]
+fn test_shout_without_punctuation() {
+    assert_eq!("Woah, chill out!", bob::reply("I HATE YOU"));
+}
+
+#[test]
+#[should_fail]
+fn test_shout_without_question_mark() {
+    assert_eq!("Whatever.", bob::reply("Ending with ? means a question."));
+}
+
+#[test]
+#[should_fail]
+fn test_silent_treatment() {
+    assert_eq!("Fine. Be that way.", bob::reply(""));
+}
+

--- a/assignments/rust/example.rs
+++ b/assignments/rust/example.rs
@@ -1,0 +1,3 @@
+pub fn reply(drivel: &str) -> &str { 
+    "world"
+}


### PR DESCRIPTION
This is obviously wip at the moment. I am building this from https://github.com/mozilla/rust/commit/c124f21af527dfc954e748a7df82af64957676b6 , which is Rust 0.8-pre. I'm not sure how much time it will take me to get this going, and generally, it's best to stay on HEAD right now anyway.

To go:
- [ ] bob
- [ ] word-count
- [ ] anagram
- [ ] beer-song
- [ ] nucleotide-count
- [ ] rna-transcription
- [ ] point-mutations
- [ ] phone-number
- [ ] grade-school
- [ ] robot-name
- [ ] leap
- [ ] etl
- [ ] meetup
- [ ] space-age
- [ ] grains
- [ ] gigasecond
- [ ] triangle
- [ ] scrabble-score
- [ ] roman-numerals
- [ ] binary
- [ ] prime-factors
- [ ] raindrops
- [ ] allergies
- [ ] strain
- [ ] atbash-cipher
- [ ] accumulate
- [ ] crypto-square
- [ ] trinary
- [ ] sieve
- [ ] simple-cipher
- [ ] octal
- [ ] luhn
- [ ] pig-latin
- [ ] pythagorean-triplet
- [ ] series
- [ ] difference-of-squares
- [ ] secret-handshake
- [ ] linked-list
- [ ] wordy
- [ ] hexadecimal
- [ ] largest-series-product
- [ ] kindergarden-garden
- [ ] binary-search-tree
- [ ] matrix
- [ ] robot-simulator
- [ ] nth-prime
- [ ] palindrome-products
- [ ] pascals-triangle
- [ ] say
- [ ] sum-of-multiples
- [ ] queen-attack
- [ ] saddle-points
- [ ] ocr-numbers
