### PR TITLE
Addressing issue #346.

### DIFF
--- a/lib/app/presenters/dashboard.rb
+++ b/lib/app/presenters/dashboard.rb
@@ -38,12 +38,24 @@ class Dashboard
       submissions
     end
 
+    def no_nits_on_this_iteration
+      @not_recently_nitted ||= pending.select { |sub| sub.no_nits_yet? }.reverse
+    end
+
+    def never_been_nitted
+      @never_nitted ||= no_nits_on_this_iteration.select { |sub| sub.no_version_has_nits? }
+    end # must be a strict subset of those without nits on this iteration...
+
+    def nits_before_but_not_on_this_iteration
+      @nits_before ||= (no_nits_on_this_iteration - never_been_nitted)
+    end
+
     def without_nits
-      @without_nits ||= pending.select { |sub| sub.nits_by_others_count.zero? }.reverse
+      no_nits_on_this_iteration
     end
 
     def with_nits
-      @with_nits ||= pending.select { |sub| !sub.nits_by_others_count.zero? }
+      @with_nits ||= pending.select { |sub| sub.this_version_has_nits }
     end
 
     def flagged_for_approval

--- a/lib/app/views/pending.erb
+++ b/lib/app/views/pending.erb
@@ -27,7 +27,11 @@
       <%= erb :pending_submission, locals: { submission: submission } %>
     <% end %>
 
-    <% submissions.without_nits.each do |submission| %>
+    <% submissions.never_been_nitted.each do |submission| %>
+      <%= erb :pending_submission, locals: { submission: submission } %>
+    <% end %>
+
+    <% submissions.nits_before_but_not_on_this_iteration.each do |submission| %>
       <%= erb :pending_submission, locals: { submission: submission } %>
     <% end %>
 

--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -77,6 +77,22 @@ class Submission
     @related_submissions ||= Submission.related(self).to_a
   end
 
+  def no_version_has_nits?
+    @no_previous_nits ||= related_submissions.find_index { |v| v.nits_by_others_count > 0 }.nil?
+  end
+
+  def some_version_has_nits?
+    !no_version_has_nits?
+  end
+
+  def this_version_has_nits?
+    nits_by_others_count > 0
+  end
+
+  def no_nits_yet?
+    !this_version_has_nits
+  end
+
   def exercise
     @exercise ||= Exercise.new(language, slug)
   end


### PR DESCRIPTION
This should result in the following order of pending submissions on the
dashboard:
- those that have never received a nit (oldest first)
- those in which some previous iteration received a nit, but this one
  has not (oldest first)
- those in which there is at least one nit on the current iteration
  (newest first)
