### PR TITLE
Fix nitpick email

### DIFF
--- a/lib/services/email/comment.erb
+++ b/lib/services/email/comment.erb
@@ -2,4 +2,4 @@ Hi <%= name %>,
 
 Your submission on <%= exercise.name %> in <%= exercise.language %> has received feedback from <%= from %>!
 
-Visit <%= site_root %>/submissions/<%= submission.id %> to find out more.
+Visit <%= site_root %>/submissions/<%= submission.key %> to find out more.

--- a/test/fixtures/approvals/nitpick_email_body.approved.txt
+++ b/test/fixtures/approvals/nitpick_email_body.approved.txt
@@ -2,4 +2,4 @@ Hi bob,
 
 Your submission on Word Count in ruby has received feedback from alice!
 
-Visit http://example.com/submissions/ID to find out more.
+Visit http://example.com/submissions/KEY to find out more.

--- a/test/services/comment_message_test.rb
+++ b/test/services/comment_message_test.rb
@@ -7,7 +7,7 @@ require 'exercism/exercise'
 class CommentMessageTest < Minitest::Test
 
   FakeUser = Struct.new(:username, :email)
-  FakeSubmission = Struct.new(:id, :user, :exercise)
+  FakeSubmission = Struct.new(:key, :user, :exercise)
 
   attr_reader :alice, :submission
 
@@ -16,7 +16,7 @@ class CommentMessageTest < Minitest::Test
     @alice = FakeUser.new('alice', 'alice@example.com')
 
     @submission = FakeSubmission.new(
-      'ID',
+      'KEY',
       FakeUser.new('bob', 'bob@example.com'),
       Exercise.new('ruby', 'word-count')
     )


### PR DESCRIPTION
After started using exercism.io few days ago I've noticed the link inside the 'new comment' notification email was broken. This PR fixes it.
