### PR TITLE
Nitpicking the Ruby Bob example (unicode is handled improperly)

### DIFF
--- a/assignments/ruby/bob/bob_test.rb
+++ b/assignments/ruby/bob/bob_test.rb
@@ -56,9 +56,9 @@ begin
       assert_equal 'Woah, chill out!', teenager.hey('I HATE YOU')
     end
 
-    def test_shouting_with_european_characters
+    def test_a_german_question
       skip
-      assert_equal 'Whatever.', teenager.hey('Hä!')
+      assert_equal 'Sure.', teenager.hey('Hä?')
     end
 
     def test_statement_containing_question_mark


### PR DESCRIPTION
The bob example and its examples propagate `str.upcase == str` as an upcase check. Sadly, this is actually an improper API usage: `#upcase` does not handle anything beyond ASCII properly. Actual, living and breathing example of a german question for bored teenagers:

```
"Hä?".upcase == "Hä?" #=> true, but not upcase
```

This pull request adds a test that "Hä?" should actually be interpreted as a question, not as shouting.

Ruby can easily check for non-downcased characters using `/\p{Ll}/`, but sadly, that would qualify this example as more advanced - maybe add a note to the README how the check is done properly?

I do understand that this is meant as a simple example. But considering that careless handling of strings is a big problem for i18n and all european software users, the wrongful usage should (IMHO) not be tought.
