### PR TITLE
Add link to GitHub flavoured markdown. Fixes #176.

### DIFF
--- a/lib/app/views/nitpick.erb
+++ b/lib/app/views/nitpick.erb
@@ -45,6 +45,9 @@
     <% else %>
       <h2>Nitpicks</h2>
     <% end %>
+
+    <p>Nitpicks and comments are parsed with <a href="https://help.github.com/articles/github-flavored-markdown">GitHub Flavoured Markdown</a></p>
+
     <% submission.nits.each do |nit| %>
     <blockquote><%= md(nit.comment) %>
       <p>


### PR DESCRIPTION
This fixes #176.

I choose what I think is the best position for the link, but let me know what you think.
