### PR TITLE
Fix typo in about/nitpick

### DIFF
--- a/lib/app/views/about/nitpick.erb
+++ b/lib/app/views/about/nitpick.erb
@@ -2,7 +2,7 @@
 <h1>How To Nitpick</h1>
 <p><b>(A practical guide to providing better feedback on solutions to exercises.)</b></p>
 
-<p>When reviewing exercism submissions, it is possible and encouraged to share advice and insight on the style and approach of a given implmentation.</p>
+<p>When reviewing exercism submissions, it is possible and encouraged to share advice and insight on the style and approach of a given implementation.</p>
 
 <p>Nitpicks should provide positive and constructive criticism, subtly nudging a coder toward progressively better implementations of an exercise.</p>
 


### PR DESCRIPTION
Hi,

This commit fix a typo in about/niptick.

Cheers, :beer: 
