### PR TITLE
Improve nodejs installation help on js dashboard

### DIFF
--- a/lib/app/views/setup/javascript.erb
+++ b/lib/app/views/setup/javascript.erb
@@ -7,10 +7,7 @@
     Install <a href="http://nodejs.org/">Node.js</a>
     <ul>
       <li>
-        Homebrew for Mac OS X
-        <ul>
-          <li>Install node with <code>brew install node</code></li>
-        </ul>
+        <a href="https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager">Installing Node.js via package manager</a>
       </li>
     </ul>
   </li>


### PR DESCRIPTION
Change the MacOS node installation command to a link to the Node project wiki page describing installation for many different platforms.
