### PR TITLE
Added approver to participants [fix #317]

### DIFF
--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -50,6 +50,7 @@ class Submission
       participants.add nit.nitpicker
       participants.merge nit.comments.map(&:commenter)
     end
+    participants.add approver if approver.present?
     @participants = participants
   end
 

--- a/test/exercism/submission_test.rb
+++ b/test/exercism/submission_test.rb
@@ -52,5 +52,25 @@ class SubmissionTest < Minitest::Test
     assert_equal 3, s3.version
   end
 
+  def test_participants_when_not_approved
+    alice = User.new(username: 'alice')
+    bob = User.new(username: 'bob', github_id: '2', admin: true)
+    s1 = Submission.create(state: 'pending', user: alice, language: 'nong', slug: 'one')
+
+    assert_equal Set.new([alice]), s1.participants
+  end
+
+  def test_participants_when_approved
+    alice = User.create(username: 'alice', github_id: '1', current: {'nong' => 'one'})
+    bob = User.create(username: 'bob', github_id: '2', admin: true)
+
+    curriculum = Curriculum.new('/tmp')
+    curriculum.add NongCurriculum.new
+    s1 = Submission.create(state: 'pending', user: alice, language: 'nong', slug: 'one')
+
+    Approval.new(s1.id, bob, nil, curriculum).save
+    s1.reload; alice.reload
+    assert_equal Set.new([alice, bob]), s1.participants
+  end
 end
 


### PR DESCRIPTION
Now submissions have `approver` in their `participants` list (which controls who would receive notifications).
