### PR TITLE
Close notifications on Esc

### DIFF
--- a/frontend/app/js/views/toggle_notifications.js
+++ b/frontend/app/js/views/toggle_notifications.js
@@ -9,6 +9,8 @@ exercism.views.ToggleNotifications = Backbone.View.extend({
     if(this.isAuthorizedUser()) {
       this.startNotificationCenter();
     }
+    _.bindAll(this, 'close_on_esc');
+    $(document).keyup(this.close_on_esc);
   },
 
   render: function() {
@@ -36,6 +38,16 @@ exercism.views.ToggleNotifications = Backbone.View.extend({
 
   toggle: function() {
     this.listNotifications.toggle();
+  },
+
+  close_on_esc: function(event) {
+    var notificationsAreVisible = this.listNotifications.$el.hasClass('reveal-notifications');
+    var noInputHasFocus = $(':focus').length === 0;
+    var keyIsEsc = event.keyCode === 27;
+
+    if(notificationsAreVisible && noInputHasFocus && keyIsEsc) {
+      this.toggle();
+    }
   },
 
   buttonStyle: function() {


### PR DESCRIPTION
This will close the notifications list when ESC is pressed, as discussed in #445 and #269.

I check if the list is visible, if any inputs have focus (in which case the user may be typing, and we don't really want to toggle anything for the poor Vim-people who habitually hit esc while typing), and if the key is indeed esc. If so, toggle that list.

I'd really like another pair of eyes on this before merging, especially since I'm don't usually do a lot of front end development. There are no tests, which makes me uncomfortable, but I don't have a lot of experience writing js-tests that hit the DOM, and I couldn't find any other js tests. "It works on my computer". ;)

Unfortunately I couldn't bind the keyup event with the normal backbone events, which is why I bindAll. See http://stackoverflow.com/questions/6033010/how-to-capture-the-key-event-from-a-view for details.
