### PR TITLE
make Haskell tests return a proper exit code on failure

### DIFF
--- a/assignments/haskell/accumulate/accumulate_test.hs
+++ b/assignments/haskell/accumulate/accumulate_test.hs
@@ -1,14 +1,18 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
 import Accumulate (accumulate)
-
+import System.Exit (ExitCode(..), exitWith)
 import Data.Char (toUpper)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList accumulateTests ]
 
 square :: Int -> Int

--- a/assignments/haskell/allergies/allergies_test.hs
+++ b/assignments/haskell/allergies/allergies_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Allergies (Allergen(..), isAllergicTo, allergies)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList allergiesTests ]
 
 allergiesTests :: [Test]

--- a/assignments/haskell/anagram/anagram_test.hs
+++ b/assignments/haskell/anagram/anagram_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Anagram (anagramsFor)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void (runTestTT (TestList anagramTests))
+main = exitProperly (runTestTT (TestList anagramTests))
 
 anagramTests :: [Test]
 anagramTests =

--- a/assignments/haskell/atbash-cipher/atbash-cipher_test.hs
+++ b/assignments/haskell/atbash-cipher/atbash-cipher_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Atbash (encode)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList atbashTests ]
 
 atbashTests :: [Test]

--- a/assignments/haskell/beer-song/beer-song_test.hs
+++ b/assignments/haskell/beer-song/beer-song_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Beer (sing, verse)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void (runTestTT (TestList [TestList verseTests, TestList singTests]))
+main = exitProperly (runTestTT (TestList [TestList verseTests, TestList singTests]))
 
 verse_8, verse_2, verse_1, verse_0 :: String
 verse_8 = "8 bottles of beer on the wall, 8 bottles of beer.\nTake one down and pass it around, 7 bottles of beer on the wall.\n"

--- a/assignments/haskell/binary-search-tree/binary-search-tree_test.hs
+++ b/assignments/haskell/binary-search-tree/binary-search-tree_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import BST (bstLeft, bstRight, bstValue, singleton, insert, fromList, toList)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList bstTests ]
 
 int4 :: Int

--- a/assignments/haskell/binary/binary_test.hs
+++ b/assignments/haskell/binary/binary_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Binary (toDecimal)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList binaryTests ]
 
 binaryTests :: [Test]

--- a/assignments/haskell/bob/bob_test.hs
+++ b/assignments/haskell/bob/bob_test.hs
@@ -1,6 +1,11 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Bob (responseFor)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
@@ -90,4 +95,4 @@ respondsToTests =
   ]
 
 main :: IO ()
-main = void (runTestTT (TestList respondsToTests))
+main = exitProperly (runTestTT (TestList respondsToTests))

--- a/assignments/haskell/crypto-square/crypto-square_test.hs
+++ b/assignments/haskell/crypto-square/crypto-square_test.hs
@@ -1,16 +1,21 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import CryptoSquare (normalizePlaintext,
                      squareSize,
                      plaintextSegments,
                      ciphertext,
                      normalizeCiphertext)
 
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestLabel "normalizePlaintext" $ TestList normalizePlaintextTests
        , TestLabel "squareSize" $ TestList squareSizeTests
        , TestLabel "plaintextSegments" $ TestList plaintextSegmentsTests

--- a/assignments/haskell/difference-of-squares/difference-of-squares_test.hs
+++ b/assignments/haskell/difference-of-squares/difference-of-squares_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Squares (sumOfSquares, squareOfSums, difference)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList squaresTests ]
 
 int :: Int -> Int

--- a/assignments/haskell/etl/etl_test.hs
+++ b/assignments/haskell/etl/etl_test.hs
@@ -1,13 +1,18 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import ETL (transform)
 import qualified Data.Map as M
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList transformTests ]
 
 transformTests :: [Test]

