### PR TITLE
Improve scripts/boot.sh and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ Different languages/trails do not need to have the same assignments or the same 
   * URL: http://localhost:4567
   * Callback url: http://localhost:4567/github/callback
 7. Run the database seed with `ruby scripts/seed.rb`
-8. Start server with: `EXERCISM_GITHUB_CLIENT_ID=xxx EXERCISM_GITHUB_CLIENT_SECRET=xxx rackup -p 4567`
-9. Login at http://localhost:4567.
-10. Run [MailCatcher](http://mailcatcher.me/) with `mailcatcher`, and open your browser to [localhost:1080](http://localhost:1080).
+8. Copy the boot script `scripts/boot.sh.example` to `scripts/boot.sh` and fill in your GitHub details
+9. Start the server with `./scripts/boot.sh`
+10. Login at http://localhost:4567.
+11. Run [MailCatcher](http://mailcatcher.me/) with `mailcatcher`, and open your browser to [localhost:1080](http://localhost:1080).
 
 ## Frontend development setup
 1. Install node and npm
@@ -114,11 +115,7 @@ If you want to send actual emails, you will need to export the following environ
 * `EMAIL_SMTP_ADDRESS`
 * `EMAIL_SMTP_PORT`
 
-#### Optional steps
-
-Copy the export values from `scripts/boot.sh.example` into your `~/.bash_profile` or `~/.zshrc`
-or
-Copy bootrunner `cp scripts/boot.sh.example scripts/boot.sh`
+You can do this in `scripts/boot.sh` for development.
 
 ## Console
 

--- a/scripts/boot.sh.example
+++ b/scripts/boot.sh.example
@@ -1,9 +1,20 @@
 #!/bin/sh
+
 # These can also be exported in your ~/.bash_profile or ~/.zshrc
 export EXERCISM_GITHUB_CLIENT_ID=xxx
 export EXERCISM_GITHUB_CLIENT_SECRET=xxx
+
+# If you want to send actual emails, export the following environment variables
+# export EMAIL_USERNAME=xxx
+# export EMAIL_PASSWORD=xxx
+# export EMAIL_DOMAIN=xxx
+# export EMAIL_SMTP_ADDRESS=xxx
+# export EMAIL_SMTP_PORT=xxx
+
 # This is the github id of your admin account if you want your admin to work
 # via the 'login via github' link on the homepage. If you want this you'll
 # need to edit the seeds file to change Katrina's user details to your own
 # export EXERCISM_ADMIN_ID=xxx
+
 rackup -p 4567
+


### PR DESCRIPTION
I think we should recommend the way to start the server. It seems to me `scripts/boot.sh` should be that way.

This makes environment variables easier to manage without introducing new dependencies as discussed here: https://github.com/kytrinyx/exercism.io/pull/333

What do you think?

I've also mentioned `.ruby-version` here as people may not be aware of it when setting up for the first time.
