### PR TITLE
Add "unsubmit" instructions

### DIFF
--- a/lib/app/views/help/cli.erb
+++ b/lib/app/views/help/cli.erb
@@ -63,6 +63,19 @@ You can work on them using your usual editor, tools, and environment.
 
 <p>You will be given a link to the submission. This is where you'll get feedback.</p>
 
+<h2>Unsubmitting the Code</h2>
+
+<p>Remove a recent submission with the following command:</p>
+
+<pre>
+  $ exercism unsubmit path/to/file.rb
+</pre> 
+
+<p>The following restrictions apply to the code you want to unsubmit:</p>
+<p> 1. Maximum time since original submission: 5 minutes. </p>
+<p> 2. There must be no comments by other people on the code. </p>
+<p> 3. The assignment must not be listed as completed. </p>
+
 <h2>Getting through your Firewall...</h2>
 
 <p>If you live behind a firewall, you can configure exercism to go through your proxy, like so:</p>


### PR DESCRIPTION
I have frequently submitted exercise code unintentionally. The addition of "unsubmit" to the CLI is welcome but not obvious. I think it would be helpful to add instructions for "unsubmit" to the CLI help.
