### PR TITLE
Adding test for calling hey() with a nil statement

### DIFF
--- a/assignments/ruby/bob/bob_test.rb
+++ b/assignments/ruby/bob/bob_test.rb
@@ -88,6 +88,11 @@ class TeenagerTest < MiniTest::Unit::TestCase
     skip
     assert_equal 'Fine. Be that way!', teenager.hey('    ')
   end
+
+  def test_nil_silence
+    skip
+    assert_equal 'Fine. Be that way!', teenager.hey(nil)
+  end
 end
 __END__
 


### PR DESCRIPTION
During my code review I used "strip" on a string, and it was noted that the string might be nil. Thought it would be nice to have a test for that so that it could be caught by the test suite instead of relying on the review.
