### PR TITLE
adds a couple missing anagram tests

### DIFF
--- a/assignments/elixir/anagram/anagram_test.exs
+++ b/assignments/elixir/anagram/anagram_test.exs
@@ -39,8 +39,18 @@ defmodule AnagramTest do
     # assert matches == ["Carthorse"]
   end
 
-  test "anagrams must not be the source word" do 
+  test "anagrams must not be the source word" do
     # matches = Anagram.match "banana", ["banana"]
+    # assert matches == []
+  end
+
+  test "anagrams must not be the source word case-insensitively" do
+    # matches = Anagram.match "banana", ["Banana"]
+    # assert matches == []
+  end
+
+  test "anagrams must use all letters exactly once" do
+    # matches = Anagram.match "patter", ["tapper"]
     # assert matches == []
   end
 end


### PR DESCRIPTION
- anagrams must not be the source word case-insensitively
- anagrams must use all letters exactly once

Without these tests, it was possible for match functions to pass all
tests while still not being entirely correct.
