### PR TITLE
Fix Minitest constant deprecations

### DIFF
--- a/assignments/ruby/accumulate/accumulate_test.rb
+++ b/assignments/ruby/accumulate/accumulate_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'array'
 
-class ArrayTest < MiniTest::Unit::TestCase
+class ArrayTest < Minitest::Test
 
   def test_empty_accumulation
     assert_equal [], [].accumulate {|e| e * e}

--- a/assignments/ruby/allergies/allergies_test.rb
+++ b/assignments/ruby/allergies/allergies_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'allergies'
 
-class AllergiesTest < MiniTest::Unit::TestCase
+class AllergiesTest < Minitest::Test
 
   def test_no_allergies_at_all
     allergies = Allergies.new(0)

--- a/assignments/ruby/anagram/anagram_test.rb
+++ b/assignments/ruby/anagram/anagram_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'anagram'
 
-class AnagramTest < MiniTest::Unit::TestCase
+class AnagramTest < Minitest::Test
 
   def test_no_matches
     detector = Anagram.new('diaper')

--- a/assignments/ruby/atbash-cipher/atbash-cipher_test.rb
+++ b/assignments/ruby/atbash-cipher/atbash-cipher_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'atbash'
 
-class AtbashTest < MiniTest::Unit::TestCase
+class AtbashTest < Minitest::Test
 
   def test_encode_no
     assert_equal 'ml', Atbash.encode('no')

--- a/assignments/ruby/beer-song/beer-song_test.rb
+++ b/assignments/ruby/beer-song/beer-song_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'beer_song'
 
-class BeerSongTest < MiniTest::Unit::TestCase
+class BeerSongTest < Minitest::Test
 
   attr_reader :beer_song
   def setup

--- a/assignments/ruby/binary-search-tree/binary-search-tree_test.rb
+++ b/assignments/ruby/binary-search-tree/binary-search-tree_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'bst'
 
-class BstTest < MiniTest::Unit::TestCase
+class BstTest < Minitest::Test
   def test_data_is_retained
     assert_equal 4, Bst.new(4).data
   end

--- a/assignments/ruby/binary/binary_test.rb
+++ b/assignments/ruby/binary/binary_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'binary'
 
-class BinaryTest < MiniTest::Unit::TestCase
+class BinaryTest < Minitest::Test
   def test_binary_1_is_decimal_1
     assert_equal 1, Binary.new("1").to_decimal
   end

--- a/assignments/ruby/bob/bob_test.rb
+++ b/assignments/ruby/bob/bob_test.rb
@@ -13,7 +13,7 @@ rescue LoadError => e
   exit!
 end
 
-class TeenagerTest < MiniTest::Unit::TestCase
+class TeenagerTest < Minitest::Test
   attr_reader :teenager
 
   def setup

--- a/assignments/ruby/crypto-square/crypto-square_test.rb
+++ b/assignments/ruby/crypto-square/crypto-square_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'crypto'
 
-class CryptoTest < MiniTest::Unit::TestCase
+class CryptoTest < Minitest::Test
   def test_normalize_strange_characters
     crypto = Crypto.new('s#$%^&plunk')
     assert_equal "splunk", crypto.normalize_plaintext

--- a/assignments/ruby/difference-of-squares/difference-of-squares_test.rb
+++ b/assignments/ruby/difference-of-squares/difference-of-squares_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'squares'
 
-class SquaresTest < MiniTest::Unit::TestCase
+class SquaresTest < Minitest::Test
 
   def test_square_of_sums_to_5
     assert_equal 225, Squares.new(5).square_of_sums

--- a/assignments/ruby/etl/etl_test.rb
+++ b/assignments/ruby/etl/etl_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'etl'
 
-class TransformTest < MiniTest::Unit::TestCase
+class TransformTest < Minitest::Test
 
   def test_transform_one_value
     old = { 'hello' => ['WORLD'] }

--- a/assignments/ruby/gigasecond/gigasecond_test.rb
+++ b/assignments/ruby/gigasecond/gigasecond_test.rb
@@ -3,7 +3,7 @@ require 'date'
 require 'time'
 require_relative 'gigasecond'
 
-class GigasecondTest < MiniTest::Unit::TestCase
+class GigasecondTest < Minitest::Test
 
   def test_1
     gs = Gigasecond.new(Date.new(2011, 4, 25))

--- a/assignments/ruby/grade-school/grade-school_test.rb
+++ b/assignments/ruby/grade-school/grade-school_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'school'
 
