### PR TITLE
Bring javascript/bob tests closer to parity with ruby/bob.

### DIFF
--- a/assignments/javascript/bob/bob_test.spec.js
+++ b/assignments/javascript/bob/bob_test.spec.js
@@ -60,16 +60,6 @@ describe("Bob", function() {
 
   xit("silence", function () {
     var result = bob.hey('');
-    expect(result).toEqual('Fine. Be that way!');
-  });
-
-  xit("more silence", function () {
-    var result = bob.hey(null);
-    expect(result).toEqual('Fine. Be that way!');
-  });
-
-  xit("more silence", function () {
-    var result = bob.hey('    ');
-    expect(result).toEqual('Fine. Be that way!');
+    expect(result).toEqual('Fine, be that way!');
   });
 });


### PR DESCRIPTION
I left a couple out as I didn't want to modify the existing javascript example.
