### PR TITLE
add missing tests for anagram in clojure, elixir, javascript, python ( #448 )

### DIFF
--- a/assignments/clojure/anagram/anagram_test.clj
+++ b/assignments/clojure/anagram/anagram_test.clj
@@ -24,4 +24,7 @@
   (is (= ["Carthorse"]
          (anagram/anagrams-for "Orchestra" ["cashregister" "Carthorse" "radishes"]))))
 
+(deftest word-is-not-own-anagram
+  (is (= [] (anagram/anagrams-for "banana" ["banana"]))))
+
 (run-tests)

--- a/assignments/clojure/anagram/example.clj
+++ b/assignments/clojure/anagram/example.clj
@@ -11,4 +11,4 @@
 (defn anagrams-for
   [word candidates]
   (let [canonical (canonicalize word)]
-    (vec (filter #(= canonical (canonicalize %)) candidates))))
+    (vec (filter #(and (not= word %) (= canonical (canonicalize %))) candidates))))

--- a/assignments/elixir/anagram/anagram_test.exs
+++ b/assignments/elixir/anagram/anagram_test.exs
@@ -38,4 +38,9 @@ defmodule AnagramTest do
     # matches = Anagram.match "Orchestra", %w(cashregister Carthorse radishes)
     # assert matches == ["Carthorse"]
   end
+
+  test "anagrams must not be the source word" do 
+    # matches = Anagram.match "banana", ["banana"]
+    # assert matches == []
+  end
 end

--- a/assignments/elixir/anagram/example.exs
+++ b/assignments/elixir/anagram/example.exs
@@ -1,7 +1,7 @@
 defmodule Anagram do
   def match(base, candidates) do
     b = canonical base
-    Enum.filter candidates, fn(c) -> b == canonical c end
+    Enum.filter candidates, fn(c) -> base != c && b == canonical c end
   end
 
   defp canonical(string), do: :lists.sort String.codepoints string

--- a/assignments/javascript/anagram/anagram_test.spec.js
+++ b/assignments/javascript/anagram/anagram_test.spec.js
@@ -49,4 +49,10 @@ describe('Anagram', function() {
     var matches = detector.match(['cashregister', 'Carthorse', 'radishes']);
     expect(matches).toEqual(['Carthorse']);
   });
+
+  xit("does not detect a word as its own anagram",function() {
+    var detector = new Anagram("banana");
+    var matches = detector.match(['banana']);
+    expect(matches).toEqual([]);
+  });
 });

--- a/assignments/javascript/anagram/example.js
+++ b/assignments/javascript/anagram/example.js
@@ -11,7 +11,7 @@
     for(var i = 0; i < words.length; i++) {
       var currentWord = words[i];
 
-      if (currentWord.length == this.word.length) {
+      if (currentWord.length == this.word.length && currentWord != this.word) {
         var currentWordLetters = currentWord.split('').sort();
         var matchingWordLetters = this.word.split('').sort();
 

--- a/assignments/python/anagram/anagram_test.py
+++ b/assignments/python/anagram/anagram_test.py
@@ -54,5 +54,11 @@ class AnagramTests(unittest.TestCase):
             Anagram('Orchestra').match('cashregister Carthorse radishes'.split())
         )
 
+    def test_same_word_isnt_anagram(self):
+        self.assertEqual(
+            [],
+            Anagram('banana').match(['banana'])
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/assignments/python/anagram/example.py
+++ b/assignments/python/anagram/example.py
@@ -1,12 +1,13 @@
 class Word(object):
     def __init__(self, word):
+        self.word = word
         self.canonical = self._canonicalize(word)
 
     def _canonicalize(self, word):
         return sorted(word.lower())
 
     def is_anagram_of(self, other):
-        return self.canonical == self._canonicalize(other)
+        return self.word != other and self.canonical == self._canonicalize(other)
 
 
 class Anagram(object):


### PR DESCRIPTION
I tried to do Go as well, but either the example is broken, or `brew install go` doesn't give a working environment.