-class SchoolTest < MiniTest::Unit::TestCase
+class SchoolTest < Minitest::Test
 
   def school
     @school

--- a/assignments/ruby/grains/grains_test.rb
+++ b/assignments/ruby/grains/grains_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'grains'
 
-class GrainsTest < MiniTest::Unit::TestCase
+class GrainsTest < Minitest::Test
 
   def test_square_1
     assert_equal 1, Grains.new.square(1)

--- a/assignments/ruby/hexadecimal/hexadecimal_test.rb
+++ b/assignments/ruby/hexadecimal/hexadecimal_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'hexadecimal'
 
-class HexadecimalTest < MiniTest::Unit::TestCase
+class HexadecimalTest < Minitest::Test
   def test_hex_1_is_decimal_1
     assert_equal 1, Hexadecimal.new("1").to_decimal
   end

--- a/assignments/ruby/kindergarten-garden/kindergarten-garden_test.rb
+++ b/assignments/ruby/kindergarten-garden/kindergarten-garden_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'garden'
 
-class GardenTest < MiniTest::Unit::TestCase
+class GardenTest < Minitest::Test
 
   def test_alices_garden
     garden = Garden.new("RC\nGG")
@@ -29,7 +29,7 @@ class GardenTest < MiniTest::Unit::TestCase
 
 end
 
-class TestFullGarden < MiniTest::Unit::TestCase
+class TestFullGarden < Minitest::Test
   def setup
     diagram = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV"
     @garden = Garden.new(diagram)
@@ -100,7 +100,7 @@ class TestFullGarden < MiniTest::Unit::TestCase
   end
 end
 
-class DisorderedTest < MiniTest::Unit::TestCase
+class DisorderedTest < Minitest::Test
 
   def setup
     diagram = "VCRRGVRG\nRVGCCGCV"
@@ -134,7 +134,7 @@ class DisorderedTest < MiniTest::Unit::TestCase
 
 end
 
-class TwoGardensDifferentStudents < MiniTest::Unit::TestCase
+class TwoGardensDifferentStudents < Minitest::Test
  def diagram
    "VCRRGVRG\nRVGCCGCV"
  end

--- a/assignments/ruby/largest-series-product/largest-series-product_test.rb
+++ b/assignments/ruby/largest-series-product/largest-series-product_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'series'
 
-class SeriesTest < MiniTest::Unit::TestCase
+class SeriesTest < Minitest::Test
   def test_digits
     assert_equal (0..9).to_a, Series.new("0123456789").digits
   end

--- a/assignments/ruby/leap/leap_test.rb
+++ b/assignments/ruby/leap/leap_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'year'
 
-class YearTest < MiniTest::Unit::TestCase
+class YearTest < Minitest::Test
   def test_vanilla_leap_year
     assert Year.new(1996).leap?
   end

--- a/assignments/ruby/linked-list/linked-list_test.rb
+++ b/assignments/ruby/linked-list/linked-list_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'linked_list'
 
-class LinkedListProxyTest < MiniTest::Unit::TestCase
+class LinkedListProxyTest < Minitest::Test
   def setup
     @list = LinkedList.new((0..100).to_a)
   end
@@ -60,7 +60,7 @@ class LinkedListProxyTest < MiniTest::Unit::TestCase
 
 end
 
-class LinkedListTest < MiniTest::Unit::TestCase
+class LinkedListTest < Minitest::Test
   def setup
     @list = LinkedList.new([1])
     @head = @list.instance_variable_get(:@head)
@@ -83,7 +83,7 @@ class LinkedListTest < MiniTest::Unit::TestCase
   end
 end
 
-class LinkedListRangeTest < MiniTest::Unit::TestCase
+class LinkedListRangeTest < Minitest::Test
   def setup
     @list = LinkedList.new((1..10).to_a)
     @head = @list.instance_variable_get(:@head)

--- a/assignments/ruby/luhn/luhn_test.rb
+++ b/assignments/ruby/luhn/luhn_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'luhn'
 
-class LuhnTest < MiniTest::Unit::TestCase
+class LuhnTest < Minitest::Test
 
   def test_addends
     luhn = Luhn.new(12121)

--- a/assignments/ruby/matrix/matrix_test.rb
+++ b/assignments/ruby/matrix/matrix_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'matrix'
 
-class MatrixTest < MiniTest::Unit::TestCase
+class MatrixTest < Minitest::Test
 
   def test_extract_a_row
     matrix = Matrix.new("1 2\n10 20")

