### PR TITLE
Update pygments.css

### DIFF
--- a/frontend/app/css/pygments.css
+++ b/frontend/app/css/pygments.css
@@ -23,6 +23,7 @@ td.gutter {
 .highlight .err{color:#a61717;background-color:#e3d2d2;}
 .highlight .k{font-weight:bold;}
 .highlight .o{font-weight:bold;}
+.highlight .cd{color:#998;font-style:italic;}
 .highlight .cm{color:#998;font-style:italic;}
 .highlight .cp{color:#999;font-weight:bold;}
 .highlight .c1{color:#998;font-style:italic;}


### PR DESCRIPTION
insert a line

```
.highlight .cd{color:#998;font-style:italic;}
```

so that haskell code will display one line comment. The color is chosen as multi-line comments.

See [this link](http://exercism.io/submissions/5244b9ac67790bd66a0001bd) for comments, and [this link](http://exercism.io/submissions/5244cab767790b5d210001d7) for effects.

![screen shot 2013-09-27 at 8 08 31 am](https://f.cloud.github.com/assets/2290484/1222969/01b6c8ba-2709-11e3-9d09-54d4588ed404.png)
