### PR TITLE
Refactor lineno css to match new markup

### DIFF
--- a/frontend/app/css/pygments.css
+++ b/frontend/app/css/pygments.css
@@ -29,7 +29,7 @@ td.gutter {
     white-space: nowrap;
 }
 
-.highlight .lineno pre { color: #999; }
+.highlight .lineno { color: #999; }
 
 /* Pygments coloring */
 .highlight .c{color:#998;font-style:italic;}


### PR DESCRIPTION
I noticed the line numbers stopped being grey after the markup from Rouge changed slightly - so have updated the CSS so they're grey again!
