### PR TITLE
Go octal

### DIFF
--- a/assignments/go/octal/example.go
+++ b/assignments/go/octal/example.go
@@ -1,0 +1,10 @@
+package octal
+
+import (
+	"strconv"
+)
+
+func ToDecimal(input string) (r int64) {
+	r, _ = strconv.ParseInt(input, 8, 0)
+	return
+}

--- a/assignments/go/octal/octal_test.go
+++ b/assignments/go/octal/octal_test.go
@@ -1,0 +1,24 @@
+package octal
+
+import "testing"
+
+type testCase struct {
+	input    string
+	expected int64
+}
+
+var testCases = []testCase{
+	testCase{"1", 1},
+	testCase{"10", 8},
+	testCase{"1234567", 342391},
+	testCase{"carrot", 0},
+}
+
+func TestToDecimal(t *testing.T) {
+	for _, test := range testCases {
+		actual := ToDecimal(test.input)
+		if actual != test.expected {
+			t.Errorf("ToDecimal(%s): expected[%d], actual [%d]", test.input, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
This uses the built in conversions from the library.

Does it make sense to have the student write something if it already exists in the stdlib?

If you'd like the "don't use the stdlib" solution, please let me know.
