### PR TITLE
Changing 'Fine, be that way' to 'Fine. Be that way' to match README spec...

### DIFF
--- a/assignments/clojure/bob/bob_test.clj
+++ b/assignments/clojure/bob/bob_test.clj
@@ -32,6 +32,6 @@
   (is (= "Whatever." (bob/response-for "Ending with ? means a question."))))
 
 (deftest responds-to-silence
-  (is (= "Fine, be that way." (bob/response-for ""))))
+  (is (= "Fine. Be that way." (bob/response-for ""))))
 
 (run-tests)

--- a/assignments/clojure/bob/example.clj
+++ b/assignments/clojure/bob/example.clj
@@ -7,7 +7,7 @@
 
 (defn response-for [input]
   (cond
-    (silence?  input) "Fine, be that way."
+    (silence?  input) "Fine. Be that way."
     (shouting? input) "Woah, chill out!"
     (question? input) "Sure."
     :else             "Whatever."))

--- a/assignments/python/bob/bob_test.py
+++ b/assignments/python/bob/bob_test.py
@@ -33,7 +33,7 @@ class BobTests(unittest.TestCase):
     def test_silence(self):
         'Bob responds to silence'
         self.assertEqual(
-            'Fine, be that way.',
+            'Fine. Be that way.',
             self.bob.hey('')
         )
 

--- a/assignments/python/bob/example.py
+++ b/assignments/python/bob/example.py
@@ -1,7 +1,7 @@
 class Bob(object):
     def hey(self, stimulus):
         if self._is_silence(stimulus):
-            return 'Fine, be that way.'
+            return 'Fine. Be that way.'
 
         elif self._is_shouting(stimulus):
             return 'Woah, chill out!'


### PR DESCRIPTION
Same as #453, fixed mismatch between test/example and spec for the 'Fine' case. 
