### PR TITLE
Add an error response when bob doesn't understand 

### DIFF
--- a/assignments/ruby/bob/bob_test.rb
+++ b/assignments/ruby/bob/bob_test.rb
@@ -83,6 +83,11 @@ begin
       skip
       assert_equal 'Fine. Be that way!', teenager.hey('    ')
     end
+    
+    def test_didnt_understand
+      skip
+      assert_equal 'No comprendo.', teenager.hey(' Aaa   ')
+    end  
   end
 
 rescue LoadError => e


### PR DESCRIPTION
Added default response 'No comprendo.' 

If the message / drivel isn't a question, shout, statement, demand, or silence, Bob gives the default response.

See, e.g. [my code / nitpicks on it, submission 5](http://exercism.io/submissions/5203b5f1b49ec8bb8400033d)

As an aside, a nitpicker on my [submission 4](http://exercism.io/submissions/52028d3b75d94d4cc20000e4) pointed out that the bob tests had changed between June 22 when I fetched it and today (Aug 8) such that my code was 'broken'.  Should there be a mechanism to update the test code, to run submissions against the current test code, or some way to confirm the submission passes the current version of the tests?

As another aside, there are so many issues now. It would be great if additional labels could be created to categorize them by tracks, e.g. ruby, go
