### PR TITLE
ruby/binary specs: 'carrot123' should become 0, not 1

### DIFF
--- a/assignments/ruby/binary/binary_test.rb
+++ b/assignments/ruby/binary/binary_test.rb
@@ -38,6 +38,6 @@ class BinaryTest < MiniTest::Unit::TestCase
 
   def test_invalid_binary_is_decimal_0
     skip
-    assert_equal 0, Binary.new("carrot").to_decimal
+    assert_equal 0, Binary.new("carrot123").to_decimal
   end
 end

--- a/assignments/ruby/binary/example.rb
+++ b/assignments/ruby/binary/example.rb
@@ -2,14 +2,18 @@ class Binary
 
   attr_reader :digits
   def initialize(decimal)
-    @digits = decimal.reverse.chars.collect(&:to_i)
+    @digits = normalize(decimal).reverse.chars.collect(&:to_i)
   end
 
   def to_decimal
-    decimal = 0
-    digits.each_with_index do |digit, index|
-      decimal += digit * 2**index
+    digits.each_with_index.inject(0) do |decimal, (digit, index)|
+      decimal + digit * 2**index
     end
-    decimal
+  end
+
+  private
+
+  def normalize(string)
+    string.match(/[^01]/) ? "0" : string
   end
 end


### PR DESCRIPTION
The README gave the impression that non-binary input should become 0, but the specs let you cheat a bit (and the example did) :)
