### PR TITLE
Add additional tests to pig-latin that initial "xr" is treated as a vowel sound as is...

### DIFF
--- a/assignments/ruby/pig-latin/example.rb
+++ b/assignments/ruby/pig-latin/example.rb
@@ -1,14 +1,28 @@
 class PigLatin
-
   def self.translate(phrase)
-    phrase.split(" ").map do |word|
-      head, tail = word.scan(/\A([^aeiou]?qu|[^aeiou]*)(.*)/).first
-      tail + head + suffix
-    end.join " "
+    phrase.split(' ').map do |word|
+      PigLatin.new(word).translate
+    end.join(' ')
   end
 
-  def self.suffix
-    "ay"
+  def initialize(word)
+    @word = word.downcase.gsub(/[^a-z]/,'')
   end
 
+  def translate
+    return (word + "ay") if it_starts_with_vowel_sound?
+    start, remainder = parse_initial_consonant_sound_and_remainder
+    remainder + start + "ay"
+  end
+
+private
+  attr_reader :word
+
+  def it_starts_with_vowel_sound?
+    word.match /\A([aeiou]|y[^aeiou]|xr)/
+  end
+
+  def parse_initial_consonant_sound_and_remainder
+    word.scan(/\A([^aeiou]?qu|[^aeiou]+)(.*)/).first
+  end
 end

--- a/assignments/ruby/pig-latin/pig_latin_test.rb
+++ b/assignments/ruby/pig-latin/pig_latin_test.rb
@@ -57,4 +57,23 @@ class PigLatinTest < MiniTest::Unit::TestCase
     assert_equal "ickquay astfay unray", PigLatin.translate("quick fast run")
   end
 
+  def test_word_beginning_with_ye
+    skip
+    assert_equal "ellowyay", PigLatin.translate("yellow")
+  end
+
+  def test_word_beginning_with_yt
+    skip
+    assert_equal "yttriaay", PigLatin.translate("yttria")
+  end
+
+  def test_word_beginning_with_xe
+    skip
+    assert_equal "enonxay", PigLatin.translate("xenon")
+  end
+
+  def test_word_beginning_with_xr
+    skip
+    assert_equal "xrayay", PigLatin.translate("xray")
+  end
 end


### PR DESCRIPTION
... initial "y<consonant>".  tests were also added to assure that adding handling of these special cases does not break appropriate handling of other initial "x" and initial "y" cases.

An example exercise solution that passes these new tests is substituted for the original example code.
