### PR TITLE
Fix "ReferenceError: Bob is not defined" for correct use of module.exports

### DIFF
--- a/assignments/javascript/bob/bob_test.spec.js
+++ b/assignments/javascript/bob/bob_test.spec.js
@@ -1,4 +1,4 @@
-require('./bob');
+var Bob = require('./bob');
 
 describe("Bob", function() {
   var bob = new Bob();


### PR DESCRIPTION
Without this fix the only way to make the spec work is to use `global.Bob = Bob;` in `bob.js`, which is not quite correct.
