### PR TITLE
Look for Bob first, not TeenagerTest::Bob

### DIFF
--- a/assignments/ruby/bob/bob_test.rb
+++ b/assignments/ruby/bob/bob_test.rb
@@ -7,7 +7,7 @@ begin
     attr_reader :teenager
 
     def setup
-      @teenager = Bob.new
+      @teenager = ::Bob.new
     end
 
     def test_stating_something


### PR DESCRIPTION
The first error after running the Very Friendly Intro said:

test_statement_containing_question_mark(TeenagerTest):
NameError: uninitialized constant TeenagerTest::Bob
    bob_test.rb:10:in `setup'

This fixes the error message so students are expected to
declare Bob as a top-level constant.
