### PR TITLE
Test haskell/word-count that symbols separate words

### DIFF
--- a/assignments/haskell/word-count/word-count_test.hs
+++ b/assignments/haskell/word-count/word-count_test.hs
@@ -28,6 +28,10 @@ wordCountTests =
   , testCase "prefix punctuation" $
     fromList [("testing", 2), ("1", 1), ("2", 1)] @=?
     wordCount "!%%#testing, 1, 2 testing"
+  , testCase "symbols are separators" $
+    fromList [("hey", 1), ("my", 1), ("spacebar", 1),
+              ("is", 1), ("broken", 1)] @=?
+    wordCount "hey,my_spacebar_is_broken."
   ]
 
 main :: IO ()


### PR DESCRIPTION
Another useful test case for wordCount: make sure that non-alphanumeric characters are treated as separators between words, so that `wordCount "foo%%%bar" /= fromList [("foobar", 1)]`.
