### PR TITLE
Add the notion of a mention.

### DIFF
--- a/lib/app/views/nitpick/nit.erb
+++ b/lib/app/views/nitpick/nit.erb
@@ -8,6 +8,14 @@
     <%= gravatar_tag nit.user.avatar_url, size: 20 %>
     <em><%= profile_link(nit.user) %></em>, <%= ago(nit.at) %>
   </cite>
+  <% unless nit.mentions.empty? %>
+    <aside>
+      Mentions:
+      <% nit.mentions.each do |mention| %>
+	<em><%= profile_link(mention) %></em>
+      <% end %>
+    </aside>
+  <% end %>
 
   <% if current_user == nit.nitpicker %>
     <a href="/submissions/<%= submission.id %>/nits/<%= nit.id %>/edit">

--- a/lib/exercism/comment.rb
+++ b/lib/exercism/comment.rb
@@ -23,6 +23,14 @@ class Comment
     user
   end
 
+  def mentions
+    # http://rubular.com/r/TagnENb1Wm
+    candidates = comment.scan(/\@\w+/).uniq
+    candidates.each_with_object([]) do |username, mentions|
+      mentions << User.find_by(:u => username.sub(/\@/, '')) rescue nil
+    end
+  end
+
   def sanitized_update(comment)
     self.comment = sanitize(comment)
     save

--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -71,6 +71,7 @@ class Submission
     related_submissions.each do |submission|
       submission.comments.each do |nit|
         participants.add nit.nitpicker
+	nit.mentions.each { |mention| participants.add mention }
       end
     end
     @participants = participants

--- a/test/exercism/submission_test.rb
+++ b/test/exercism/submission_test.rb
@@ -120,6 +120,23 @@ class SubmissionTest < Minitest::Test
     assert_equal %w(alice bob charlie), s2.participants.map(&:username).sort
   end
 
+  def test_participants_with_mentions
+    alice = User.create(username: 'alice')
+    bob = User.create(username: 'bob')
+    charlie = User.create(username: 'charlie')
+    mention_user = User.create(username: 'mention_user')
+    s1 = Submission.create(state: 'superseded', user: alice, language: 'nong', slug: 'one')
+    s1.comments << Comment.new(user: alice, comment: 'What about @bob?')
+    s1.save
+    s2 = Submission.create(state: 'pending', user: alice, language: 'nong', slug: 'one')
+    s2.comments << Comment.new(user: charlie, comment: '@mention_user should have bleh')
+    s2.save
+
+    # NOTE: mention_user doesn't enter until s2, but it's related to s1.
+    assert_equal %w(alice bob charlie mention_user), s1.participants.map(&:username).sort
+    assert_equal %w(alice bob charlie mention_user), s2.participants.map(&:username).sort
+  end
+
   def test_muted_by_when_muted
     submission = Submission.new(state: 'pending', muted_by: ['alice'])
     assert submission.muted_by?(alice)

--- a/test/exercism/use_cases/nitpick_test.rb
+++ b/test/exercism/use_cases/nitpick_test.rb
@@ -75,4 +75,13 @@ class NitpickTest < Minitest::Test
     submission.reload
     assert submission.superseded?
   end
+
+  def test_nitpick_with_mentions
+    nitpicker = User.new(username: 'alice')
+    nitpick = Nitpick.new(submission.id, nitpicker, "Mention @#{@submission.user.username}").save
+    submission.reload
+    comment = submission.comments.last
+    assert_equal 1, comment.mentions.count
+    assert_equal submission.user, comment.mentions.first
+  end
 end


### PR DESCRIPTION
- Look through the comment to find @username
- Add the mention list at the end of the nitpick with links to the exercism profile
- Add that to the list of submission participants
  - that taps into the existing notification system
  - exploit the fact that no guard exists to keep someone out of a submission given the correct submission ID
- Tested all the things that I could find. I couldn't figure out how to test sending emails. I didn't see emails sent for any nits.
