### PR TITLE
Fix scrollbars appear while opening notifications

### DIFF
--- a/frontend/app/css/notifications.less
+++ b/frontend/app/css/notifications.less
@@ -88,4 +88,5 @@ body {
 body.reveal-notifications {
   margin-right: 17.5em;
   margin-left: -17.5em;
+  overflow-x: hidden;
 }


### PR DESCRIPTION
When opening the notification sidebar (in some browsers and OS) there will be horizontal scrollbars appearing for the duration of the opening animation. This is caused by the notification list dangling outside of the window. By setting the body's `overflow-x` to `hidden` when the panel is out, these scrollbars are gone. The problem fixed here was probably introduced with 0215134 when the animation was enabled.
