### PR TITLE
Add lein-exec instructions for Clojure on OSX

### DIFF
--- a/lib/app/views/setup/clojure.erb
+++ b/lib/app/views/setup/clojure.erb
@@ -7,7 +7,8 @@
     Homebrew for Mac OS X
     <ul>
       <li>Update your homebrew to latest: <code>brew update</code></li>
-      <li>Install Clojure: <code>brew install clojure</code></li>
+      <li>Install Leiningen: <code>brew install leiningen</code></li>
+      <li>Install lein-exec: edit <code>~/.lein/profiles.clj</code> and add <code>{:user {:plugins [[lein-exec "0.3.1"]]}}</code></li>
     </ul>
   </li>
   <li>
@@ -19,9 +20,8 @@
 </ul>
 
 <h4>Running tests:</h4>
-<p>If installed with homebrew: </p>
-<pre>$ clj bob_test.clj</pre>
+<p>If you installed lein-exec: </p>
+<pre>$ lein exec bob_test.clj</pre>
 
 <p>If jar file downloaded, assuming <code>clojure-1.5.1.jar</code></p>
 <pre>$ java -cp clojure-1.5.1.jar clojure.main bob_test.clj</pre>
-


### PR DESCRIPTION
Since the homebrew community decided to delete the clojure recipe, here are alternate instructions using the lein-exec plugin (https://github.com/kumarshantanu/lein-exec/wiki).

Fixes #610
