### PR TITLE
Open Github profile link in new tab

### DIFF
--- a/lib/app/helpers/github_link_helper.rb
+++ b/lib/app/helpers/github_link_helper.rb
@@ -2,7 +2,7 @@ module Sinatra
   module GithubLinkHelper
     def github_profile_link(user, link_text = nil)
       link_text = user.username if link_text.nil?
-      '<a href="https://github.com/%s">%s</a>' % [user.username, link_text]
+      '<a target="_blank" href="https://github.com/%s">%s</a>' % [user.username, link_text]
     end
   end
 end


### PR DESCRIPTION
I feel that this link should open in a new tab since it is navigating away from the site.

Having it open in a new tab allows a user to view the Github profile and browse their repos, then simply close the tab and never interrupt their exercism.io session.
