### PR TITLE
remove duplicate text in grains assignment description

### DIFF
--- a/assignments/shared/grains.yml
+++ b/assignments/shared/grains.yml
@@ -1,4 +1,4 @@
 ---
-blurb: "Write a program that calculates the number of grains of grains of wheat on a chessboard given that the number on each square doubles."
+blurb: "Write a program that calculates the number of grains of wheat on a chessboard given that the number on each square doubles."
 source: "JavaRanch Cattle Drive, exercise 6"
 source_url: "http://www.javaranch.com/grains.jsp"


### PR DESCRIPTION
Fix duplication in the shared description of the "grains" assignment. 