--- a/assignments/haskell/gigasecond/gigasecond_test.hs
+++ b/assignments/haskell/gigasecond/gigasecond_test.hs
@@ -1,13 +1,18 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Gigasecond (fromDay)
 import Data.Time.Calendar (fromGregorian)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList gigasecondTests ]
 
 gigasecondTests :: [Test]

--- a/assignments/haskell/grade-school/grade-school_test.hs
+++ b/assignments/haskell/grade-school/grade-school_test.hs
@@ -1,13 +1,18 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import qualified School as S
 import Data.List (foldl')
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList schoolTests ]
 
 gradeWithStudents :: Int -> [String] -> S.School

--- a/assignments/haskell/grains/grains_test.hs
+++ b/assignments/haskell/grains/grains_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Grains (square, total)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList grainsTests ]
 
 grainsTests :: [Test]

--- a/assignments/haskell/hexadecimal/hexadecimal_test.hs
+++ b/assignments/haskell/hexadecimal/hexadecimal_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Hexadecimal (hexToInt)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList hexTests ]
 
 hexTests :: [Test]

--- a/assignments/haskell/kindergarten-garden/kindergarten-garden_test.hs
+++ b/assignments/haskell/kindergarten-garden/kindergarten-garden_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Garden (garden, defaultGarden, lookupPlants, Plant(..))
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
   [ TestList gardenTests ]
 
 gardenTests :: [Test]

--- a/assignments/haskell/largest-series-product/largest-series-product_test.hs
+++ b/assignments/haskell/largest-series-product/largest-series-product_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Series (digits, slices, largestProduct)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
   [ TestList seriesTests ]
 
 -- Allow implementations that work with Integral to compile without warning

--- a/assignments/haskell/leap/leap_test.hs
+++ b/assignments/haskell/leap/leap_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import LeapYear (isLeapYear)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList isLeapYearTests ]
 
 isLeapYearTests :: [Test]

--- a/assignments/haskell/linked-list/linked-list_test.hs
+++ b/assignments/haskell/linked-list/linked-list_test.hs
@@ -1,14 +1,19 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 -- Consider using Control.Concurrent.STM.TMVar or Control.Concurrent.MVar
 -- to deal with the mutability
 import Deque (mkDeque, push, pop, shift, unshift)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
   [ TestList dequeTests ]
 
 dequeTests :: [Test]

--- a/assignments/haskell/luhn/luhn_test.hs
+++ b/assignments/haskell/luhn/luhn_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Luhn (checkDigit, addends, checksum, isValid, create)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList luhnTests ]
 
 int :: Integer -> Integer

--- a/assignments/haskell/matrix/matrix_test.hs
+++ b/assignments/haskell/matrix/matrix_test.hs
@@ -1,5 +1,5 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Matrix ( Matrix, row, column, rows, cols, shape, transpose
               , reshape, flatten, fromString, fromList)
 import Control.Arrow ((&&&))
@@ -17,11 +17,16 @@ import qualified Data.Vector as V
 
 -- shape is (rows, cols)
 
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList matrixTests ]
 
 v :: [a] -> V.Vector a

--- a/assignments/haskell/meetup/meetup_test.hs
+++ b/assignments/haskell/meetup/meetup_test.hs
@@ -1,13 +1,18 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Meetup (Weekday(..), Schedule(..), meetupDay)
 import Data.Time.Calendar (fromGregorian)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList meetupDayTests ]
 
 -- NOTE: This would be a good opportunity to write some QuickCheck properties.

--- a/assignments/haskell/nth-prime/nth-prime_test.hs
+++ b/assignments/haskell/nth-prime/nth-prime_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Prime (nth)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList primeTests ]
 
 primeTests :: [Test]

--- a/assignments/haskell/nucleotide-count/nucleotide-count_test.hs
+++ b/assignments/haskell/nucleotide-count/nucleotide-count_test.hs
@@ -1,8 +1,13 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), assertFailure)
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, assertFailure, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import DNA (count, nucleotideCounts)
 import Data.Map (fromList)
 import qualified Control.Exception as E
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 assertError :: String -> a -> IO ()
 assertError err f =
