### PR TITLE
ruby/beer-song: use BeerSong, not Beer, for the class.

### DIFF
--- a/assignments/ruby/beer-song/beer-song_test.rb
+++ b/assignments/ruby/beer-song/beer-song_test.rb
@@ -1,45 +1,45 @@
 require 'minitest/autorun'
-require_relative 'beer'
+require_relative 'beer_song'
 
-class BeerTest < MiniTest::Unit::TestCase
+class BeerSongTest < MiniTest::Unit::TestCase
 
-  attr_reader :beer
+  attr_reader :beer_song
   def setup
-    @beer = Beer.new
+    @beer_song = BeerSong.new
   end
 
   def test_a_verse
     expected = "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n"
-    assert_equal expected, beer.verse(8)
+    assert_equal expected, beer_song.verse(8)
   end
 
   def test_verse_1
     skip
     expected = "1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n"
-    assert_equal expected, beer.verse(1)
+    assert_equal expected, beer_song.verse(1)
   end
 
   def test_verse_2
     skip
     expected = "2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n"
-    assert_equal expected, beer.verse(2)
+    assert_equal expected, beer_song.verse(2)
   end
 
   def test_verse_0
     skip
     expected = "No more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n"
-    assert_equal expected, beer.verse(0)
+    assert_equal expected, beer_song.verse(0)
   end
 
   def test_singing_several_verses
     skip
     expected = "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n\n7 bottles of beer on the wall, 7 bottles of beer.\nTake one down and pass it around, 6 bottles of beer on the wall.\n\n6 bottles of beer on the wall, 6 bottles of beer.\nTake one down and pass it around, 5 bottles of beer on the wall.\n\n"
-    assert_equal expected, beer.sing(8, 6)
+    assert_equal expected, beer_song.sing(8, 6)
   end
 
   def test_sing_all_the_rest_of_the_verses
     skip
     expected = "3 bottles of beer on the wall, 3 bottles of beer.\nTake one down and pass it around, 2 bottles of beer on the wall.\n\n2 bottles of beer on the wall, 2 bottles of beer.\nTake one down and pass it around, 1 bottle of beer on the wall.\n\n1 bottle of beer on the wall, 1 bottle of beer.\nTake it down and pass it around, no more bottles of beer on the wall.\n\nNo more bottles of beer on the wall, no more bottles of beer.\nGo to the store and buy some more, 99 bottles of beer on the wall.\n\n"
-    assert_equal expected, beer.sing(3)
+    assert_equal expected, beer_song.sing(3)
   end
 end

--- a/assignments/ruby/beer-song/example.rb
+++ b/assignments/ruby/beer-song/example.rb
@@ -1,4 +1,4 @@
-class Beer
+class BeerSong
   def sing(first, last = 0)
     s = ""
     first.downto(last).each do |number|


### PR DESCRIPTION
We probably want to encourage good naming, and this seems like a better one.
