### PR TITLE
Change text in nitpicks to have a more readable aspect

### DIFF
--- a/frontend/app/css/style.css
+++ b/frontend/app/css/style.css
@@ -184,6 +184,12 @@ blockquote.submitter {
   border-left: 5px solid #0088cc;
 }
 
+blockquote p{
+  font-size: 1.2em;
+  font-weight: initial;
+  line-height: 1.4em;
+}
+
 a code {
   color: #0088cc;
 }


### PR DESCRIPTION
It changes the style of the comments so that they are a bit more readable.

Before:
![before](https://f.cloud.github.com/assets/259568/1022339/edf25a3a-0d7f-11e3-97c1-c864570ab36f.png)

After:
![after](https://f.cloud.github.com/assets/259568/1022340/efee3958-0d7f-11e3-9336-dd6a39edd3f1.png)
