### PR TITLE
Fixed 500 on peek when there are no more exercises [fix #238]

### DIFF
--- a/lib/app/api.rb
+++ b/lib/app/api.rb
@@ -48,8 +48,10 @@ class ExercismApp < Sinatra::Base
       halt 401, {error: "Please provide API key"}.to_json
     end
 
-    assignments = Assignments.new(params[:key])
+    assignments = Assignments.new(params[:key]).next
 
-    pg :assignments, locals: {assignments: assignments.next}
+    halt 404, 'No more assignments!' if assignments.empty?
+
+    pg :assignments, locals: {assignments: assignments}
   end
 end

--- a/lib/exercism/use_cases/assignments.rb
+++ b/lib/exercism/use_cases/assignments.rb
@@ -38,7 +38,7 @@ class Assignments
       exercise = curriculum.in(exercise.language).successor(exercise)
       next if exercise.slug == 'congratulations'
       curriculum.assign(exercise)
-    end
+    end.compact
   end
 
   def completed_exercises

--- a/test/app/api_test.rb
+++ b/test/app/api_test.rb
@@ -91,4 +91,25 @@ class ApiTest < Minitest::Test
     options = {format: :json, name: 'api_peek_on_two_incomplete_trails'}
     Approvals.verify(output, options)
   end
+
+  def test_peek_behind_complete_trail
+    user = User.create(github_id: 2, current: {'ruby' => 'congratulations'})
+
+    get '/api/v1/user/assignments/next', {key: user.key}
+
+    assert_equal 404, last_response.status
+    assert_equal "No more assignments!", last_response.body
+  end
+
+  def test_peek_returns_assignments_for_incomplete_trails
+    user = User.create(github_id: 2, current: {'ruby' => 'congratulations', 'clojure' => 'bob'})
+
+    get '/api/v1/user/assignments/next', {key: user.key}
+
+    assert_equal 200, last_response.status
+
+    output = last_response.body
+    options = {format: :json, name: 'api_peek_with_complete_trail'}
+    Approvals.verify(output, options)
+  end
 end

--- a/test/fixtures/approvals/api_peek_on_two_incomplete_trails.approved.json
+++ b/test/fixtures/approvals/api_peek_on_two_incomplete_trails.approved.json
@@ -1,0 +1,18 @@
+{
+  "assignments": [
+    {
+      "track": "ruby",
+      "slug": "rna-transcription",
+      "readme": "# Rna Transcription\n\nWrite a program that can translate a given DNA string to the transcribed RNA string corresponding to it.\n\nBoth DNA and RNA strands are a sequence of nucleotides.\n\nThe four nucleotides found in DNA are adenine (**A**), cytosine (**C**), guanine (**G**) and thymine (**T**).\n\nThe four nucleotides found in RNA are adenine (**A**), cytosine (**C**), guanine (**G**) and uracil (**U**).\n\nGiven a DNA strand, its transcribed RNA strand is formed by replacing all occurrences of thymine with uracil.\n\n\n\n## Source\n\nRosalind [view source](http://rosalind.info/problems/rna)\n",
+      "test_file": "rna-transcription_test.rb",
+      "tests": "require 'minitest/autorun'\nrequire_relative 'dna'\n\nclass DNATest < MiniTest::Unit::TestCase\n\n  def test_transcribes_cytidine_unchanged\n    assert_equal 'C', DNA.new(\"C\").to_rna\n  end\n\n  def test_transcribes_guanosine_unchanged\n    skip\n    assert_equal 'G', DNA.new(\"G\").to_rna\n  end\n\n  def test_transcribes_adenosine_unchanged\n    skip\n    assert_equal 'A', DNA.new(\"A\").to_rna\n  end\n\n  def test_it_transcribes_thymidine_to_uracil\n    skip\n    assert_equal 'U', DNA.new(\"T\").to_rna\n  end\n\n  def test_it_transcribes_all_occurrences_of_thymidine_to_uracil\n    skip\n    assert_equal 'ACGUGGUCUUAA', DNA.new('ACGTGGTCTTAA').to_rna\n  end\n\nend\n"
+    },
+    {
+      "track": "clojure",
+      "slug": "word-count",
+      "readme": "# Word Count\n\nWrite a program that given a phrase can count the occurrences of each word in that phrase.\n\nFor example for the input `\"olly olly in come free\"`\n\n```plain\nolly: 2\nin: 1\ncome: 1\nfree: 1\n```\n\n\n\n## Source\n\nThe golang tour [view source](http://tour.golang.org)\n",
+      "test_file": "word-count_test.clj",
+      "tests": "(ns word-count.test (:use clojure.test))\n(load-file \"word_count.clj\")\n\n(deftest count-one-word\n  (is (= {\"word\" 1}\n         (phrase/word-count \"word\"))))\n\n(deftest count-one-of-each\n  (is (= {\"one\" 1 \"of\" 1 \"each\" 1}\n         (phrase/word-count \"one of each\"))))\n\n(deftest count-multiple-occurrences\n  (is (= {\"one\" 1 \"fish\" 4 \"two\" 1 \"red\" 1 \"blue\" 1}\n         (phrase/word-count \"one fish two fish red fish blue fish\"))))\n\n(deftest ignore-punctuation\n  (is (= {\"car\" 1, \"carpet\" 1 \"as\" 1 \"java\" 1 \"javascript\" 1}\n         (phrase/word-count \"car : carpet as java : javascript!!&@$%^&\"))))\n\n(deftest include-numbers\n  (is (= {\"testing\" 2 \"1\" 1 \"2\" 1}\n         (phrase/word-count \"testing, 1, 2 testing\"))))\n\n(deftest normalize-case\n  (is (= {\"go\" 3}\n         (phrase/word-count \"go Go GO\"))))\n\n(run-tests)\n"
+    }
+  ]
+}

--- a/test/fixtures/approvals/api_peek_with_complete_trail.approved.json
+++ b/test/fixtures/approvals/api_peek_with_complete_trail.approved.json
@@ -1,0 +1,11 @@
+{
+  "assignments": [
+    {
+      "track": "clojure",
+      "slug": "rna-transcription",
+      "readme": "# Rna Transcription\n\nWrite a program that can translate a given DNA string to the transcribed RNA string corresponding to it.\n\nBoth DNA and RNA strands are a sequence of nucleotides.\n\nThe four nucleotides found in DNA are adenine (**A**), cytosine (**C**), guanine (**G**) and thymine (**T**).\n\nThe four nucleotides found in RNA are adenine (**A**), cytosine (**C**), guanine (**G**) and uracil (**U**).\n\nGiven a DNA strand, its transcribed RNA strand is formed by replacing all occurrences of thymine with uracil.\n\n\n\n## Source\n\nRosalind [view source](http://rosalind.info/problems/rna)\n",
+      "test_file": "rna-transcription_test.clj",
+      "tests": "(ns rna-transcription.test (:use clojure.test))\n(load-file \"dna.clj\")\n\n(deftest transcribes-cytidine-unchanged\n  (is (= \"C\" (dna/to-rna \"C\"))))\n\n(deftest transcribes-guanosine-unchanged\n  (is (= \"G\" (dna/to-rna \"G\"))))\n\n(deftest transcribes-adenosine-unchanged\n  (is (= \"A\" (dna/to-rna \"A\"))))\n\n(deftest it-transcribes-thymidine-to-uracil\n  (is (= \"U\" (dna/to-rna \"T\"))))\n\n(deftest it-transcribes-all-occurrences-of-thymidine-to-uracil\n  (is (= \"ACGUGGUCUUAA\" (dna/to-rna \"ACGTGGTCTTAA\"))))\n\n(run-tests)\n"
+    }
+  ]
+}


### PR DESCRIPTION
Nobody wants to nitpick my code on exercism, so I decided to go deeper.

Please don’t consider this as a complete fix since it’s more of a rough draft.

Since user can have multiple tracks running, I can see two options here:
- Silently ignore completed tracks when there is at least one incomplete (for which we can provide a peek) and throw a message if we can’t (that’s what I’m doing in this PR.)
- Mark completed tracks in response, then handle it in CLI. This requires some refactoring and breaks compatibility with current CLI (not a big deal though since it just changes error message.)

But hey, it’s 7 AM so I can be wrong.