@@ -15,7 +20,7 @@ testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList countTests
        , TestList nucleotideCountTests]
 

--- a/assignments/haskell/ocr-numbers/ocr-numbers_test.hs
+++ b/assignments/haskell/ocr-numbers/ocr-numbers_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import OCR (convert)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList ocrTests ]
 
 ocrTests :: [Test]

--- a/assignments/haskell/octal/octal_test.hs
+++ b/assignments/haskell/octal/octal_test.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 import Test.QuickCheck
 import Test.QuickCheck.All (quickCheckAll)
-import Control.Monad (void)
+import System.Exit (ExitCode(..), exitWith)
 import Octal (showOct, readOct)
 import qualified Numeric as N
 
@@ -15,6 +15,11 @@ that the solution is efficient.
 
 Handling invalid input is not necessary.
 -}
+
+exitProperly :: IO Bool -> IO ()
+exitProperly m = do
+  didSucceed <- m
+  exitWith $ if didSucceed then ExitSuccess else ExitFailure 1
 
 prop_showOct_integral :: (Integral a, Show a) => (Positive a) -> Bool
 prop_showOct_integral (Positive n) = N.showOct n "" == showOct n
@@ -30,4 +35,4 @@ prop_readOct_int :: (Positive Int) -> Bool
 prop_readOct_int = prop_readOct_integral
 
 main :: IO ()
-main = void $quickCheckAll
+main = exitProperly $quickCheckAll

--- a/assignments/haskell/palindrome-products/palindrome-products_test.hs
+++ b/assignments/haskell/palindrome-products/palindrome-products_test.hs
@@ -1,5 +1,5 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Palindromes (largestPalindrome, smallestPalindrome)
 import qualified Data.Set as S
 
@@ -12,11 +12,16 @@ import qualified Data.Set as S
 -- You should consider using a slightly different algorithm to find small or
 -- large palindromes.
 
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList palindromesTests ]
 
 norm :: Ord a => [(a, a)] -> [(a, a)]

--- a/assignments/haskell/pascals-triangle/pascals-triangle_test.hs
+++ b/assignments/haskell/pascals-triangle/pascals-triangle_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Triangle (row, triangle)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList triangleTests ]
 
 triangleTests :: [Test]

--- a/assignments/haskell/phone-number/phone-number_test.hs
+++ b/assignments/haskell/phone-number/phone-number_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Phone (areaCode, number, prettyPrint)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList numberTests
        , TestList areaCodeTests
        , TestList prettyPrintTests ]

--- a/assignments/haskell/pig-latin/pig-latin_test.hs
+++ b/assignments/haskell/pig-latin/pig-latin_test.hs
@@ -1,11 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import PigLatin (translate)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList pigLatinTests ]
 
 pigLatinTests :: [Test]

--- a/assignments/haskell/point-mutations/point-mutations_test.hs
+++ b/assignments/haskell/point-mutations/point-mutations_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import DNA (hammingDistance)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList hammingDistanceTests ]
 
 hammingDistanceTests :: [Test]

--- a/assignments/haskell/prime-factors/prime-factors_test.hs
+++ b/assignments/haskell/prime-factors/prime-factors_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import PrimeFactors (primeFactors)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList primeTests ]
 
 primeTests :: [Test]

--- a/assignments/haskell/pythagorean-triplet/pythagorean-triplet_test.hs
+++ b/assignments/haskell/pythagorean-triplet/pythagorean-triplet_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Triplet (mkTriplet, isPythagorean, pythagoreanTriplets)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList tripletTests ]
 
 tripletTests :: [Test]

--- a/assignments/haskell/queen-attack/queen-attack_test.hs
+++ b/assignments/haskell/queen-attack/queen-attack_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Queens (boardString, canAttack)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
   [ TestList queenTests ]
 
 emptyBoard, board :: String

