### PR TITLE
Fix jasmine-node installation instructions.

### DIFF
--- a/lib/app/views/account.erb
+++ b/lib/app/views/account.erb
@@ -94,7 +94,7 @@
 
       <li>
         Install <a href="https://github.com/mhevery/jasmine-node">jasmine-node</a> with
-        <code>npm install jasmine-node</code>
+        <code>npm install jasmine-node -g</code>
       </li>
     </ul>
 


### PR DESCRIPTION
The current installation instructions for jasmine-node result in it being installed in the current directory, while the the rest of the instructions assume jasmine-node will be available in /usr/local/share/npm/bin - instructions should read `npm install jasmine-node -g`
