### PR TITLE
Ruby accumulate spec typo.

### DIFF
--- a/assignments/ruby/accumulate/accumulate_test.rb
+++ b/assignments/ruby/accumulate/accumulate_test.rb
@@ -20,7 +20,7 @@ class ArrayTest < MiniTest::Unit::TestCase
     result = %w(hello world).accumulate { |word|
       word.upcase
     }
-    assert_equal %(HELLO WORLD), result
+    assert_equal %w(HELLO WORLD), result
   end
 
   def test_accumulate_reversed_strings


### PR DESCRIPTION
Found another spec typo. This is supposed to map an array to an array, not an array to a string.