--- a/assignments/haskell/raindrops/raindrops_test.hs
+++ b/assignments/haskell/raindrops/raindrops_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Raindrops (convert)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList raindropsTests ]
 
 raindropsTests :: [Test]

--- a/assignments/haskell/rna-transcription/rna-transcription_test.hs
+++ b/assignments/haskell/rna-transcription/rna-transcription_test.hs
@@ -1,6 +1,11 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import DNA (toRNA)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
@@ -20,4 +25,4 @@ toRNATests =
   ]
 
 main :: IO ()
-main = void (runTestTT (TestList toRNATests))
+main = exitProperly (runTestTT (TestList toRNATests))

--- a/assignments/haskell/robot-name/robot-name_test.hs
+++ b/assignments/haskell/robot-name/robot-name_test.hs
@@ -1,15 +1,20 @@
-import Test.HUnit (Assertion, (@?), (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@?), (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Robot (robotName, mkRobot, resetName)
 import Text.Regex (mkRegex)
 import Text.Regex.Base (matchTest)
 import Control.Applicative ((<$>))
 
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList robotTests ]
 
 {-

--- a/assignments/haskell/robot-simulator/robot-simulator_test.hs
+++ b/assignments/haskell/robot-simulator/robot-simulator_test.hs
@@ -1,14 +1,19 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Robot (Bearing(..), Robot, mkRobot,
               coordinates, simulate,
               bearing, turnRight, turnLeft)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
   [ TestList robotTests ]
 
 robotTests :: [Test]

--- a/assignments/haskell/roman-numerals/roman-numerals_test.hs
+++ b/assignments/haskell/roman-numerals/roman-numerals_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Roman (numerals)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList numeralsTests ]
 
 numeralsTests :: [Test]

--- a/assignments/haskell/saddle-points/saddle-points_test.hs
+++ b/assignments/haskell/saddle-points/saddle-points_test.hs
@@ -1,13 +1,18 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Matrix (saddlePoints)
 import Data.Array (listArray)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList matrixTests ]
 
 matrixTests :: [Test]

--- a/assignments/haskell/say/say_test.hs
+++ b/assignments/haskell/say/say_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Say (inEnglish)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList inEnglishTests ]
 
 inEnglishTests :: [Test]

--- a/assignments/haskell/scrabble-score/scrabble-score_test.hs
+++ b/assignments/haskell/scrabble-score/scrabble-score_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Scrabble (scoreLetter, scoreWord)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList scrabbleTests ]
 
 scrabbleTests :: [Test]

--- a/assignments/haskell/secret-handshake/secret-handshake_test.hs
+++ b/assignments/haskell/secret-handshake/secret-handshake_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import SecretHandshake (handshake)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList handshakeTests ]
 
 -- The trick to this one is defining the appropriate typeclass or typeclasses

--- a/assignments/haskell/series/series_test.hs
+++ b/assignments/haskell/series/series_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Series (digits, slices)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList seriesTests ]
 
 seriesTests :: [Test]

--- a/assignments/haskell/sieve/sieve_test.hs
+++ b/assignments/haskell/sieve/sieve_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Sieve (primesUpTo)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList sieveTests ]
 
 sieveTests :: [Test]

--- a/assignments/haskell/simple-cipher/simple-cipher_test.hs
+++ b/assignments/haskell/simple-cipher/simple-cipher_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Cipher (caesarEncode, caesarDecode, caesarEncodeRandom)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList caesarTests ]
 
 caesarTests :: [Test]

--- a/assignments/haskell/simple-linked-list/simple-linked-list_test.hs
+++ b/assignments/haskell/simple-linked-list/simple-linked-list_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import qualified LinkedList as L
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
   [ TestList listTests ]
 
 listTests :: [Test]

--- a/assignments/haskell/space-age/space-age_test.hs
+++ b/assignments/haskell/space-age/space-age_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import SpaceAge (Planet(..), ageOn)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList ageOnTests ]
 
 roundsTo :: Float -> Float -> Assertion

