### PR TITLE
anagram_test.rb excludes anagram subsets

### DIFF
--- a/assignments/ruby/anagram/anagram_test.rb
+++ b/assignments/ruby/anagram/anagram_test.rb
@@ -40,11 +40,11 @@ class AnagramTest < MiniTest::Unit::TestCase
     detector = Anagram.new('mass')
     assert_equal [], detector.match(['last'])
   end
-  
+
   def test_eliminate_anagram_subsets
     skip
-    detector = Anagram.new('dog')
-    assert_equal [], detector.match(['good'])
+    detector = Anagram.new('good')
+    assert_equal [], detector.match(['dog', 'goody'])
   end
 
   def test_detect_anagram


### PR DESCRIPTION
Someone sorted letters and then incorrectly did a prefix check instead of a full comparison:

http://exercism.io/submissions/520ea215d908bd42b70005d0
