### PR TITLE
Don't handle nil where string arguments should go in Elixir

### DIFF
--- a/assignments/elixir/bob/bob_test.exs
+++ b/assignments/elixir/bob/bob_test.exs
@@ -41,10 +41,6 @@ defmodule TeenagerTest do
     # assert Teenager.hey("") == "Fine. Be that way!"
   end
 
-  test "empty silence" do
-    # assert Teenager.hey(nil) == "Fine. Be that way!"
-  end
-
   test "prolonged silence" do
     # assert Teenager.hey("  ") == "Fine. Be that way!"
   end

--- a/assignments/elixir/bob/example.exs
+++ b/assignments/elixir/bob/example.exs
@@ -26,7 +26,7 @@ defmodule Teenager do
     end
   end
 
-  defp silent?(input),   do: input == ""
-  defp shouting?(input), do: input == String.upcase input
-  defp question?(input), do: "?" == String.last input
+  defp silent?(input),   do: "" == String.strip(input)
+  defp shouting?(input), do: input == String.upcase(input)
+  defp question?(input), do: String.ends_with?(input, "?")
 end

--- a/assignments/elixir/scrabble-score/example.exs
+++ b/assignments/elixir/scrabble-score/example.exs
@@ -1,6 +1,6 @@
 defmodule Scrabble do
   def score(word) do
-    (word || "") |> letters |> summarize
+    word |> letters |> summarize
   end
 
   defp letters(word), do: word |> String.strip |> String.downcase |> String.codepoints

--- a/assignments/elixir/scrabble-score/scrabble-score_test.exs
+++ b/assignments/elixir/scrabble-score/scrabble-score_test.exs
@@ -13,10 +13,6 @@ defmodule ScrabbleScoreTest do
     assert 0 == Scrabble.score(" \t\n")
   end
 
-  test "nil scores zero" do
-    assert 0 == Scrabble.score(nil)
-  end
-
   test "scores very short word" do
     assert 1 == Scrabble.score("a")
   end


### PR DESCRIPTION
From https://github.com/kytrinyx/exercism.io/commit/4f5c26f204dec40a034a8796eb1ad52c8409861c#commitcomment-3835719 and the discussion here http://exercism.io/submissions/5207d10e162e6154b200003a

This is the wrong thing to do in Elixir or any other language that doesn't have [nullable types](http://en.wikipedia.org/wiki/Nullable_type) by default. I'd strongly recommend that this test be removed, because it forces the participants to write bad code in order to pass the test.

The cases in a language like Elixir or Erlang where nil or some other atom is acceptable in the same place you might expect a string are few and far between. Generally speaking, you'll only see a sum type of nil plus something else in Elixir where you'd see an option type in other functional languages (e.g. Maybe in Haskell or Option in Scala), some examples of that would be search or extractions that might fail (String.at/2, String.first/1, String.last/1, String.slice/3). Note that exported functions that accept nil as a valid argument are _very_ rare, it's only really acceptable to _return_ nil and the caller is responsible for doing the right thing with it.
