### PR TITLE
Test all Haskell exercises with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: ruby
 rvm:
   - 1.9.3
 services: mongodb
-before_script: 'bundle exec mailcatcher'
+before_script:
+  - './test/haskell/bootstrap.sh'
+  - 'bundle exec mailcatcher'
 script:
   - rake
-  - 'cd frontend && npm install && lineman spec-ci'
+  - '( cd frontend && npm install && lineman spec-ci )'
+  - '( export PATH=/opt/hp-2013.2.0.0/bin:$PATH; runhaskell ./test/haskell/check-exercises.hs )'

--- a/test/haskell/bootstrap.sh
+++ b/test/haskell/bootstrap.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# This installs a Haskell platform to PREFIX=/opt/hp-2013.2.0.0
+set -x
+set -e
+HP_VER=2013.2.0.0
+HP_URL=https://github.com/etrepum/travis-haskell/releases/download/${HP_VER}/hp-${HP_VER}.tar.bz2
+PREFIX=/opt/hp-${HP_VER}
+sudo apt-get -y install git gcc make autoconf libtool zlib1g-dev \
+  libncurses-dev libgmp-dev
+if [ ! -e "/usr/lib/libgmp.so.3" ]; then
+  sudo ln -s /usr/lib/x86_64-linux-gnu/libgmp.so.10 /usr/lib/libgmp.so.3
+fi
+if [ ! -e "/usr/lib/libgmp.so" ]; then
+  sudo ln -s /usr/lib/x86_64-linux-gnu/libgmp.so.10 /usr/lib/libgmp.so
+fi
+if [ ! -e "${PREFIX}" ]; then
+  ( cd /
+    curl -L "${HP_URL}" | sudo tar jxf - )
+fi
+sudo chmod ugo+rX -R "${PREFIX}"


### PR DESCRIPTION
Here's an example of this working: https://travis-ci.org/etrepum/exercism.io/builds/11617656

Building a copy of Haskell Platform for Ubuntu 12.04 that's small enough to host as a GitHub release, and making it work in Travis' environment, was much harder than I thought it would be. A similar technique could be used to test the exercises from other languages.

The before_script does this:
- Ensures that the relevant deb packages are installed
- Does some dumb stuff to /usr/lib so that the GHC build can find libgmp.so.3
- Downloads a binary of Haskell Platform that I built and untars it to /opt/hp-2013.2.0.0

The check-exercises.hs script does this:
- Creates a temporary directory (that it cleans up on exit)
- Finds all of the Haskell exercises (relative to the current directory)
- For each exercise (serially), figure out what the correct filename for the module should be, copy it to the temporary directory with the right name, and run the test. It collects the name of the exercise if it failed.
- Collect the results, and either print out "SUCCESS!" with exit code 0, or print out "Failures: …" with the list of exercises that failed separated by commas and then fail with exit code 1.
