### PR TITLE
Adding pagination to the gallery page.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ gem 'rouge'
 gem 'sinatra', require: 'sinatra/base'
 gem 'pony'
 gem 'sanitize'
+gem 'will_paginate', git: 'https://github.com/mislav/will_paginate.git' # master for mongoid support
+gem 'will_paginate-bootstrap'
 gem 'pry', require: false
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/mislav/will_paginate.git
+  revision: 0da168851b9356f678106abd19055fc6e9a6df72
+  specs:
+    will_paginate (3.0.4)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -98,6 +104,8 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.37)
+    will_paginate-bootstrap (0.2.4)
+      will_paginate (>= 3.0.3)
 
 PLATFORMS
   ruby
@@ -122,3 +130,5 @@ DEPENDENCIES
   sanitize
   simplecov
   sinatra
+  will_paginate!
+  will_paginate-bootstrap

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -1,5 +1,7 @@
 require 'exercism'
 require 'sinatra/petroglyph'
+require 'will_paginate'
+require 'will_paginate/mongoid'
 
 require 'app/presenters/dashboard'
 
@@ -36,6 +38,7 @@ class ExercismApp < Sinatra::Base
   set :session_secret, ENV.fetch('SESSION_SECRET') { "Need to know only." }
   use Rack::Flash
 
+  helpers WillPaginate::Sinatra::Helpers
   helpers Sinatra::SubmissionsHelper
   helpers Sinatra::SiteTitleHelper
   helpers Sinatra::FuzzyTimeHelper

--- a/lib/app/exercises.rb
+++ b/lib/app/exercises.rb
@@ -12,8 +12,10 @@ class ExercismApp < Sinatra::Base
       redirect '/'
     end
 
-    submissions = Submission.completed_for(language, slug).limit(50)
-    erb :completed, locals: {submissions: submissions}
+    submissions = Submission.completed_for(language, slug)
+                            .paginate(page: params[:page], per_page: per_page)
+
+    erb :completed, locals: {language: language, slug: slug, submissions: submissions}
   end
 
   get '/user/:language/:slug' do |language, slug|
@@ -52,6 +54,12 @@ class ExercismApp < Sinatra::Base
       iterations: submissions
     }
     erb :summary, locals: locals
+  end
+
+  private
+
+  def per_page
+    params[:per_page] || 50
   end
 
 end

--- a/lib/app/views/completed.erb
+++ b/lib/app/views/completed.erb
@@ -30,9 +30,11 @@
       <% end %>
     </tbody>
   </table>
-  <p>Want to see more? <a href="https://github.com/kytrinyx/exercism.io/issues/532" target="_blank">Add pagination :)</a></p>
+  <p>
+    <%= will_paginate submissions, renderer: BootstrapPagination::Sinatra %>
+  </p>
 <% else %>
   <p>
-    <b>No recently approved submissions in <%= submission.language %>: <%= submission.slug %></b>
+    <b>No recently approved submissions in <%= language %>: <%= slug %></b>
   </p>
 <% end %>

--- a/test/app/exercises_test.rb
+++ b/test/app/exercises_test.rb
@@ -1,0 +1,29 @@
+require './test/api_helper'
+require 'mocha/setup'
+
+class ExercisesTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    ExercismApp
+  end
+
+  def setup
+    @alice = User.create(username: 'alice', github_id: 1, email: 'alice@example.com')
+  end
+
+  def teardown
+    Mongoid.reset
+  end
+
+  def logged_in
+    { github_id: @alice.github_id }
+  end
+
+  def test_exercise_gallery
+    User.any_instance.expects(:completed?).returns(true)
+    get "/completed/ruby/bob", {}, 'rack.session' => logged_in
+    assert_equal 200, last_response.status
+  end
+
+end


### PR DESCRIPTION
Fixes #532

Ok, I originally wanted to use Kaminari since it has a released version with Mongoid support, but Sinatra and Kaminari are currently not getting along -- they both require conflicting versions of Rack.

So I went with will_paginate, but the one caveat is that I had to pull it from master because the Mongoid support has not seen an official release yet. If that's an issue let me know and I can figure something else out. Also, there's a second gem in there to make the pagination view helper format itself for bootstrap. 

There also was not a test for the gallery routes, so I added a really basic one just to run through the method I added pagination to, and it required some stubbing. It seemed kind of difficult to create all the objects necessary for really testing that page (users and submissions and exercises and trails and...), but if I missed an easy way to do that let me know and I can fill that in. 

Cheers!
