### PR TITLE
vary the test inputs, reorder tests to allow for smaller incremental changes

### DIFF
--- a/assignments/ruby/phone-number/phone-number_test.rb
+++ b/assignments/ruby/phone-number/phone-number_test.rb
@@ -2,6 +2,10 @@ gem 'minitest'
 require 'minitest/autorun'
 require_relative 'phone_number'
 
+gem 'minitest'
+require 'minitest/autorun'
+require_relative 'phone_number'
+
 class PhoneNumberTest < MiniTest::Unit::TestCase
 
   def test_cleans_number
@@ -9,16 +13,16 @@ class PhoneNumberTest < MiniTest::Unit::TestCase
     assert_equal "1234567890", number
   end
 
-  def test_cleans_number_with_dots
+  def test_cleans_a_different_number
     skip
-    number = PhoneNumber.new("123.456.7890").number
-    assert_equal "1234567890", number
+    number = PhoneNumber.new("(987) 654-3210").number
+    assert_equal "9876543210", number
   end
 
-  def test_valid_when_11_digits_and_first_is_1
+  def test_cleans_number_with_dots
     skip
-    number = PhoneNumber.new("11234567890").number
-    assert_equal "1234567890", number
+    number = PhoneNumber.new("456.123.7890").number
+    assert_equal "4561237890", number
   end
 
   def test_invalid_with_letters_in_place_of_numbers
@@ -27,15 +31,21 @@ class PhoneNumberTest < MiniTest::Unit::TestCase
     assert_equal "0000000000", number
   end
 
-  def test_invalid_when_11_digits
-    skip
-    number = PhoneNumber.new("21234567890").number
-    assert_equal "0000000000", number
-  end
-
   def test_invalid_when_9_digits
     skip
     number = PhoneNumber.new("123456789").number
+    assert_equal "0000000000", number
+  end
+
+  def test_valid_when_11_digits_and_first_is_1
+    skip
+    number = PhoneNumber.new("19876543210").number
+    assert_equal "9876543210", number
+  end
+
+  def test_invalid_when_11_digits
+    skip
+    number = PhoneNumber.new("21234567890").number
     assert_equal "0000000000", number
   end
 
@@ -51,10 +61,16 @@ class PhoneNumberTest < MiniTest::Unit::TestCase
     assert_equal "123", number.area_code
   end
 
+  def test_different_area_code
+    skip
+    number = PhoneNumber.new("9876543210")
+    assert_equal "987", number.area_code
+  end
+
   def test_pretty_print
     skip
-    number = PhoneNumber.new("1234567890")
-    assert_equal "(123) 456-7890", number.to_s
+    number = PhoneNumber.new("5551234567")
+    assert_equal "(555) 123-4567", number.to_s
   end
 
   def test_pretty_print_with_full_us_phone_number
@@ -62,5 +78,4 @@ class PhoneNumberTest < MiniTest::Unit::TestCase
     number = PhoneNumber.new("11234567890")
     assert_equal "(123) 456-7890", number.to_s
   end
-
 end


### PR DESCRIPTION
For the Ruby phone number assignment, I can make the entire test suite pass without implementing most of the functionality. Note the hardcoded return values for number, area_code, and to_s. 

``` ruby
class PhoneNumber
  attr_reader :phone_number_input

  def initialize(phone_number_input)
    @phone_number_input = sanitize(phone_number_input)
  end

  def number
    if invalid_number?
      "0000000000"
    else
      "1234567890"
    end
  end

  def area_code
    "123"
  end

  def to_s
    "(123) 456-7890"
  end

  private

  def sanitize(input)
    input.gsub(/\D/,"")
  end

  def invalid_number?
    phone_number_input.length < 10 ||
    phone_number_input.length > 11 ||
      (phone_number_input.length == 11 && phone_number_input[0] == "2")
  end
end
```

I've made some changes to the test suite that will force the developer to return input other than "1234567890", "123", or "(123) 456-7890". I've also changed the order slightly to allow developers to make some smaller incremental changes to implement the algorithm.
