### PR TITLE
markdown: don't double-escape ">" and "<" in code blocks

### DIFF
--- a/lib/exercism/converts_markdown_to_html.rb
+++ b/lib/exercism/converts_markdown_to_html.rb
@@ -16,17 +16,11 @@ class ConvertsMarkdownToHTML
   end
 
   def convert
-    sanitize_markdown
     convert_markdown_to_html
     sanitize_html
   end
 
   private
-
-  def sanitize_markdown
-    @content.gsub!('>', '&gt;')
-    @content.gsub!('<', '&lt;')
-  end
 
   def sanitize_html
     @content = Loofah.xml_fragment(@content).scrub!(:escape).to_s

--- a/test/exercism/converts_markdown_to_html_test.rb
+++ b/test/exercism/converts_markdown_to_html_test.rb
@@ -16,7 +16,6 @@ class ConvertsMarkdownToHTMLTest < Minitest::Test
 
   def test_convert_calls_correct_methods
     converter = ConvertsMarkdownToHTML.new(nil)
-    converter.expects(:sanitize_markdown)
     converter.expects(:convert_markdown_to_html)
     converter.expects(:sanitize_html)
     converter.convert
@@ -152,7 +151,7 @@ Post text}
           <div class="lineno">3</div>
         </td>
         <td class="code">class Foobar
-  foos.each { |foo| foo.bar &amp;gt; 10 }
+  foos.each { |foo| foo.bar &gt; 10 }
 end
 </td>
       </tr>


### PR DESCRIPTION
See #416.

I removed the `sanitize_markdown` method call, which will gsub all "<" and  ">" with their HTML entities.

When Markdown parsed the file, it kept those entities intact, _unless_ they were in a &lt;pre&gt; or &lt;code&gt; block. Then it escaped them again, so they were doubly-escaped.

I also changed a test which incorrectly expected the doubly-escaped output.

The other tests pass, but does this introduce a XSS vulnerability I'm not seeing?
