### PR TITLE
Strip off trailing \n in submissions. Fixes #411.

### DIFF
--- a/lib/exercism/use_cases/attempt.rb
+++ b/lib/exercism/use_cases/attempt.rb
@@ -3,7 +3,7 @@ class Attempt
   attr_reader :user, :code, :language
   def initialize(user, code, filename, curriculum = Exercism.current_curriculum)
     @user = user
-    @code = code
+    @code = sanitize(code)
     @language = curriculum.identify_language(filename)
   end
 
@@ -40,6 +40,10 @@ class Attempt
 
   def exercise
     @exercise ||= user.current_on(language)
+  end
+
+  def sanitize(code)
+    code.gsub(/\n*\z/, "")
   end
 
 end

--- a/test/exercism/use_cases/attempt_test.rb
+++ b/test/exercism/use_cases/attempt_test.rb
@@ -118,5 +118,10 @@ class AttemptTest < Minitest::Test
     assert_equal [], two.flagged_by
   end
 
+  def test_newlines_are_removed_at_the_end_of_the_file
+    Attempt.new(user, "\nCODE1\n\nCODE2\n\n\n", 'one.fp', curriculum).save
+    assert_equal "\nCODE1\n\nCODE2", user.submissions.first.code
+  end
+
 end
 


### PR DESCRIPTION
@rubysolo Would you mind sanity-checking this? I'm terrified that I've missed some important detail and will end up mangling the code people submit.
