### PR TITLE
Fix to ordering and number of nits per page in nits history.

### DIFF
--- a/lib/app/nitpick_history.rb
+++ b/lib/app/nitpick_history.rb
@@ -3,16 +3,12 @@ class ExercismApp < Sinatra::Base
   get '/user/history' do
     please_login
 
+    per_page = params[:per_page] || 10
+
     nitpicks = current_user.comments
+                           .order('created_at DESC')
                            .paginate(page: params[:page], per_page: per_page)
 
     erb :history, locals: {nitpicks: nitpicks}
   end
-
-  private
-
-  def per_page
-    params[:per_page] || 10
-  end
-
 end


### PR DESCRIPTION
I have fixed the ordering of entries in nits history view so that the newest ones are in the beginning, which makes more sense. On that occasion I've also changed the way the per page count is retrieved, because the private method overlapped with one defined elsewhere (in app/exercises.rb).
