### PR TITLE
Look for Bob first, not TeenagerTest::Bob

### DIFF
--- a/assignments/ruby/bob/bob_test.rb
+++ b/assignments/ruby/bob/bob_test.rb
@@ -7,7 +7,7 @@ begin
     attr_reader :teenager
 
     def setup
-      @teenager = Bob.new
+      @teenager = ::Bob.new
     end
 
     def test_stating_something


### PR DESCRIPTION
Rebased https://github.com/kytrinyx/exercism.io/pull/337 since there was no reaction by @avit, and I thought the fix was useful. Cherrypicked his commit so history keeps correct.
