### PR TITLE
Use workload + breakdown in dashboard

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -129,10 +129,13 @@ class ExercismApp < Sinatra::Base
       %{<li class="#{active_top_nav(path)} #{html[:class]}"><a href="#{path}">#{nav_text(language)}</a></li>}
     end
 
-    def dashboard_assignment_nav(language, exercise=nil, html={})
+    def dashboard_assignment_nav(language, exercise=nil, counts=nil)
+      return if counts && counts.zero?
+
       path = path_for(language)
       path += "/#{exercise}/" if exercise
-      %{<li class="#{active_nav(path)} #{html[:class]}"><a href="#{path}">#{nav_text(exercise)}</a></li>}
+      tally = counts ? " (#{counts})" : ""
+      %{<li class="#{active_nav(path)}"><a href="#{path}">#{nav_text(exercise)} #{tally}</a></li>}
     end
 
     def exercises_available_for(language)

--- a/lib/app/client.rb
+++ b/lib/app/client.rb
@@ -5,12 +5,13 @@ class ExercismApp < Sinatra::Base
     if current_user.guest?
       erb :index
     else
-      dashboard = Dashboard.new(current_user, Submission.nitless)
+      dashboard = Dashboard.new(current_user)
 
       locals = {
-        submissions: dashboard.submissions,
-        language: nil,
-        exercise: nil
+        featured: true,
+        submissions: dashboard.featured,
+        language: false,
+        exercise: false
       }
       erb :dashboard, locals: locals
     end

--- a/lib/app/dashboard.rb
+++ b/lib/app/dashboard.rb
@@ -1,16 +1,18 @@
 require 'app/presenters/dashboard'
 class ExercismApp < Sinatra::Base
 
-['/dashboard/:language/:exercise/', '/dashboard/:language/?'].each do |route|
+['/dashboard/:language/:exercise/?', '/dashboard/:language/?'].each do |route|
   get route do
-    language, exercise = params[:language], params[:exercise]
     if current_user.guest?
       erb :index
     else
-      dashboard = Dashboard.new(current_user, Submission.pending_for(language, exercise))
-
+      language, exercise = params[:language], params[:exercise]
+      dashboard = Dashboard.new(current_user).in(language).for(exercise)
       locals = {
+        featured: false,
         submissions: dashboard.submissions,
+        exercises: dashboard.exercises,
+        breakdown: dashboard.breakdown,
         language: language,
         exercise: exercise
       }

--- a/lib/app/views/dashboard.erb
+++ b/lib/app/views/dashboard.erb
@@ -4,11 +4,10 @@
     <nav>
       <ul class="nav nav-tabs nav-stacked">
         <% if language %>
-          <% exercises = exercises_available_for(language) %>
           <% if exercises.any? %>
             <%= dashboard_assignment_nav(language) %>
             <% exercises.each do |exercise| %>
-              <%= dashboard_assignment_nav(language, exercise.slug) %>
+              <%= dashboard_assignment_nav(language, exercise.slug, breakdown[exercise]) %>
             <% end %>
           <% end %>
         <% end %>

--- a/lib/app/views/pending.erb
+++ b/lib/app/views/pending.erb
@@ -18,23 +18,8 @@
   <hr/>
 
   <div class="pending-submissions">
-    <% submissions.flagged_for_approval.each do |submission| %>
+    <% submissions.each do |submission| %>
       <%= erb :pending_submission, locals: { submission: submission } %>
     <% end %>
-
-    <% submissions.never_been_nitted.each do |submission| %>
-      <%= erb :pending_submission, locals: { submission: submission } %>
-    <% end %>
-
-      <% submissions.nits_before_but_not_on_this_iteration.each do |submission| %>
-        <%= erb :pending_submission, locals: { submission: submission } %>
-      <% end %>
-
-    <% if exercise %>
-      <% submissions.with_nits.each do |submission| %>
-        <%= erb :pending_submission, locals: { submission: submission } %>
-      <% end %>
-    <% end %>
-
   </div>
 <% end %>


### PR DESCRIPTION
This adds pending count to dashboard assignment navigation (left sidebar).

It adds `wants_opinions` to the featured pages.
It also pulls "looks great" submissions into the featured list for locksmiths.

It does not yet account for the logic around no nits ever vs no nits this iteration.

The Dashboard presenter has been entirely rewritten using the Workload and Breakdown classes which move a lot of the underlying dashboard logic into the model layer. Those model objects have some very fat integration tests.

There's still a fair amount of cleaning up to be done in the view code, and (in particular) the view helper code.
