### PR TITLE
Fixes #795: Login error message being displayed unnecessarily

### DIFF
--- a/lib/app/auth.rb
+++ b/lib/app/auth.rb
@@ -22,6 +22,7 @@ class ExercismApp < Sinatra::Base
         expires: Time.now + (60 * 60 * 24 * 30) # 1 month
       }
       response.set_cookie('_exercism_login', data)
+      @current_user = user
     end
 
     def logout
@@ -67,11 +68,11 @@ class ExercismApp < Sinatra::Base
       user = Authentication.perform(params[:code])
       login(user)
     rescue => e
-      flash[:error] = "We're having trouble with logins right now. Please come back later"
+      flash[:error] = "We're having trouble with logins right now. Please come back later."
     end
 
     if current_user.guest?
-      flash[:error] = "We're having trouble with logins right now. Please come back later"
+      flash[:error] = "We're having trouble with logins right now. Please come back later."
     end
 
     # params[:splat] might be an empty array


### PR DESCRIPTION
I believe this fixes #795, which is being caused by current_user not being set. I could reproduce in a browser and now with this fix I can't any more.

I'll add test coverage at some point, but I'm too tired right now and I figured a fix is better than nothing!