--- a/assignments/ruby/meetup/meetup_test.rb
+++ b/assignments/ruby/meetup/meetup_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require 'date'
 require_relative 'meetup'
 
-class MeetupTest < MiniTest::Unit::TestCase
+class MeetupTest < Minitest::Test
 
   def test_monteenth_of_may_2013
     assert_equal Date.new(2013, 5, 13), Meetup.new(5, 2013).monteenth

--- a/assignments/ruby/nth-prime/nth-prime_test.rb
+++ b/assignments/ruby/nth-prime/nth-prime_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'prime'
 
-class TestPrimes < MiniTest::Unit::TestCase
+class TestPrimes < Minitest::Test
 
   def test_first
     assert_equal 2, Prime.nth(1)

--- a/assignments/ruby/nucleotide-count/nucleotide-count_test.rb
+++ b/assignments/ruby/nucleotide-count/nucleotide-count_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'dna'
 
-class DNATest < MiniTest::Unit::TestCase
+class DNATest < Minitest::Test
   def test_empty_dna_string_has_no_adenosine
     assert_equal 0, DNA.new('').count('A')
   end

--- a/assignments/ruby/ocr-numbers/ocr-numbers_test.rb
+++ b/assignments/ruby/ocr-numbers/ocr-numbers_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'ocr'
 
-class OCRTest < MiniTest::Unit::TestCase
+class OCRTest < Minitest::Test
 
   def test_recognize_zero
     text = <<-NUMBER.chomp

--- a/assignments/ruby/octal/octal_test.rb
+++ b/assignments/ruby/octal/octal_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'octal'
 
-class OctalTest < MiniTest::Unit::TestCase
+class OctalTest < Minitest::Test
   def test_octal_1_is_decimal_1
     assert_equal 1, Octal.new("1").to_decimal
   end

--- a/assignments/ruby/palindrome-products/palindrome-products_test.rb
+++ b/assignments/ruby/palindrome-products/palindrome-products_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'palindromes'
 
-class PalindromesTest < MiniTest::Unit::TestCase
+class PalindromesTest < Minitest::Test
 
   def test_largest_palindrome_from_single_digit_factors
     palindromes = Palindromes.new(max_factor: 9)

--- a/assignments/ruby/pascals-triangle/pascals-triangle_test.rb
+++ b/assignments/ruby/pascals-triangle/pascals-triangle_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'triangle'
 
-class TriangleTest < MiniTest::Unit::TestCase
+class TriangleTest < Minitest::Test
 
   def test_one_row
     triangle = Triangle.new(1)

--- a/assignments/ruby/phone-number/phone-number_test.rb
+++ b/assignments/ruby/phone-number/phone-number_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'phone'
 
-class PhoneTest < MiniTest::Unit::TestCase
+class PhoneTest < Minitest::Test
 
   def test_cleans_number
     number = Phone.new("(123) 456-7890").number

--- a/assignments/ruby/pig-latin/pig-latin_test.rb
+++ b/assignments/ruby/pig-latin/pig-latin_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'pig_latin'
 
-class PigLatinTest < MiniTest::Unit::TestCase
+class PigLatinTest < Minitest::Test
 
   def test_word_beginning_with_a
     assert_equal "appleay", PigLatin.translate("apple")

--- a/assignments/ruby/point-mutations/point-mutations_test.rb
+++ b/assignments/ruby/point-mutations/point-mutations_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'dna'
 
-class DNATest < MiniTest::Unit::TestCase
+class DNATest < Minitest::Test
 
   def test_no_difference_between_empty_strands
     assert_equal 0, DNA.new('').hamming_distance('')

--- a/assignments/ruby/prime-factors/prime-factors_test.rb
+++ b/assignments/ruby/prime-factors/prime-factors_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'prime_factors'
 
-class PrimeFactorsTest < MiniTest::Unit::TestCase
+class PrimeFactorsTest < Minitest::Test
 
   def test_1
     assert_equal [], PrimeFactors.for(1)

--- a/assignments/ruby/pythagorean-triplet/pythagorean-triplet_test.rb
+++ b/assignments/ruby/pythagorean-triplet/pythagorean-triplet_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'triplet'
 
-class TripletTest < MiniTest::Unit::TestCase
+class TripletTest < Minitest::Test
   def test_sum
     assert_equal 12, Triplet.new(3, 4, 5).sum
   end

--- a/assignments/ruby/queen-attack/queen-attack_test.rb
+++ b/assignments/ruby/queen-attack/queen-attack_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'queens'
 
