### PR TITLE
Rebased attempt at hyperlinking mentions inline.

### DIFF
--- a/lib/exercism/markdown.rb
+++ b/lib/exercism/markdown.rb
@@ -1,6 +1,38 @@
 require 'redcarpet'
+require 'nokogiri'
 require 'rouge'
 require 'rouge/plugins/redcarpet'
+
+# GitHub usernames can contain alphanumerics and dashes, but must not
+# start with a dash.
+USERNAME_REGEX = /(@[0-9a-zA-z][0-9a-zA-Z\-]*)/
+
+def hyperlink_mentions!(node)
+  node.children.each do |child|
+    if child.node_type == Nokogiri::XML::Node::ELEMENT_NODE and
+       !child.matches?('code,td[class=code]')
+      hyperlink_mentions! child
+    elsif child.node_type == Nokogiri::XML::Node::TEXT_NODE
+      set = []
+      remaining = child.content
+      until remaining.empty?
+        head, match, remaining = remaining.partition(USERNAME_REGEX)
+        set << child.document.create_text_node(head)
+        unless match.empty?
+          link = child.document.create_element("a")
+          link.set_attribute('class', 'mention')
+          link.set_attribute('href', '/' + match[1..-1])
+          link.content = match
+          set << link
+        end
+      end
+      if set.length > 1
+        set = Nokogiri::XML::NodeSet.new(child.document, set)
+        child.replace(set)
+      end
+    end
+  end
+end
 
 class Markdown < Redcarpet::Render::XHTML
 
@@ -28,6 +60,16 @@ class Markdown < Redcarpet::Render::XHTML
       space_after_headers: true,
       xhtml: true
     }
+  end
+
+  def postprocess(html_content)
+    dom = Nokogiri::HTML(html_content)
+    body = dom.css("body").first
+    if body
+      hyperlink_mentions! body
+      return body.inner_html
+    end
+    ""
   end
 
   def block_code(code, language)

--- a/test/exercism/markdown_test.rb
+++ b/test/exercism/markdown_test.rb
@@ -2,9 +2,33 @@ require './test/test_helper'
 require 'exercism/markdown'
 
 class MarkdownTest < Minitest::Test
+  def test_mention
+    markdown = "u @goose."
+    expected = "<p>u <a class=\"mention\" href=\"/goose\">@goose</a>.</p>"
+    assert_equal expected, Markdown.render(markdown)
+  end
+
+  def test_mention_works_multiple_times
+    markdown = "u @goose of @doom."
+    expected = "<p>u <a class=\"mention\" href=\"/goose\">@goose</a> of " +
+               "<a class=\"mention\" href=\"/doom\">@doom</a>.</p>"
+    assert_equal expected, Markdown.render(markdown)
+  end
+
+  def test_mention_ignores_code_spans
+    markdown = "`@goose`"
+    expected = "<p><code>@goose</code></p>"
+    assert_equal expected, Markdown.render(markdown)
+  end
+
+  def test_mention_ignores_fenced_code_blocks
+    markdown = "```\n@goose\n```"
+    assert_match "<pre>@goose", Markdown.render(markdown)
+  end
+
   def test_newlines
     markdown = "Foo\nBar"
-    expected = "<p>Foo<br/>\nBar</p>\n"
+    expected = "<p>Foo<br>\nBar</p>"
     assert_equal expected, Markdown.render(markdown)
   end
 end


### PR DESCRIPTION
This is just a rebased and squished version of #899.

Once this is accepted, I will need to file bugs for the following:
- Right now we don't ensure that there are only spaces/punctuation around the mention, meaning e.g. our code would think `hi@toolness.com` contains a mention of `@toolness`. However, I _think_ the `ExtractsMentionsFromMarkdown` class has the same limitation (not sure though).
- A class `mention` is given to the hyperlink but it's not actually given any special display via CSS.
- The list of mentions are still enumerated after the comment, but should be removed as per the discussion in #877.
- We shouldn't hyperlink mentions if the mentioned user doesn't actually exist.
- The `ExtractsMentionsFromMarkdown` class duplicates some of the functionality in this PR, albeit by analyzing Markdown source rather than the converted HTML. It would be nice to consolidate the functionality somehow.
