### PR TITLE
Change to make tests for '8' and '9' as invalid octal chars pass.

### DIFF
--- a/assignments/ruby/octal/example.rb
+++ b/assignments/ruby/octal/example.rb
@@ -10,6 +10,7 @@ class Octal
   def to_decimal
     decimal = 0
     digits.each_with_index do |digit, index|
+      digit = 0 if [8,9].include? digit
       decimal += digit * BASE**index
     end
     decimal


### PR DESCRIPTION
This makes the tests I proposed for invalid 'octal' characters '8' & '9' pass. However, it should be noted that the provided code and tests still allow '18' to return 8 as would 'abc1z'. I think both should return 0.
