### PR TITLE
Expose language setup pages as public routes.

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -16,6 +16,7 @@ require 'app/dashboard'
 require 'app/exercises'
 require 'app/trails'
 require 'app/users'
+require 'app/setup'
 require 'app/not_found' # always include last
 
 require 'app/helpers/submissions_helper'

--- a/lib/app/setup.rb
+++ b/lib/app/setup.rb
@@ -1,0 +1,18 @@
+class ExercismApp < Sinatra::Base
+
+  def in_curriculum? language
+    languages = Exercism.current_curriculum.trails.keys
+    languages.include? language.to_sym
+  end
+  
+  get '/setup/:language/?' do
+    language = params[:language].downcase
+    unless in_curriculum? language
+        status 404
+        erb :not_found
+    else
+      erb :"setup/#{language}"
+    end
+  end
+
+end

--- a/test/app/setup_test.rb
+++ b/test/app/setup_test.rb
@@ -1,0 +1,27 @@
+require './test/api_helper'
+
+class SetupPageTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    ExercismApp
+  end
+
+  def visit_setup_page language
+    get "/setup/#{language}"
+    assert last_response.body.include?(language)
+    assert last_response.body.include?("Installation")
+    assert last_response.status == 200
+  end
+  
+  def test_language_setup_pages
+    ['Clojure', 'Ruby', 'Python', 'Elixir', 'Haskell', 'JavaScript'].each do |lang|
+      visit_setup_page lang
+    end
+  end
+
+  def test_usupported_language_returns_not_found
+    get '/setup/fortran'
+    assert last_response.status == 404
+  end
+end


### PR DESCRIPTION
```
+ Add setup.rb route handler. '/setup/:language/'
  routes display setup information for each
  supported language, even if the user has
  already started the language track.
+ Add setup handler tests.
```

This is a simple handler that displays the setup pages for each language, which currently disappear once a user starts a language track. It would be useful to make these public, both in case users need them for future reference, and so the Exercism gem can refer users whose test suites error due to misconfiguration to a friendly help page.
