### PR TITLE
Anagram test: case-insensitivity must go both ways

### DIFF
--- a/assignments/clojure/anagram/anagram_test.clj
+++ b/assignments/clojure/anagram/anagram_test.clj
@@ -20,4 +20,8 @@
   (is (= ["gallery" "regally" "largely"]
          (anagram/anagrams-for "allergy" ["gallery" "ballerina" "regally" "clergy" "largely" "leading"]))))
 
+(deftest case-insensitive-anagrams
+  (is (= ["Carthorse"]
+         (anagram/anagrams-for "Orchestra" ["cashregister" "Carthorse" "radishes"]))))
+
 (run-tests)

--- a/assignments/elixir/anagram/anagram_test.exs
+++ b/assignments/elixir/anagram/anagram_test.exs
@@ -33,4 +33,9 @@ defmodule AnagramTest do
     # matches = Anagram.match "allergy", %w(gallery ballerina regally clergy largely leading)
     # assert matches == ["gallery", "regally", "largely"]
   end
+
+  test "detect anagrams case-insensitively" do
+    # matches = Anagram.match "Orchestra", %w(cashregister Carthorse radishes)
+    # assert matches == ["Carthorse"]
+  end
 end

--- a/assignments/go/anagram/anagram_test.go
+++ b/assignments/go/anagram/anagram_test.go
@@ -47,3 +47,18 @@ func TestEliminateAnagramSubsets(t *testing.T) {
 		t.Errorf("Expected empty slice, got %v.", matches)
 	}
 }
+
+func TestAnagramsAreCaseInsensitive(t *testing.T) {
+	in := "Orchestra"
+	possibleMatches := []string{"cashregister", "Carthorse", "radishes"}
+
+	matches := Detect(in, possibleMatches)
+
+	if len(matches) != 1 {
+		t.Errorf("Expected 1 element, got %d.", len(matches))
+	}
+
+	if matches[0] != "Carthorse" {
+		t.Errorf("Expected Carthorse, got %v.", matches[0:])
+	}
+}

--- a/assignments/javascript/anagram/anagram_test.spec.js
+++ b/assignments/javascript/anagram/anagram_test.spec.js
@@ -43,4 +43,10 @@ describe('Anagram', function() {
     var matches = detector.match(['gallery', 'ballerina', 'regally', 'clergy', 'largely', 'leading']);
     expect(matches).toEqual(['gallery', 'regally', 'largely']);
   });
+
+  xit("detects anagrams case-insensitively",function() {
+    var detector = new Anagram("Orchestra");
+    var matches = detector.match(['cashregister', 'Carthorse', 'radishes']);
+    expect(matches).toEqual(['Carthorse']);
+  });
 });

--- a/assignments/python/anagram/anagram_test.py
+++ b/assignments/python/anagram/anagram_test.py
@@ -50,8 +50,8 @@ class AnagramTests(unittest.TestCase):
 
     def test_anagrams_are_case_insensitive(self):
         self.assertEqual(
-            ['carthorse'],
-            Anagram('Orchestra').match('cashregister carthorse radishes'.split())
+            ['Carthorse'],
+            Anagram('Orchestra').match('cashregister Carthorse radishes'.split())
         )
 
 if __name__ == '__main__':

--- a/assignments/ruby/anagram/anagram_test.rb
+++ b/assignments/ruby/anagram/anagram_test.rb
@@ -64,7 +64,7 @@ class AnagramTest < MiniTest::Unit::TestCase
   def test_anagrams_are_case_insensitive
     skip
     detector = Anagram.new('Orchestra')
-    anagrams = detector.match %w(cashregister carthorse radishes)
-    assert_equal ['carthorse'], anagrams
+    anagrams = detector.match %w(cashregister Carthorse radishes)
+    assert_equal ['Carthorse'], anagrams
   end
 end


### PR DESCRIPTION
Previously it was enough to normalize just the subject.

This also adds the missing case-insensitivity test to the rest of the languages. But I'm not sure if that's a good policy going forward, that you have to update all languages. What could have been a quick fix took a while, so I will be more reluctant to fix small things in future.

If the problem never pops up in say the Clojure community, perhaps because it never happens in that language or nobody makes that mistake or nobody spots it, the value of that test is kind of low. The value of getting more spec fixes for languages where a problem does pop up is higher.

There's also the higher risk of making mistakes when updating tests for a language you don't know or don't know well.
