### PR TITLE
Update how nits are counted for a user's own work

### DIFF
--- a/lib/app/views/work.erb
+++ b/lib/app/views/work.erb
@@ -1,13 +1,13 @@
 <div class="work"
   data-language="<%= work.language %>"
   <% if work.submitted? %>
-    data-nits="<%= work.nits.count %>"
+    data-nits="<%= work.nits_by_others_count %>"
   <% end %>>
   <%= language_icon(work.language) %>
   <% if work.submitted? %>
     <a href="/submissions/<%= work.id %>">
       <h4 style="display: inline"><%= work.slug %></h4></a>
-    <div class="nits circle"><%= work.nits.count %></div>
+    <div class="nits circle"><%= work.nits_by_others_count %></div>
     <div class="versions circle"><%= work.versions_count %></div>
   <% elsif work.slug == 'congratulations' %>
     <span class="label label-info">No more Assignments</span>


### PR DESCRIPTION
Inspired by reading #334 tonight.

Right now, the nit count that a user sees in the sidebar includes their own
nits.  But the count of nits used for the Featured page does not include them.

This is confusing (and a mistake).  A user might be afraid that leaving a note
on their own code would push the submission off the Featured page, because
they learn that putting a nit caused a "1" to appear next to their own work, and 
they see the column of "0"s on the Featured page.

This commit brings the two "nit counts" in sync.  Now, a user's own nits do not
increase the count in either place.  (More explanatory text may be needed in the
hover text, if you keep the hover text.  But this at least brings the numbers in sync.)
