### PR TITLE
Fix #737, place responsive css before bootstrap

### DIFF
--- a/frontend/config/files.coffee
+++ b/frontend/config/files.coffee
@@ -30,4 +30,11 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('files', {
       "app/js/**/namespace.coffee",
       "app/js/**/*.coffee"
     ]
+
+  css:
+    vendor: [
+      "vendor/css/bootstrap.css",
+      "vendor/css/bootstrap-responsive.css",
+      "vendor/css/**/*.css",
+    ]
 })


### PR DESCRIPTION
The default config for concatenating the vendor css files does not seem to specify an order. However, for the responsive features of bootstrap to take effect, the file `bootstrap-responsive.css` must follow the file `bootstrap.css` in the source. This commit makes the files and their order explicit.

The default vendor config can be seen here:
https://github.com/testdouble/lineman/blob/master/config/files.coffee

This change has major influence on the way the site look on non-standard screen sizes. 
