### PR TITLE
rewrite test suite for ruby hamming exercise

### DIFF
--- a/assignments/ruby/hamming/hamming_test.rb
+++ b/assignments/ruby/hamming/hamming_test.rb
@@ -2,42 +2,47 @@ require 'minitest/autorun'
 require_relative 'hamming'
 
 class HammingTest < MiniTest::Unit::TestCase
-  def test_no_difference_between_empty_strands
-    assert_equal 0, Hamming.compute('', '')
-  end
-
   def test_no_difference_between_identical_strands
-    skip
-    assert_equal 0, Hamming.compute('GGACTGA','GGACTGA')
+    assert_equal 0, Hamming.compute('A', 'A')
   end
 
-  def test_complete_hamming_distance_in_small_strand
+  def test_complete_hamming_distance_of_for_single_nucleotide_strand
     skip
-    assert_equal 3, Hamming.compute('ACT', 'GGA')
+    assert_equal 1, Hamming.compute('A','G')
   end
 
-  def test_hamming_distance_in_off_by_one_strand
+  def test_complete_hamming_distance_of_for_small_strand
     skip
-    assert_equal 9, Hamming.compute('GGACGGATTCTG', 'AGGACGGATTCT')
+    assert_equal 2, Hamming.compute('AG','CT')
   end
 
-  def test_small_hamming_distance_in_middle_somewhere
+  def test_small_hamming_distance
+    skip
+    assert_equal 1, Hamming.compute('AT','CT')
+  end
+
+  def test_small_hamming_distance_in_longer_strand
     skip
     assert_equal 1, Hamming.compute('GGACG', 'GGTCG')
   end
 
-  def test_larger_distance
+  def test_ignores_extra_length_on_first_strand_when_longer
     skip
-    assert_equal 2, Hamming.compute('ACCAGGG', 'ACTATGG')
+    assert_equal 0, Hamming.compute('AAAG', 'AAA')
   end
 
   def test_ignores_extra_length_on_other_strand_when_longer
     skip
-    assert_equal 3, Hamming.compute('AAACTAGGGG', 'AGGCTAGCGGTAGGAC')
+    assert_equal 0, Hamming.compute('AAA', 'AAAG')
   end
 
-  def test_ignores_extra_length_on_original_strand_when_longer
+  def test_large_hamming_distance
     skip
-    assert_equal 5, Hamming.compute('GACTACGGACAGGGTAGGGAAT', 'GACATCGCACACC')
+    assert_equal 4, Hamming.compute('GATACA', 'GCATAA')
+  end
+
+  def test_hamming_distance_in_very_long_strand
+    skip
+    assert_equal 9, Hamming.compute('GGACGGATTCTG', 'AGGACGGATTCT')
   end
 end


### PR DESCRIPTION
I rewrote the tests for the Ruby hamming exercise to encourage users to take smaller steps, [based on some observations I've made while teaching TDD to first timers](http://blog.8thlight.com/mike-jansen/2013/07/18/the-right-tests-in-the-wrong-order.html). As I worked through the exercise myself the first time, I found that I was making a large leap to implement the algorithm right away, instead of working in smaller chunks. 

For example - in the master branch, the first two tests are:

``` ruby
  def test_no_difference_between_empty_strands
    assert_equal 0, Hamming.compute('', '')
  end

  def test_no_difference_between_identical_strands
    skip
    assert_equal 0, Hamming.compute('GGACTGA','GGACTGA')
  end
```

You can make these pass by just defining a method that returns 0:

``` ruby
  def self.compute(strand1, strand2)
    0
  end
```

You can make the third test pass by returning the length of either strand, but then it's straight to a really long strand:

``` ruby
  def test_complete_hamming_distance_in_small_strand
    skip
    assert_equal 3, Hamming.compute('ACT', 'GGA')
  end

  def test_hamming_distance_in_off_by_one_strand
    skip
    assert_equal 9, Hamming.compute('GGACGGATTCTG', 'AGGACGGATTCT')
  end
```

I found myself implementing the entire solution by this point. The next two tests pass without any work:

``` ruby
  def test_small_hamming_distance_in_middle_somewhere
    skip
    assert_equal 1, Hamming.compute('GGACG', 'GGTCG')
  end

  def test_larger_distance
    skip
    assert_equal 2, Hamming.compute('ACCAGGG', 'ACTATGG')
  end
```

And then you get two more tests that need some additional code changes:

``` ruby
  def test_ignores_extra_length_on_other_strand_when_longer
    skip
    assert_equal 3, Hamming.compute('AAACTAGGGG', 'AGGCTAGCGGTAGGAC')
  end

  def test_ignores_extra_length_on_original_strand_when_longer
    skip
    assert_equal 5, Hamming.compute('GACTACGGACAGGGTAGGGAAT', 'GACATCGCACACC')
  end
```

In the order in this pull request, I tried to make the strings shorter to make the first unit tests more readable (I had to count the characters manually to make sure the tests were right in the old version), and forced the issue of mismatching lengths sooner. I kept a few final tests at the end with longer strings at the end to "prove" that the implementation works. 

Note - I copied the example.rb file into hamming.rb and ran all of my new tests and the old tests to verify that it worked as expected. I didn't see a way to automatically verify the assignments against the examples - is that possible?
