### PR TITLE
Removed ruby specific array syntax in the README for anagram

### DIFF
--- a/assignments/shared/anagram.md
+++ b/assignments/shared/anagram.md
@@ -1,1 +1,1 @@
-Given `"listen"` and `%w(enlists google inlets banana)` the program should return "inlets".
+Given `"listen"` and a list of candidates like `enlists google inlets banana` the program should return "inlets".


### PR DESCRIPTION
README should be language agnostic
