### PR TITLE
site_root uses HTTP_HOST header

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -52,11 +52,7 @@ class ExercismApp < Sinatra::Base
   helpers do
 
     def site_root
-      if ENV['RACK_ENV'].to_sym == :production
-        'http://exercism.io'
-      else
-        'http://localhost:4567'
-      end
+      env.fetch 'HTTP_HOST', 'http://exercism.io'
     end
 
     def current_user


### PR DESCRIPTION
Pretty sure this allows it to be whatever the client sees. For example,
this allowed it to work with pow.cx and also with the default Sinatra
localhost:4567, and sinatra run on a different port (rackup -p 1818).

It uses 'http://exercism.io' as a backup just in case this isn't
always set (might depend on the server, IDK).
