### PR TITLE
Warn When Closing Page if Nitpick Text Not Submitted See #495

### DIFF
--- a/frontend/app/js/script.js
+++ b/frontend/app/js/script.js
@@ -71,7 +71,7 @@ $(function() {
       });
       function unloadPage() {
           if(unsaved){
-              return "You have unsaved changes on this page"
+              return "You have unsaved changes on this page";
           }
       }
       window.onbeforeunload = unloadPage;


### PR DESCRIPTION
I don't do much Javascript, but thought I'd give this a shot. 

Tested in the recent versions of Firefox, Chrome and Safari (I don't have IE on my machine, so I'd need someone to verify I suppose).

Alert when you've added data to the Nitpick comment form and navigate away without saving.

edit / Ahh, dang Javascript and all those semicolons. Build passing now :)
