### PR TITLE
elixir version of nucleotide-count changed: one element lists like 'C' or 'T' replaced by characters like ?C or ?T.

### DIFF
--- a/assignments/elixir/nucleotide-count/example.exs
+++ b/assignments/elixir/nucleotide-count/example.exs
@@ -1,20 +1,23 @@
 defmodule DNA do
+
+  @empty_nucleotide_table HashDict.new([{?A, 0}, {?C, 0}, {?G, 0}, {?T, 0}])
+
   @doc """
   Counts individual nucleotides in a DNA strand.
 
   ## Examples
 
-  iex> DNA.count('AATAA', 'A')
+  iex> DNA.count('AATAA', ?A)
   4
 
-  iex> DNA.count('AATAA', 'T')
+  iex> DNA.count('AATAA', ?T)
   1
   """
 
-  def count(dna, [n | _]),  do: count(dna, n)
-  def count([], _),         do: 0
-  def count([n | tail], n), do: 1 + count(tail, n)
-  def count([_ | tail], n), do: count(tail, n)
+  def count(dna, nucleotide) do
+    Enum.count dna,  &1 == nucleotide
+  end
+
 
   @doc """
   Returns a summary of counts by nucleotide.
@@ -22,9 +25,14 @@ defmodule DNA do
   ## Examples
 
   iex> DNA.nucleotide_counts('AATAA')
-  HashDict.new [{'A', 4}, {'T', 1}, {'C', 0}, {'G', 0}]
+  HashDict.new [{?A, 4}, {?T, 1}, {?C, 0}, {?G, 0}]
   """
-  def nucleotide_counts(dna) do
-    HashDict.new Enum.map 'ATCG', fn(n) -> { [n | []], count(dna, n) } end
+
+  def nucleotide_counts(nucleotides) do
+    List.foldl(nucleotides, @empty_nucleotide_table, fn(nucleotide, acc) ->
+      HashDict.update(acc, nucleotide, 1, &1+1)
+    end)
   end
+
+
 end

--- a/assignments/elixir/nucleotide-count/nucleotide-count_test.exs
+++ b/assignments/elixir/nucleotide-count/nucleotide-count_test.exs
@@ -6,34 +6,34 @@ defmodule DNATest do
   doctest DNA
 
   test "empty dna string has no adenosine" do
-    assert DNA.count('', 'A') == 0
+    assert DNA.count('', ?A) == 0
   end
 
   test "empty dna string has no nucleotides" do
-    expected = HashDict.new [{'A', 0}, {'T', 0}, {'C', 0}, {'G', 0}]
+    expected = HashDict.new [{?A, 0}, {?T, 0}, {?C, 0}, {?G, 0}]
     assert expected == DNA.nucleotide_counts('')
   end
 
   test "repetitive cytidine gets counted" do
-    assert 5 == DNA.count('CCCCC', 'C')
+    assert 5 == DNA.count('CCCCC', ?C)
   end
 
   test "repetitive sequence has only guanosine" do
-    expected = HashDict.new [{'A', 0}, {'T', 0}, {'C', 0}, {'G', 8}]
+    expected = HashDict.new [{?A, 0}, {?T, 0}, {?C, 0}, {?G, 8}]
     assert expected == DNA.nucleotide_counts('GGGGGGGG')
   end
 
   test "counts only thymidine" do
-    assert 1 == DNA.count('GGGGGTAACCCGG', 'T')
+    assert 1 == DNA.count('GGGGGTAACCCGG', ?T)
   end
 
   test "dna has no uracil" do
-    assert 0 == DNA.count('GATTACA', 'U')
+    assert 0 == DNA.count('GATTACA', ?U)
   end
 
   test "counts all nucleotides" do
     s = 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
-    expected = HashDict.new [{'A', 20}, {'T', 21}, {'C', 12}, {'G', 17}]
+    expected = HashDict.new [{?A, 20}, {?T, 21}, {?C, 12}, {?G, 17}]
     assert expected == DNA.nucleotide_counts(s)
   end
 end


### PR DESCRIPTION
`'abc'` in elixir is not a string, this is a list of integers.  This is not Ruby. This is the erlang VM.

```
iex(5)> [97, 98, 99]
'abc'
```

Thus, the first character of `'AATAA'` is not `'A'`! The first character of `'AATAA'` is 65, or `?A`

The erlang and elixir way to denote characters is via this `?` notation.

Thus it makes absolutely no sense to use one element lists like `'A'` or `'C'` for this assignment when the erlang/elixir way is using characters like `?A` and `?C`.
