### PR TITLE
"octal" strings containing invalid characters should evaluate to 0.

### DIFF
--- a/assignments/ruby/octal/example.rb
+++ b/assignments/ruby/octal/example.rb
@@ -4,14 +4,19 @@ class Octal
 
   attr_reader :digits
   def initialize(decimal)
-    @digits = decimal.reverse.chars.collect(&:to_i)
+    @digits = decimal.reverse.chars
   end
 
   def to_decimal
     decimal = 0
     digits.each_with_index do |digit, index|
-      decimal += digit * BASE**index
+      return 0 unless valid_chars.include? digit
+      decimal += digit.to_i * BASE**index
     end
     decimal
+  end
+
+  def valid_chars
+    [*('0'..(BASE-1).to_s)]
   end
 end

--- a/assignments/ruby/octal/octal_test.rb
+++ b/assignments/ruby/octal/octal_test.rb
@@ -45,4 +45,29 @@ class OctalTest < MiniTest::Unit::TestCase
     skip
     assert_equal 0, Octal.new("carrot").to_decimal
   end
+
+  def test_8_is_seen_as_invalid_and_returns_0
+    skip
+    assert_equal 0, Octal.new("8").to_decimal
+  end
+
+  def test_9_is_seen_as_invalid_and_returns_0
+    skip
+    assert_equal 0, Octal.new("9").to_decimal
+  end
+
+  def test_6789_is_seen_as_invalid_and_returns_0
+    skip
+    assert_equal 0, Octal.new("6789").to_decimal
+  end
+
+  def test_abc1z_is_seen_as_invalid_and_returns_0
+    skip
+    assert_equal 0, Octal.new("abc1z").to_decimal
+  end
+
+  def test_valid_octal_formatted_string_011_is_decimal_9
+    skip
+    assert_equal 9, Octal.new("011").to_decimal
+  end
 end


### PR DESCRIPTION
Have added tests to assert that"8", "9", "6789" & "abc1z" should each evaluate to 0. Also added tests that a leading 0 in the octal string is considered valid.

The octal class code has been changed to pass the additional tests.
