### PR TITLE
Change grade school tests and example to encourage idiomatic Elixir list building

### DIFF
--- a/assignments/elixir/grade-school/example.exs
+++ b/assignments/elixir/grade-school/example.exs
@@ -1,6 +1,6 @@
 defmodule School do
   def add(db, student, grade) do
-    HashDict.update db, grade, [student], &1 ++ [student]
+    HashDict.update db, grade, [student], &([ student | &1 ])
   end
 
   def grade(db, grade) do

--- a/assignments/elixir/grade-school/grade-school_test.exs
+++ b/assignments/elixir/grade-school/grade-school_test.exs
@@ -18,7 +18,7 @@ defmodule SchoolTest do
       |> School.add("Blair", 2)
       |> School.add("Paul", 2)
 
-    # assert actual == HashDict.new [{2, ["James", "Blair", "Paul"]}]
+    # assert Enum.sort(actual[2]) == ["Blair", "James", "Paul"]
   end
 
   test "add students to different grades" do
@@ -36,7 +36,7 @@ defmodule SchoolTest do
       |> School.add("Jeff", 1)
       |> School.grade(5)
 
-    # assert ["Franklin", "Bradley"] == actual
+    # assert Enum.sort(actual) == ["Bradley", "Franklin"]
   end
 
   test "get students in a non existant grade" do


### PR DESCRIPTION
@pminten reminded me that lists in Elixir are implemented as singly
linked lists and as a result it is O(1) to add an item to the beginning
of a list, while it is O(n) to add an item to the end of a list.

I updated the tests so that they do not care in what order the
students are added to the list, and updated the example to use the
[ head | tail ] form of adding an item to the head of a list.

I'm an Elixir newbie, so if my change to the example is not ideal,
feel free to correct me!
