### PR TITLE
add "log" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 coverage
 InstalledFiles
 lib/bundler/man
+log
 pkg
 rdoc
 spec/reports


### PR DESCRIPTION
Minor change - I noticed a new log directory after running tests and the server locally. 
