### PR TITLE
Provide tests that '8' and '9' are seen as invalid octal characters.

### DIFF
--- a/assignments/ruby/octal/octal_test.rb
+++ b/assignments/ruby/octal/octal_test.rb
@@ -45,4 +45,14 @@ class OctalTest < MiniTest::Unit::TestCase
     skip
     assert_equal 0, Octal.new("carrot").to_decimal
   end
+  
+  def test_8_is_seen_as_invalid_and_returns_0
+    assert_equal 0, Octal.new("8").to_decimal
+  end
+
+  def test_9_is_seen_as_invalid_and_returns_0
+    assert_equal 0, Octal.new("9").to_decimal
+  end
+
+
 end


### PR DESCRIPTION
The ruby octal exercise needs tests to verify that a submitted octal string, like "89" is converted to 0 by #to_decimal.

A mixture of valid and invalid characters is not tested. In fact "6789" would be converted to 3520 with the current example code. I have not provided a test to assert that "6789" should convert to 0. It is not clear from the provided tests and example code that conversion to 0 is considered correct behavior by the author. 

I can provide tests and alternate example code to convert any string containing invalid octal characters to 0, if requested.
