### PR TITLE
Add ng-min to dist lineman task to fix angular injection minification is...

### DIFF
--- a/frontend/config/application.coffee
+++ b/frontend/config/application.coffee
@@ -19,4 +19,17 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
 
   # enableSass: true
 
+  # configure lineman to load additional angular related npm tasks
+  loadNpmTasks: [ "grunt-ngmin" ]
+  # task override configuration
+  prependTasks:
+    dist: ["ngmin"]         # ngmin should run in dist only
+
+  # configuration for grunt-ngmin, this happens _after_ concat once, which is the ngmin ideal :)
+  ngmin: {
+    js: {
+      src: "<%= files.js.concatenated %>",
+      dest: "<%= files.js.concatenated %>"
+    }
+  },
 })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "company": "ACME, Inc."
   },
   "dependencies": {
+    "grunt": "~0.4.1",
+    "grunt-ngmin": "~0.0.2",
     "lineman": "~>0"
   },
   "engines": {


### PR DESCRIPTION
Fixes production issue introduced by pull request for issue #368. The issue is that Angular handles automatic dependency injection using parameter names which got minified and doesn't match angular services names anymore. Ng-min solves the problem by generating declaration of dependencies separately using string array.
