### PR TITLE
Fix assertions in elixir phone number tests

### DIFF
--- a/assignments/elixir/phone-number/phone-number_test.exs
+++ b/assignments/elixir/phone-number/phone-number_test.exs
@@ -10,11 +10,11 @@ defmodule PhoneTest do
   end
 
   test "cleans number with dots" do
-    # assert "1234567890", Phone.number("123.456.7890")
+    # assert "1234567890" == Phone.number("123.456.7890")
   end
 
   test "valid when 11 digits and first is 1" do
-    # assert "1234567890", Phone.number("11234567890")
+    # assert "1234567890" == Phone.number("11234567890")
   end
 
   test "invalid when 11 digits" do


### PR DESCRIPTION
Two of the tests were giving false positives because there was a comma
between the expected and the actual instead of `==`.