--- a/assignments/haskell/strain/strain_test.hs
+++ b/assignments/haskell/strain/strain_test.hs
@@ -1,12 +1,18 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Strain (keep, discard)
 import Data.List (isPrefixOf)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList strainTests ]
 
 ints :: [Int] -> [Int]

--- a/assignments/haskell/sum-of-multiples/sum-of-multiples_test.hs
+++ b/assignments/haskell/sum-of-multiples/sum-of-multiples_test.hs
@@ -1,11 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import SumOfMultiples (sumOfMultiples, sumOfMultiplesDefault)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
+
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList sumOfMultiplesTests ]
 
 ints :: [Int] -> [Int]

--- a/assignments/haskell/triangle/triangle_test.hs
+++ b/assignments/haskell/triangle/triangle_test.hs
@@ -1,12 +1,17 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Triangle (TriangleType(..), triangleType)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList triangleTests ]
 
 tri :: Int -> Int -> Int -> TriangleType

--- a/assignments/haskell/trinary/trinary_test.hs
+++ b/assignments/haskell/trinary/trinary_test.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 import Test.QuickCheck
 import Test.QuickCheck.All (quickCheckAll)
-import Control.Monad (void)
+import System.Exit (ExitCode(..), exitWith)
 import Trinary (showTri, readTri)
 import qualified Numeric as N
 import Data.Char (intToDigit)
@@ -18,6 +18,11 @@ Handling invalid input is not necessary.
 
 If you've done the Octal exercise, perhaps you should generalize it.
 -}
+
+exitProperly :: IO Bool -> IO ()
+exitProperly m = do
+  didSucceed <- m
+  exitWith $ if didSucceed then ExitSuccess else ExitFailure 1
 
 refShowTri :: (Integral a, Show a) => a -> String
 refShowTri n = N.showIntAtBase 3 intToDigit n ""
@@ -36,4 +41,4 @@ prop_readOct_int :: (Positive Int) -> Bool
 prop_readOct_int = prop_readOct_integral
 
 main :: IO ()
-main = void $quickCheckAll
+main = exitProperly $quickCheckAll

--- a/assignments/haskell/word-count/word-count_test.hs
+++ b/assignments/haskell/word-count/word-count_test.hs
@@ -1,7 +1,12 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import Data.Map (fromList)
 import WordCount (wordCount)
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
@@ -35,4 +40,4 @@ wordCountTests =
   ]
 
 main :: IO ()
-main = void (runTestTT (TestList wordCountTests))
+main = exitProperly (runTestTT (TestList wordCountTests))

--- a/assignments/haskell/wordy/wordy_test.hs
+++ b/assignments/haskell/wordy/wordy_test.hs
@@ -1,14 +1,19 @@
-import Test.HUnit (Assertion, (@=?), runTestTT, Test(..))
-import Control.Monad (void)
+import Test.HUnit (Assertion, (@=?), runTestTT, Test(..), Counts(..))
+import System.Exit (ExitCode(..), exitWith)
 import WordProblem (answer)
 
 -- This is a perfect opportunity to learn some Attoparsec or Parsec!
+
+exitProperly :: IO Counts -> IO ()
+exitProperly m = do
+  counts <- m
+  exitWith $ if failures counts /= 0 || errors counts /= 0 then ExitFailure 1 else ExitSuccess
 
 testCase :: String -> Assertion -> Test
 testCase label assertion = TestLabel label (TestCase assertion)
 
 main :: IO ()
-main = void $ runTestTT $ TestList
+main = exitProperly $ runTestTT $ TestList
        [ TestList answerTests ]
 
 answerTests :: [Test]


### PR DESCRIPTION
This fixes all of the Haskell tests so that the exit code makes sense. Should help with https://github.com/kytrinyx/exercism/pull/79 and similar efforts. I'm also looking into what it will take to get these tests run by Travis. I have a script working locally, but Travis doesn't really do multi-language and the Haskell it has is too old anyway so I have to build some compatible binaries to make that work.
