### PR TITLE
Add word is not its own anagram test to Haskell.

### DIFF
--- a/assignments/haskell/anagram/anagram_test.hs
+++ b/assignments/haskell/anagram/anagram_test.hs
@@ -28,4 +28,6 @@ anagramTests =
   , testCase "case insensitive anagrams" $
     ["Carthorse"] @=?
     anagramsFor "Orchestra" ["cashregister", "Carthorse", "radishes"]
+  , testCase "does not detect a word as its own anagram" $
+    [] @=? anagramsFor "banana" ["banana"]
   ]

--- a/assignments/haskell/anagram/example.hs
+++ b/assignments/haskell/anagram/example.hs
@@ -1,11 +1,14 @@
 module Anagram (anagramsFor) where
+import Control.Applicative (liftA2)
 import Data.Char (toLower)
 import Data.Map (Map, fromListWith)
 
 anagramsFor :: String -> [String] -> [String]
-anagramsFor word = filter ((canonical ==) . canonicalize)
+anagramsFor word = filter (liftA2 (&&) different anagram)
   where
+    anagram = ((canonical ==) . canonicalize)
     canonical = canonicalize word
     canonicalize :: String -> Map Char Int
     canonicalize = fromListWith (+) . map key
     key char = (toLower char, 1)
+    different = (word /=)


### PR DESCRIPTION
Also updated the example to pass the new test but tried to slide the change in without changing too much; hopefully it's not too obtuse.
