### PR TITLE
Change color of code blocks that are inside links.

### DIFF
--- a/frontend/app/css/style.css
+++ b/frontend/app/css/style.css
@@ -179,3 +179,7 @@ textarea.comment {
 blockquote.submitter {
   border-left: 5px solid #0088cc;
 }
+
+a code {
+  color: #0088cc;
+}


### PR DESCRIPTION
This PR changes the color of `<code>` tags that link to e.g. documentation references. Currently, there is no visual indicator that a given code snippet is a link until you hover over it. 

I am also partial to adding a dotted underline (`border-bottom: 1px dotted #08c;`) but that didn't seem to fit the rest of the visual design in the app, so I'll leave that up to the core team :)

Before:
![capturfiles](https://f.cloud.github.com/assets/56947/982949/5dfd8bcc-0832-11e3-9041-530aa796f1c1.png)

After:
![capturfiles_1](https://f.cloud.github.com/assets/56947/982950/5fb310ae-0832-11e3-86bb-9a32a7bd720f.png)
