### PR TITLE
ruby/grade-school: test for key order

### DIFF
--- a/assignments/ruby/grade-school/example.rb
+++ b/assignments/ruby/grade-school/example.rb
@@ -15,7 +15,7 @@ class School
   end
 
   def sort
-    sorted = db.map { |grade, students| [ grade, students.sort ] }
+    sorted = db.map { |grade, students| [ grade, students.sort ] }.sort
     Hash[sorted]
   end
 end

--- a/assignments/ruby/grade-school/grade-school_test.rb
+++ b/assignments/ruby/grade-school/grade-school_test.rb
@@ -61,5 +61,6 @@ class SchoolTest < MiniTest::Unit::TestCase
       6 => ["Kareem"]
     }
     assert_equal sorted, school.sort
+    assert_equal [3, 4, 6], school.sort.keys
   end
 end


### PR DESCRIPTION
The README states grades should be ordered but we don't test for it, and the example doesn't sort them.
