### PR TITLE
Test haskell/word-count for prefixed punctuation

### DIFF
--- a/assignments/haskell/word-count/word-count_test.hs
+++ b/assignments/haskell/word-count/word-count_test.hs
@@ -25,6 +25,9 @@ wordCountTests =
     wordCount "testing, 1, 2 testing"
   , testCase "normalize case" $
     fromList [("go", 3)] @=? wordCount "go Go GO"
+  , testCase "prefix punctuation" $
+    fromList [("testing", 2), ("1", 1), ("2", 1)] @=?
+    wordCount "!%%#testing, 1, 2 testing"
   ]
 
 main :: IO ()


### PR DESCRIPTION
This is a failure case I discovered in my own word-count submission, which would break if the string starts with non-word data. Seems like a good test case to include.
