### PR TITLE
fix User#random_work to return a value always

### DIFF
--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -31,6 +31,7 @@ class User
   end
 
   def random_work
+    return nil if completed.keys.empty?
     completed.keys.shuffle.each do |language|
       work = Submission.pending.where(language: language).in(slug: completed[language]).asc(:nc)
       if work.count > 0


### PR DESCRIPTION
Screenshot of the error in development (after clicking login as admin):

![screen shot 2013-09-03 at 12 09 13 am](https://f.cloud.github.com/assets/1118323/1070558/dad009c2-1458-11e3-8a32-3a7896cb4edd.png)

User#random_work currently returns an empty array if completed is empty.
This causes the dashboard view to explode for users with no completed
exercises because asking:

if []

will return true, and continue on to call [].user.username and other
badness. An alternative fix would be to just call [].present? in the
view, but I think this is better in the long term rather than knowing
that random_work might return a single item or an empty collection.
