### PR TITLE
Ruby pythagorean triplet spec typo.

### DIFF
--- a/assignments/ruby/pythagorean-triplet/pythagorean-triplet_test.rb
+++ b/assignments/ruby/pythagorean-triplet/pythagorean-triplet_test.rb
@@ -24,21 +24,21 @@ class TripletTest < MiniTest::Unit::TestCase
   def test_triplets_upto_10
     skip
     triplets = Triplet.where(max_factor: 10)
-    products = triplets.map(&:product).sort
+    products = triplets.map {|x| x.inject(:*) }.sort
     assert_equal [60, 480], products
   end
 
   def test_triplets_from_11_upto_20
     skip
     triplets = Triplet.where(min_factor: 11, max_factor: 20)
-    products = triplets.map(&:product).sort
+    products = triplets.map {|x| x.inject(:*) }.sort
     assert_equal [3840], products
   end
 
   def test_triplets_where_sum_x
     skip
     triplets = Triplet.where(sum: 180, max_factor: 100)
-    products = triplets.map(&:product).sort
+    products = triplets.map {|x| x.inject(:*) }.sort
     assert_equal [118080, 168480, 202500], products
   end
 end


### PR DESCRIPTION
This method name is a bit misleading in ruby. It finds all combinations of an array instead of finding the product, thus the tests will fail.