-class QueensTest < MiniTest::Unit::TestCase
+class QueensTest < Minitest::Test
 
   def test_default_positions
     queens = Queens.new

--- a/assignments/ruby/raindrops/raindrops_test.rb
+++ b/assignments/ruby/raindrops/raindrops_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'raindrops'
 
-class RaindropsTest < MiniTest::Unit::TestCase
+class RaindropsTest < Minitest::Test
 
   def setup
     @drops = Raindrops.new

--- a/assignments/ruby/rna-transcription/rna-transcription_test.rb
+++ b/assignments/ruby/rna-transcription/rna-transcription_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'dna'
 
-class RibonucleicAcidTest < MiniTest::Unit::TestCase
+class RibonucleicAcidTest < Minitest::Test
   def setup
     @cga = RibonucleicAcid.new('CGA')
     @agc = RibonucleicAcid.new('AGC')

--- a/assignments/ruby/robot-name/robot-name_test.rb
+++ b/assignments/ruby/robot-name/robot-name_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'robot'
 
-class RobotTest < MiniTest::Unit::TestCase
+class RobotTest < Minitest::Test
   def test_has_name
     assert_match /\w{2}\d{3}/, Robot.new.name
   end

--- a/assignments/ruby/robot-simulator/robot-simulator_test.rb
+++ b/assignments/ruby/robot-simulator/robot-simulator_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'simulator'
 
-class RobotTurningTest < MiniTest::Unit::TestCase
+class RobotTurningTest < Minitest::Test
 
   def robot
     @robot
@@ -126,7 +126,7 @@ class RobotTurningTest < MiniTest::Unit::TestCase
   end
 end
 
-class RobotSimulatorTest < MiniTest::Unit::TestCase
+class RobotSimulatorTest < Minitest::Test
   def simulator
     @simulator ||= Simulator.new
   end

--- a/assignments/ruby/roman-numerals/roman-numerals_test.rb
+++ b/assignments/ruby/roman-numerals/roman-numerals_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'roman'
 
-class RomanTest < MiniTest::Unit::TestCase
+class RomanTest < Minitest::Test
 
   def test_1
     assert_equal 'I', 1.to_roman

--- a/assignments/ruby/saddle-points/saddle-points_test.rb
+++ b/assignments/ruby/saddle-points/saddle-points_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'matrix'
 
-class MatrixTest < MiniTest::Unit::TestCase
+class MatrixTest < Minitest::Test
 
   def test_extract_a_row
     matrix = Matrix.new("1 2\n10 20")

--- a/assignments/ruby/say/say_test.rb
+++ b/assignments/ruby/say/say_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'say'
 
-class SayTest < MiniTest::Unit::TestCase
+class SayTest < Minitest::Test
   def test_0
     assert_equal 'zero', Say.new(0).in_english
   end

--- a/assignments/ruby/scrabble-score/scrabble-score_test.rb
+++ b/assignments/ruby/scrabble-score/scrabble-score_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative './scrabble'
 
-class ScrabbleTest < MiniTest::Unit::TestCase
+class ScrabbleTest < Minitest::Test
   def test_empty_word_scores_zero
     assert_equal 0, Scrabble.new("").score
   end

--- a/assignments/ruby/secret-handshake/secret-handshake_test.rb
+++ b/assignments/ruby/secret-handshake/secret-handshake_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'secret_handshake'
 
-class SecretHandshakeTest < MiniTest::Unit::TestCase
+class SecretHandshakeTest < Minitest::Test
   def test_handshake_1_to_wink
     handshake = SecretHandshake.new(1)
     assert_equal ["wink"], handshake.commands

--- a/assignments/ruby/series/series_test.rb
+++ b/assignments/ruby/series/series_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'series'
 
-class SeriesTest < MiniTest::Unit::TestCase
+class SeriesTest < Minitest::Test
 
   def test_simple_series
     assert_equal (0..4).to_a, Series.new("01234").digits

--- a/assignments/ruby/sieve/sieve_test.rb
+++ b/assignments/ruby/sieve/sieve_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'sieve'
 
-class SieveTest < MiniTest::Unit::TestCase
+class SieveTest < Minitest::Test
 
   def test_a_few_primes
     expected = [2, 3, 5, 7]

--- a/assignments/ruby/simple-cipher/simple-cipher_test.rb
+++ b/assignments/ruby/simple-cipher/simple-cipher_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'cipher'
 
