### PR TITLE
Refining the tests for how Bob responds to silence

### DIFF
--- a/assignments/elixir/bob/bob_test.exs
+++ b/assignments/elixir/bob/bob_test.exs
@@ -40,4 +40,12 @@ defmodule TeenagerTest do
   test "silence" do
     # assert Teenager.hey("") == "Fine. Be that way!"
   end
+
+  test "empty silence" do
+    # assert Teenager.hey(nil) == "Fine. Be that way!"
+  end
+
+  test "prolonged silence" do
+    # assert Teenager.hey("  ") == "Fine. Be that way!"
+  end
 end

--- a/assignments/ruby/bob/bob_test.rb
+++ b/assignments/ruby/bob/bob_test.rb
@@ -73,6 +73,11 @@ begin
       skip
       assert_equal 'Fine. Be that way!', teenager.hey(nil)
     end
+
+    def test_prolonged_silence
+      skip
+      assert_equal 'Fine. Be that way!', teenager.hey('    ')
+    end
   end
 
 rescue LoadError => e


### PR DESCRIPTION
The Elixir suite case doesn't current check for nil, while the Ruby test
suite demands that nil be understood as a form of silence. This adds a
test to the Elixir quite to check for nil.

It also adds a test case for a different kind of "empty" string: one
consisting solely of spaces, such as `"    "`.  Both of these test suites
will now check to see that is correctly interpreted as silence rather
than shouting (because `"   ".upcase == "   "`).
