### PR TITLE
run haskell tests with warnings on, recommend -Wall in the setup instructions

### DIFF
--- a/lib/app/views/setup/haskell.erb
+++ b/lib/app/views/setup/haskell.erb
@@ -8,7 +8,7 @@
 </p>
 
 <h4>Building and running tests: </h4>
-<pre>$ runhaskell bob_test.hs</pre>
+<pre>$ runhaskell -Wall bob_test.hs</pre>
 
 <h4>Making your first Haskell module</h4>
 

--- a/test/haskell/check-exercises.hs
+++ b/test/haskell/check-exercises.hs
@@ -33,10 +33,11 @@ testAssignment dir fn = do
   let d = dir </> fn
       example = d </> "example.hs"
       testFile = d </> (fn ++ "_test.hs")
+      opts = ["-Wall", "-Werror", testFile]
   putStrLn $ "-- " ++ fn
   modFile <- (++ ".hs") . parseModule . lines <$> readFile example
   copyFile example modFile
-  exitCode <- finally (rawSystem "runhaskell" [testFile]) (removeFile modFile)
+  exitCode <- finally (rawSystem "runhaskell" opts) (removeFile modFile)
   return $ case exitCode of
     ExitSuccess -> Nothing
     _           -> Just fn


### PR DESCRIPTION
If people read the -Wall in the setup instructions, it might help them from submitting code that has mistakes that the Haskell compiler can catch for them.

This also dogfoods it by making sure all the tests and exercises actually compile without warnings too… Emacs with ghc-mod does this for me so fortunately there isn't any cleanup to do in that department.
