### PR TITLE
Use underscore to require file in elixir/word-count

### DIFF
--- a/assignments/elixir/word-count/word_count_test.exs
+++ b/assignments/elixir/word-count/word_count_test.exs
@@ -1,4 +1,4 @@
-Code.load_file("word-count.exs")
+Code.load_file("word_count.exs")
 ExUnit.start
 
 defmodule WordsTest do


### PR DESCRIPTION
Just started exercism today and I love it so far! I ran into this little issue, but the fix is simple.
