### PR TITLE
Test question on several line in bob ruby assigment

### DIFF
--- a/assignments/ruby/bob/bob_test.rb
+++ b/assignments/ruby/bob/bob_test.rb
@@ -88,6 +88,13 @@ class TeenagerTest < MiniTest::Unit::TestCase
     skip
     assert_equal 'Fine. Be that way!', teenager.hey('    ')
   end
+
+  def test_on_multiple_line_questions
+    skip
+    assert_equal 'Whatever.', teenager.hey(%{
+Does this cryogenic chamber make me look fat?
+no})
+  end
 end
 __END__
 


### PR DESCRIPTION
This commit add a new test to validate that we can't work with a
multiline.

Before this commit you can pass all test with using regexp /\?$/ but if
you use this regexp is not valid you need use /\?\Z/ to force to use
this one.
