### PR TITLE
Update user-facing notification

### DIFF
--- a/lib/app/api/assignments.rb
+++ b/lib/app/api/assignments.rb
@@ -56,7 +56,7 @@ class ExercismApp < Sinatra::Base
     Notify.everyone(attempt.previous_submission, 'code', except: user)
 
     if upgrade_gem?(request.user_agent)
-      Notify.about("Please upgrade your exercism gem, as there have been some significant improvements.", to: attempt.submission.user)
+      Notify.about("Please update your exercism gem, as there have been some significant improvements.", to: attempt.submission.user)
     end
 
     status 201


### PR DESCRIPTION
The command to update a gem is 'gem update', not 'gem upgrade'.
Asking people to upgrade their gem is misleading (I know because
the first thing I typed was 'gem upgrade exercism').
