### PR TITLE
Made test for 'Fine. Be that way' match the specs in README.md

### DIFF
--- a/assignments/javascript/bob/bob_test.spec.js
+++ b/assignments/javascript/bob/bob_test.spec.js
@@ -60,6 +60,6 @@ describe("Bob", function() {
 
   xit("silence", function () {
     var result = bob.hey('');
-    expect(result).toEqual('Fine, be that way!');
+    expect(result).toEqual('Fine. Be that way!');
   });
 });

--- a/assignments/javascript/bob/example.js
+++ b/assignments/javascript/bob/example.js
@@ -15,7 +15,7 @@ function Bob() {
 
   this.hey = function(message) {
     if (isSilence(message)) {
-      return "Fine, be that way!";
+      return "Fine. Be that way!";
     } else if (isShouting(message)) {
       return "Woah, chill out!";
     } else if (isAQuestion(message)) {


### PR DESCRIPTION
Bug fix for #452, "Javascript: Bob: 'fine' testcase drifting from README spec" .

Details:
In the Bob assignment, the README spec says Bob should reply 'Fine. Be that way!'

The test case and example is checking for 'Fine, be that way'. The test fails.

You'd mentioned in another bug that the README.md is generated from other components - from assigments/shared? - so I updated the test and example to match the spec rather than visa versa.
