### PR TITLE
Fix link to precompiled elixir packages

### DIFF
--- a/lib/app/views/account.erb
+++ b/lib/app/views/account.erb
@@ -118,7 +118,7 @@
       <li>Fedora 17+ and Fedora Rawhide: <code>sudo yum -y install elixir</code></li>
       <li>Arch Linux : Elixir is available on AUR via <code>yaourt -S elixir</code></li>
       <li>Other: Get <a href="http://www.erlang.org/download.html">Erlang R16B</a>, then download a
-        <a href="http://elixir-lang.org/packages.html">precompiled package</a></li>
+        <a href="https://github.com/elixir-lang/elixir/releases/">precompiled package</a></li>
     </ul>
 
     <h4>Running tests:</h4>


### PR DESCRIPTION
I clicked the link and got a 404.  This is where the elixir-lang site
leads when you click to download precompiled packages now.
