### PR TITLE
Actually test sorting in Elixir grade-school

### DIFF
--- a/assignments/elixir/grade-school/grade-school_test.exs
+++ b/assignments/elixir/grade-school/grade-school_test.exs
@@ -45,9 +45,9 @@ defmodule SchoolTest do
 
   test "sort school" do
     actual = db
+      |> School.add("Christopher", 4)
       |> School.add("Jennifer", 4)
       |> School.add("Kareem", 6)
-      |> School.add("Christopher", 4)
       |> School.add("Kyle", 3)
       |> School.sort
 


### PR DESCRIPTION
@gvauhn found that simply returning the db in the sorting test works as well.
This fixes that loophole.
