### PR TITLE
Add test to ruby phone-number for numbers with greater than 11 digits that start with 1

### DIFF
--- a/assignments/ruby/phone-number/phone-number_test.rb
+++ b/assignments/ruby/phone-number/phone-number_test.rb
@@ -32,6 +32,12 @@ class PhoneNumberTest < MiniTest::Unit::TestCase
     assert_equal "0000000000", number
   end
 
+  def test_invalid_when_12_digits_and_first_is_1
+    skip
+    number = PhoneNumber.new("112345678901").number
+    assert_equal "0000000000", number
+  end
+
   def test_area_code
     skip
     number = PhoneNumber.new("1234567890")


### PR DESCRIPTION
I came across an implementation where the validation was written in such
a way that any numbers greater than 10 digits in length that started with
1 were considered valid. Without this extra test extremely long numbers
that happen to start with 1 could all be considered valid and could be
passed through with just the 1 removed from the front. (That is how the
implementation I came across was doing it: `number[0] = ""`).
