### PR TITLE
Submission view count

### DIFF
--- a/lib/app/helpers/submissions_helper.rb
+++ b/lib/app/helpers/submissions_helper.rb
@@ -9,6 +9,11 @@ module Sinatra
       "/submissions/#{submission.id}/#{action}"
     end
 
+    def view_count_for(submission)
+      count = submission.view_count
+      "#{count} " + "view".pluralize(count)
+    end
+
     def these_people_like_it(liked_by)
       everyone = liked_by.map {|name| "@#{name}"}
       case everyone.size

--- a/lib/app/submissions.rb
+++ b/lib/app/submissions.rb
@@ -52,6 +52,7 @@ class ExercismApp < Sinatra::Base
     please_login
 
     submission = Submission.find(id)
+    submission.viewed!(current_user)
 
     title(submission.slug + " in " + submission.language + " by " + submission.user.username)
 

--- a/lib/app/views/submission.erb
+++ b/lib/app/views/submission.erb
@@ -12,6 +12,7 @@
 
     <%= erb :byline, locals: {exercise: submission.exercise, user: submission.user} %>
     <p>Submitted <%= ago(submission.at) %>.</p>
+    <p><%= view_count_for(submission) %>.</p>
     <p>
       Iteration <b><%= submission.version %></b> of <b><%= submission.versions_count %></b>.
       <% if submission.user.completed?(submission.exercise) %>

--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -15,6 +15,7 @@ class Submission
   field :nc, as: :nit_count, type: Integer, default: 0 # nits by others
   field :v, as: :version, type: Integer, default: 0
   field :st_n, as: :stash_name, type: String
+  field :vs, as: :viewers, type: Array, default: []
 
   belongs_to :user
   has_many :comments
@@ -211,6 +212,14 @@ class Submission
   def unmute_all!
     muted_by.clear
     save
+  end
+
+  def viewed!(user)
+    add_to_set(:viewers, user.username)
+  end
+
+  def view_count
+    @view_count ||= viewers.count
   end
 
   private

--- a/test/app/helpers/submissions_helper_test.rb
+++ b/test/app/helpers/submissions_helper_test.rb
@@ -20,6 +20,24 @@ class SubmissionsHelperTest < Minitest::Test
     @submission = Submission.new(user: @alice)
   end
 
+  def test_no_views
+    @submission.save
+    assert_equal "0 views", helper.view_count_for(@submission)
+  end
+
+  def test_1_view
+    @submission.save
+    @submission.viewed!(@fred)
+    assert_equal "1 view", helper.view_count_for(@submission)
+  end
+
+  def test_many_views
+    @submission.save
+    @submission.viewed!(@fred)
+    @submission.viewed!(@alice)
+    assert_equal "2 views", helper.view_count_for(@submission)
+  end
+
   def test_user_can_mute_other_submissions
     assert_equal true, helper.can_mute?(@submission, @fred)
   end

--- a/test/app/submissions_test.rb
+++ b/test/app/submissions_test.rb
@@ -42,6 +42,31 @@ class SubmissionsTest < Minitest::Test
     Mongoid.reset
   end
 
+  def test_submission_view_count
+    bob = User.create(github_id: 2, username: "bob", email: "bob@example.com", mastery: ['ruby'])
+    Attempt.new(alice, 'CODE', 'word-count/file.rb').save
+    submission = Submission.first
+
+    assert_equal 0, submission.view_count
+
+    get "/submissions/#{submission.id}", {}, {'rack.session' => {github_id: 2}}
+
+    submission = Submission.first
+    assert_equal 1, submission.view_count
+  end
+
+  def test_submission_view_count_for_guest
+    Attempt.new(alice, 'CODE', 'word-count/file.rb').save
+    submission = Submission.first
+
+    assert_equal 0, submission.view_count
+
+    get "/submissions/#{submission.id}"
+
+    submission = Submission.first
+    assert_equal 0, submission.view_count
+  end
+
   def test_nitpick_assignment
     bob = User.create(github_id: 2, email: "bob@example.com", mastery: ['ruby'])
     Attempt.new(alice, 'CODE', 'word-count/file.rb').save

--- a/test/exercism/submission_test.rb
+++ b/test/exercism/submission_test.rb
@@ -146,5 +146,24 @@ class SubmissionTest < Minitest::Test
     submission = Submission.new(state: 'pending')
     refute submission.muted_by?(alice)
   end
+
+  def test_submissions_with_no_views
+    assert_empty submission.viewers
+    assert_equal 0, submission.view_count
+  end
+
+  def test_viewed_submission
+    alice = User.create(username: 'alice')
+    bob = User.create(username: 'bob')
+    charlie = User.create(username: 'charlie')
+    submission.viewed!(alice)
+    submission.viewed!(bob)
+    submission.viewed!(charlie)
+    submission.viewed!(bob)
+    submission.reload
+
+    assert_equal %w(alice bob charlie), submission.viewers
+    assert_equal 3, submission.view_count
+  end
 end
 


### PR DESCRIPTION
This is my first attempt at adding the submission view count in reference to #740

First time messing around with mongo and this was the first way I thought of implementing this.

Another possible way of implementing this would be to create a new collection for `SubmissionViews` and associate  it to the Submission and count the number of documents for submission. I'm not sure how much more performant that would be. It would've been a much easier if mongo behaved like redis on the `add_to_set` call and returned the number of inserted elements but oh well!

Let me know if there's anything I should fix/change or if there's a better approach?
