### PR TITLE
Fix: pending assignments undefined for iterations

### DIFF
--- a/lib/app/views/work.erb
+++ b/lib/app/views/work.erb
@@ -2,6 +2,7 @@
   data-language="<%= work.language %>"
   <% if work.submitted? %>
     data-nits="<%= work.nits_by_others_count %>"
+    data-versions="<%= work.versions_count %>"
   <% end %>>
   <%= language_icon(work.language) %>
   <% if work.submitted? %>


### PR DESCRIPTION
The iterations tooltip for the users pending assignments was showing
undefined instead of the actual count. This PR fixes that.
