### PR TITLE
Use :gitub key, :tag key, and production group in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'sanitize'
 gem 'will_paginate', github: 'mislav/will_paginate', tag: "4cb4986d5ce05aa84572b05cfd1c1d0aa9bc07df"
 gem 'will_paginate-bootstrap'
 gem 'pry', require: false
-gem 'newrelic_rpm', "3.5.8.72"
 
 group :test, :development do
   gem 'ruby-prof'
@@ -28,4 +27,8 @@ group :test, :development do
   gem 'json_expressions', require: false
   gem 'mailcatcher', require: false # for Travis-CI
   gem 'faker', require: false # for seed data
+end
+
+group :production do
+  gem 'newrelic_rpm', "3.5.8.72"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,14 @@
 GIT
-  remote: https://github.com/jayferd/rouge.git
-  revision: b6c4fb5df11cbfbe852e4fc157c01fbad2d47754
+  remote: git://github.com/jayferd/rouge.git
+  revision: a75c074d5dfdd8973e5f4d3d5ce8c235cc947ec5
   specs:
-    rouge (0.4.0)
+    rouge (0.5.3)
       thor
 
 GIT
-  remote: https://github.com/mislav/will_paginate.git
-  revision: 0da168851b9356f678106abd19055fc6e9a6df72
+  remote: git://github.com/mislav/will_paginate.git
+  revision: 4cb4986d5ce05aa84572b05cfd1c1d0aa9bc07df
+  tag: 4cb4986d5ce05aa84572b05cfd1c1d0aa9bc07df
   specs:
     will_paginate (3.0.4)
 


### PR DESCRIPTION
Two Gemfile related commits. I've left them as two commits as I think they add different things.

The first adds github and tag keys. Tags are important if bundling against master as it can easily vary experience on different systems. I've left the rouge one without as I believe you're hoping master will be updated to fix #157.

The newrelic to production thing just stops newrelic slowing down development/test mode (it can be really annoying in my experience).
