### PR TITLE
Increase nodification panel width

### DIFF
--- a/frontend/app/css/notifications.less
+++ b/frontend/app/css/notifications.less
@@ -31,8 +31,8 @@
 #list-notifications {
   position: relative;
   opacity: 0;
-  right: -15em;
-  width: 15em;
+  right: -17.5em;
+  width: 17.5em;
   height: 0;
   overflow: hidden;
 }
@@ -72,7 +72,7 @@ li.new-notification {
   overflow-y: auto;
   height: auto;
   min-height: 5em;
-  max-height: 75%;
+  max-height: 100%;
 }
 
 #list-notifications {
@@ -83,7 +83,6 @@ body {
 }
 
 body.reveal-notifications {
-  margin-right: 15em;
-  margin-left: -15em;
-  transition: all .3s ease-in-out;
+  margin-right: 17.5em;
+  margin-left: -17.5em;
 }


### PR DESCRIPTION
Per #269 this should make the notifications feel less cramped. Here we
increase the width from 15em to 17.5em and use the entire window height.

Before: 
![screen shot 2013-08-01 at 12 34 54 pm](https://f.cloud.github.com/assets/1697198/895273/0d51fdbe-fac9-11e2-8982-ed158dc37bf2.png)

After:
![screen shot 2013-08-01 at 12 34 24 pm](https://f.cloud.github.com/assets/1697198/895277/1399ea42-fac9-11e2-9641-d5557bafc414.png)
