### PR TITLE
update nitpick help page with workflow description

### DIFF
--- a/lib/app/views/help/nitpick.erb
+++ b/lib/app/views/help/nitpick.erb
@@ -1,5 +1,13 @@
 <h1>How To Nitpick</h1>
-<p><b>A practical guide to providing better feedback on solutions to exercises.</b></p>
+
+<p>By clicking on a programming language in the Nitpick menu, you may provide feedback to other users who have submitted code samples from exercises you have already completed.</p>
+
+<p>The list view for a particular exercise shows all contributions that you haven't commented on or are not manually muted.  After submitting a Nitpick, a user's submission will be automatically muted so that you can focus on other submissions.</p>
+
+<p>You may mute particular submissions in the list so that they do not show up by clicking on the <i class='icon-microphone-off'></i>button.  After muting submissions they will not show up in your list view until a new submission has been made.  You can still access those submissions by the direct link or through the gallery.  You can also unmute the submission by clicking on the <i class='icon-microphone'></i>button.</p>
+
+
+<h4>A practical guide to providing better feedback on solutions to exercises.</h4>
 
 <p>When reviewing exercism submissions, it is possible and encouraged to share advice and insight on the style and approach of a given implementation.</p>
 


### PR DESCRIPTION
Re: Issue #694
I am attempting to explain the process of muting.  I'm not sure that all of the
added text belongs on the Nitpick help page and am open to discussion about a
better place to put it.