-class RandomKeyCipherTest < MiniTest::Unit::TestCase
+class RandomKeyCipherTest < Minitest::Test
   def setup
     @cipher = Cipher.new(nil)
   end
@@ -32,7 +32,7 @@ class RandomKeyCipherTest < MiniTest::Unit::TestCase
   end
 end
 
-class IncorrectKeyCipherTest < MiniTest::Unit::TestCase
+class IncorrectKeyCipherTest < Minitest::Test
   def test_cipher_with_caps_key
     skip
     assert_raises ArgumentError do
@@ -55,7 +55,7 @@ class IncorrectKeyCipherTest < MiniTest::Unit::TestCase
   end
 end
 
-class SubstitutionCipherTest < MiniTest::Unit::TestCase
+class SubstitutionCipherTest < Minitest::Test
   def setup
     @key = "abcdefghij"
     @cipher = Cipher.new(@key)
@@ -102,7 +102,7 @@ class SubstitutionCipherTest < MiniTest::Unit::TestCase
 
 end
 
-class PseudoShiftCipherTest < MiniTest::Unit::TestCase
+class PseudoShiftCipherTest < Minitest::Test
   def setup
     @cipher = Cipher.new("dddddddddd")
   end

--- a/assignments/ruby/simple-linked-list/simple-linked-list_test.rb
+++ b/assignments/ruby/simple-linked-list/simple-linked-list_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 
 require_relative 'linked_list'
 
-class LinkedListTest < MiniTest::Unit::TestCase
+class LinkedListTest < Minitest::Test
   def setup
     @head = linked_list([1])
   end
@@ -26,7 +26,7 @@ class LinkedListTest < MiniTest::Unit::TestCase
   end
 end
 
-class LinkedListRangeTest < MiniTest::Unit::TestCase
+class LinkedListRangeTest < Minitest::Test
   def setup
     @head = linked_list((1..10).to_a)
   end

--- a/assignments/ruby/space-age/space-age_test.rb
+++ b/assignments/ruby/space-age/space-age_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'space_age'
 
-class SpaceAgeTest < MiniTest::Unit::TestCase
+class SpaceAgeTest < Minitest::Test
 
   def test_age_in_seconds
     age = SpaceAge.new(1_000_000)

--- a/assignments/ruby/strain/strain_test.rb
+++ b/assignments/ruby/strain/strain_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'array'
 
-class ArrayTest < MiniTest::Unit::TestCase
+class ArrayTest < Minitest::Test
 
   def test_empty_keep
     assert_equal [], [].keep {|e| e < 10}

--- a/assignments/ruby/sum-of-multiples/sum-of-multiples_test.rb
+++ b/assignments/ruby/sum-of-multiples/sum-of-multiples_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'sum'
 
-class SumTest < MiniTest::Unit::TestCase
+class SumTest < Minitest::Test
 
   def test_sum_to_1
     assert_equal 0, SumOfMultiples.to(1)

--- a/assignments/ruby/triangle/triangle_test.rb
+++ b/assignments/ruby/triangle/triangle_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'triangle'
 
-class TriangeTest < MiniTest::Unit::TestCase
+class TriangeTest < Minitest::Test
   def test_equilateral_triangles_have_equal_sides
     assert_equal :equilateral, Triangle.new(2, 2, 2).kind
   end

--- a/assignments/ruby/trinary/trinary_test.rb
+++ b/assignments/ruby/trinary/trinary_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'trinary'
 
-class TrinaryTest < MiniTest::Unit::TestCase
+class TrinaryTest < Minitest::Test
   def test_trinary_1_is_decimal_1
     assert_equal 1, Trinary.new("1").to_decimal
   end

--- a/assignments/ruby/word-count/word-count_test.rb
+++ b/assignments/ruby/word-count/word-count_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'phrase'
 
-class PhraseTest < MiniTest::Unit::TestCase
+class PhraseTest < Minitest::Test
 
   def test_count_one_word
     phrase = Phrase.new("word")

--- a/assignments/ruby/wordy/wordy_test.rb
+++ b/assignments/ruby/wordy/wordy_test.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require_relative 'word_problem'
 
-class WordProblemTest < MiniTest::Unit::TestCase
+class WordProblemTest < Minitest::Test
   def test_add_1
     assert_equal 2, WordProblem.new('What is 1 plus 1?').answer
   end


### PR DESCRIPTION
Since Minitest 5, `MiniTest`, and `MiniTest::Unit::TestCase` has been
deprecated.

See https://github.com/seattlerb/minitest/blob/master/History.txt for
more information.
