### PR TITLE
Fix different duplicates test

### DIFF
--- a/assignments/ruby/anagram/anagram_test.rb
+++ b/assignments/ruby/anagram/anagram_test.rb
@@ -25,7 +25,13 @@ class AnagramTest < MiniTest::Unit::TestCase
   def test_does_not_confuse_different_duplicates
     skip
     detector = Anagram.new('abb')
-    assert_equal [], detector.match(['caa'])
+    assert_equal [], detector.match(['aab'])
+  end
+
+  def test_eliminate_anagrams_with_same_checksum
+    skip
+    detector = Anagram.new('abb')
+    assert_equal [], detector.match(['aac'])
   end
 
   def test_detect_anagram


### PR DESCRIPTION
If anyone uses `sum` method, all tests pass in old version. Now `test_does_not_confuse_different_duplicates` test fails.

For example:

```
def anagram?(anagram)
    anagram.downcase.sum == @sequence.downcase.sum
end
```
