### PR TITLE
Add test for same length, same letters, different letter instance counts to javascript/anagram

### DIFF
--- a/assignments/javascript/anagram/anagram_test.spec.js
+++ b/assignments/javascript/anagram/anagram_test.spec.js
@@ -13,6 +13,12 @@ describe('Anagram', function() {
     var matches = detector.match(['ab', 'abc', 'bac']);
     expect(matches).toEqual(['ab']);
   });
+  
+  xit("does not detect false positives",function() {
+    var detector = new Anagram("bba");
+    var matches = detector.match(["aab"]);
+    expect(matches).toEqual([]);
+  });
 
   xit("detects multiple anagrams",function() {
     var detector = new Anagram("abc");


### PR DESCRIPTION
One possible solution to detecting an anagram might be to check to see if the words are the same length and that each letter from the first word is contained in the second word. This additional test would guard against that solution appearing to work.

I wasn't sure in what position in the test sequence it ought to go, or what the exact test description should be. Feel free to suggest changes.
