### PR TITLE
Don't treat instance variables in markdown code blocks as mentions

### DIFF
--- a/lib/exercism/comment.rb
+++ b/lib/exercism/comment.rb
@@ -1,3 +1,5 @@
+require 'exercism/markdown'
+
 class Comment
   include Mongoid::Document
   include InputSanitation
@@ -25,7 +27,7 @@ class Comment
 
   def mentions
     # http://rubular.com/r/TagnENb1Wm
-    candidates = comment.scan(/\@\w+/).uniq
+    candidates = html_comment_without_code.scan(/\@\w+/).uniq
     candidates.each_with_object([]) do |username, mentions|
       mentions << User.find_by(:u => username.sub(/\@/, '')) rescue nil
     end
@@ -35,4 +37,15 @@ class Comment
     self.comment = sanitize(comment)
     save
   end
+
+  private
+
+  def html_comment_without_code
+    html_comment = Markdown.render(comment)
+    dom = Nokogiri::HTML(html_comment)
+    dom.css("code").remove
+    dom.css("td[class='code']").remove
+    dom.css("body").first.content
+  end
+
 end

--- a/test/exercism/use_cases/nitpick_test.rb
+++ b/test/exercism/use_cases/nitpick_test.rb
@@ -84,4 +84,21 @@ class NitpickTest < Minitest::Test
     assert_equal 1, comment.mentions.count
     assert_equal submission.user, comment.mentions.first
   end
+
+  def test_ignore_mentions_in_code_spans
+    nitpicker = User.new(username: 'alice')
+    nitpick = Nitpick.new(submission.id, nitpicker, "`@#{@submission.user.username}`").save
+    submission.reload
+    comment = submission.comments.last
+    assert_equal 0, comment.mentions.count
+  end
+
+  def test_ignore_mentions_in_fenced_code_blocks
+    nitpicker = User.new(username: 'alice')
+    nitpick = Nitpick.new(submission.id, nitpicker, "```\n@#{submission.user.username}\n```").save
+    submission.reload
+    comment = submission.comments.last
+    assert_equal 0, comment.mentions.count
+  end
+
 end


### PR DESCRIPTION
Possible fix for issue #754

For lack of the knowledge of a simpler way and because I did't want to write code to parse markdown code blocks myself, I implemented this by rendering the comment markdown to HTML using the same Markdown processor
that the site uses and then using Nokogiri to strip out any `<code>` or `<td class="code">` nodes, which are the two ways that the code spans and fenced code blocks are being rendered, respectively. This result is then passed to the existing code that scans for mentions.

A couple of potential downsides to this method are:
1. If the way the markdown processor renders code blocks changes this will no longer work. (However the tests should catch it).
2. This definitely isn't super efficient. If the markdown processor / renderer or nokogiri are slow at all this could be a performance hit. I'm guessing they're fast enough that it's probably not significant, but I haven't benchmarked it.
