### PR TITLE
GoCurriculum#slugs should return an array and not a string

### DIFF
--- a/lib/exercism/curriculum/go.rb
+++ b/lib/exercism/curriculum/go.rb
@@ -1,7 +1,7 @@
 class Exercism
   class GoCurriculum
     def slugs
-      %(
+      %w(
         bob word-count anagram nucleotide-count
         binary
       )


### PR DESCRIPTION
`GoCurriculum#slugs` returns a string instead of an array of assignments, causing an exception if you active the go curriculum.

Is it worth it to update the tests to catch this bug ? You can't load any pages once the go curriculum is activated, so this is not going to be an easily missed problem.
