### PR TITLE
Add empty string test case to phone-number_test.hs

### DIFF
--- a/assignments/haskell/phone-number/phone-number_test.hs
+++ b/assignments/haskell/phone-number/phone-number_test.hs
@@ -25,6 +25,8 @@ numberTests =
     "0000000000" @=? number "123456789"
   , testCase "invalid when empty" $
     "0000000000" @=? number ""
+  , testCase "invalid when no digits present" $
+    "0000000000" @=? number " (-) "
   ]
 
 areaCodeTests :: [Test]


### PR DESCRIPTION
When solving the Haskell phone number assignment with a pattern match, one could get into a situation where the patterns are non-exhaustive for empty strings. The resulting error should be triggered by the automatic test. This commit adds another test case to assert that an empty string is treated like an invalid phone number.
