### PR TITLE
Makes 'test_invalid_with_letters' test more robust by including 10 digits

### DIFF
--- a/assignments/ruby/phone-number/phone-number_test.rb
+++ b/assignments/ruby/phone-number/phone-number_test.rb
@@ -23,7 +23,7 @@ class PhoneNumberTest < MiniTest::Unit::TestCase
 
   def test_invalid_with_letters
     skip
-    number = PhoneNumber.new("123-abc-1234").number
+    number = PhoneNumber.new("abc-123-456-7890").number
     assert_equal "0000000000", number
   end
 


### PR DESCRIPTION
This makes "test_invalid_with_letters" for the "phone-number" assignment more robust. 

This prevents phone numbers that have 10 digits mixed with numbers from passing. The use case of a phone number that has more than or less than 10 digits is already covered in the other tests, but the use case where a 10 digit number has additional numbers is not covered.
