### PR TITLE
Switch :use to :require :refer in clojure tests

### DIFF
--- a/assignments/clojure/allergies/allergies_test.clj
+++ b/assignments/clojure/allergies/allergies_test.clj
@@ -1,4 +1,4 @@
-(ns allergies.test (:use clojure.test))
+(ns allergies.test (:require [clojure.test :refer :all]))
 (load-file "allergies.clj")
 
 (deftest no-allergies-at-all

--- a/assignments/clojure/anagram/anagram_test.clj
+++ b/assignments/clojure/anagram/anagram_test.clj
@@ -1,4 +1,4 @@
-(ns anagram.test (:use clojure.test))
+(ns anagram.test (:require [clojure.test :refer :all]))
 (load-file "anagram.clj")
 
 (deftest no-matches

--- a/assignments/clojure/beer-song/beer-song_test.clj
+++ b/assignments/clojure/beer-song/beer-song_test.clj
@@ -1,4 +1,4 @@
-(ns beer-test (:use clojure.test))
+(ns beer-test (:require [clojure.test :refer :all]))
 (load-file "beer.clj")
 
 (def verse-8 "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n")

--- a/assignments/clojure/binary/binary_test.clj
+++ b/assignments/clojure/binary/binary_test.clj
@@ -1,4 +1,4 @@
-(ns binary.test (:use clojure.test))
+(ns binary.test (:require [clojure.test :refer :all]))
 (load-file "binary.clj")
 
 (deftest binary-1-is-decimal-1

--- a/assignments/clojure/bob/bob_test.clj
+++ b/assignments/clojure/bob/bob_test.clj
@@ -1,4 +1,4 @@
-(ns bob.test (:use clojure.test))
+(ns bob.test (:require [clojure.test :refer :all]))
 (load-file "bob.clj")
 
 (deftest responds-to-something

--- a/assignments/clojure/etl/etl_test.clj
+++ b/assignments/clojure/etl/etl_test.clj
@@ -1,4 +1,4 @@
-(ns etl.test (:use clojure.test))
+(ns etl.test (:require [clojure.test :refer :all]))
 (load-file "etl.clj")
 
 

--- a/assignments/clojure/gigasecond/gigasecond_test.clj
+++ b/assignments/clojure/gigasecond/gigasecond_test.clj
@@ -1,4 +1,4 @@
-(ns gigasecond.test (:use clojure.test))
+(ns gigasecond.test (:require [clojure.test :refer :all]))
 (load-file "gigasecond.clj")
 
 (deftest from-apr-25-2011

--- a/assignments/clojure/grade-school/grade-school_test.clj
+++ b/assignments/clojure/grade-school/grade-school_test.clj
@@ -1,4 +1,4 @@
-(ns grade-school.test (:use clojure.test))
+(ns grade-school.test (:require [clojure.test :refer :all]))
 (load-file "school.clj")
 
 (def db {})

--- a/assignments/clojure/grains/grains_test.clj
+++ b/assignments/clojure/grains/grains_test.clj
@@ -1,4 +1,4 @@
-(ns grains.test (:use clojure.test))
+(ns grains.test (:require [clojure.test :refer :all]))
 (load-file "grains.clj")
 
 (deftest square-1

--- a/assignments/clojure/leap/leap_test.clj
+++ b/assignments/clojure/leap/leap_test.clj
@@ -1,4 +1,4 @@
-(ns leap.test (:use clojure.test))
+(ns leap.test (:require [clojure.test :refer :all]))
 (load-file "leap_year.clj")
 
 (deftest vanilla-leap-year

--- a/assignments/clojure/meetup/meetup_test.clj
+++ b/assignments/clojure/meetup/meetup_test.clj
@@ -1,4 +1,4 @@
-(ns meetup.test (:use clojure.test))
+(ns meetup.test (:require [clojure.test :refer :all]))
 (load-file "meetup.clj")
 
 (deftest monteenth-of-may-2013

--- a/assignments/clojure/nucleotide-count/nucleotide-count_test.clj
+++ b/assignments/clojure/nucleotide-count/nucleotide-count_test.clj
@@ -1,4 +1,4 @@
-(ns nucleotide-count.test (:use clojure.test))
+(ns nucleotide-count.test (:require [clojure.test :refer :all]))
 (load-file "dna.clj")
 
 (deftest empty-dna-strand-has-no-adenosine

--- a/assignments/clojure/phone-number/phone-number_test.clj
+++ b/assignments/clojure/phone-number/phone-number_test.clj
@@ -1,4 +1,4 @@
-(ns phone-number.test (:use clojure.test))
+(ns phone-number.test (:require [clojure.test :refer :all]))
 (load-file "phone.clj")
 
 (deftest cleans-number

--- a/assignments/clojure/point-mutations/point-mutations_test.clj
+++ b/assignments/clojure/point-mutations/point-mutations_test.clj
@@ -1,4 +1,4 @@
-(ns point-mutations.test (:use clojure.test))
+(ns point-mutations.test (:require [clojure.test :refer :all]))
 (load-file "dna.clj")
 
 (deftest no-difference-between-empty-strands

--- a/assignments/clojure/prime-factors/prime-factors_test.clj
+++ b/assignments/clojure/prime-factors/prime-factors_test.clj
@@ -1,4 +1,4 @@
-(ns prime-factors.test (:use clojure.test))
+(ns prime-factors.test (:require [clojure.test :refer :all]))
 (load-file "prime_factors.clj")
 
 (deftest one

--- a/assignments/clojure/raindrops/raindrops_test.clj
+++ b/assignments/clojure/raindrops/raindrops_test.clj
@@ -1,4 +1,4 @@
-(ns raindrops.test (:use clojure.test))
+(ns raindrops.test (:require [clojure.test :refer :all]))
 (load-file "raindrops.clj")
 
 (deftest one

--- a/assignments/clojure/rna-transcription/rna-transcription_test.clj
+++ b/assignments/clojure/rna-transcription/rna-transcription_test.clj
@@ -1,4 +1,4 @@
-(ns rna-transcription.test (:use clojure.test))
+(ns rna-transcription.test (:require [clojure.test :refer :all]))
 (load-file "dna.clj")
 
 (deftest transcribes-cytidine-unchanged

--- a/assignments/clojure/robot-name/robot-name_test.clj
+++ b/assignments/clojure/robot-name/robot-name_test.clj
@@ -1,4 +1,4 @@
-(ns robot-name.test (:use clojure.test))
+(ns robot-name.test (:require [clojure.test :refer :all]))
 (load-file "robot.clj")
 
 (def robbie (robot))

--- a/assignments/clojure/roman-numerals/roman-numerals_test.clj
+++ b/assignments/clojure/roman-numerals/roman-numerals_test.clj
@@ -1,4 +1,4 @@
-(ns roman.test (:use clojure.test))
+(ns roman.test (:require [clojure.test :refer :all]))
 (load-file "roman.clj")
 
 (deftest one

--- a/assignments/clojure/space-age/space-age_test.clj
+++ b/assignments/clojure/space-age/space-age_test.clj
@@ -1,4 +1,4 @@
-(ns space-age.test (:use clojure.test))
+(ns space-age.test (:require [clojure.test :refer :all]))
 (load-file "space_age.clj")
 
 (defn- rounds-to

--- a/assignments/clojure/word-count/word-count_test.clj
+++ b/assignments/clojure/word-count/word-count_test.clj
@@ -1,4 +1,4 @@
-(ns word-count.test (:use clojure.test))
+(ns word-count.test (:require [clojure.test :refer :all]))
 (load-file "word_count.clj")
 
 (deftest count-one-word


### PR DESCRIPTION
@ryanbraganza pointed out that `use` is deprecated/discouraged [1] in favor of `require` plus `refer`.

This tripped me up, so I've updated all the clojure assignment tests (gulp) to use the preferred form.

[1] http://dev.clojure.org/jira/browse/CLJ-879
