### PR TITLE
Remove confirmation dialog when submitting nitpicks, related to #495

### DIFF
--- a/frontend/app/js/script.js
+++ b/frontend/app/js/script.js
@@ -67,9 +67,13 @@ $(function() {
   $('textarea').each(function () {
     var $this = $(this);
     var question_text = "You have unsaved changes on this page";
+    var was_sumbitted = false;
+    $this.parents("form").on('submit',function(){
+      was_sumbitted = true;
+    });
     window.onbeforeunload = function (e) {
       var unsaved = $this.text() !== $this.val();
-      if(unsaved) {
+      if(!was_sumbitted && unsaved) {
         // see http://stackoverflow.com/questions/10311341/confirmation-before-closing-of-tab-browser
         e = e || window.event;
         


### PR DESCRIPTION
Ok, I'm terribly sorry, but my PR #673 introduced this terrible bug, that bothered everyone submitting nitpicks in the last minutes. I hope this fixes it now. 
