### PR TITLE
teams: Plug-in names to the UI

### DIFF
--- a/lib/app/views/teams/new.erb
+++ b/lib/app/views/teams/new.erb
@@ -5,6 +5,8 @@
   <% end %>
   <label for="team_slug">Slug</label>
   <input type="text" name="team[slug]" id="team_slug" placeholder="e.g. gocowboys" value="<%= team.slug %>">
+  <label for="team_name">Name (optional; defaults to slug)</label>
+  <input type="text" name="team[name]" id="team_name" placeholder="e.g. Go Cowboys" value="<%= team.name %>">
   <label for="team_usernames">Usernames (comma-separated list)</label>
   <textarea name="team[usernames]" id="team_usernames" placeholder="e.g. kytrinyx, seeflanigan, rubysolo, theotherzach"><%= team.usernames.join(", ") %></textarea>
   <button type="submit" class="btn btn-primary">Save</button>

--- a/lib/app/views/teams/show.erb
+++ b/lib/app/views/teams/show.erb
@@ -1,5 +1,5 @@
 <h1>
-  Team <%= team.slug %>
+  Team <%= team.name %>
 </h1>
 
 <% if current_user == team.creator %>

--- a/lib/exercism/team.rb
+++ b/lib/exercism/team.rb
@@ -16,6 +16,7 @@ class Team < ActiveRecord::Base
 
   def defined_with(options)
     self.slug = options[:slug]
+    self.name = options[:name] || options[:slug]
     self.members = User.find_in_usernames(options[:usernames].to_s.scan(/\w+/))
     self
   end

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -49,6 +49,20 @@ class TeamsTest < Minitest::Test
     assert_equal expected_status, last_response.status
   end
 
+  def test_team_creation_without_name_uses_slug
+    post '/teams', {team: {slug: 'no_members', usernames: ""}}, login(alice)
+    team = Team.first
+
+    assert_equal 'no_members', team.name
+  end
+
+  def test_team_creation_with_name
+    post '/teams', {team: {name: 'No Members', slug: 'no_members', usernames: ""}}, login(alice)
+    team = Team.first
+
+    assert_equal 'No Members', team.name
+  end
+
   def test_team_creation_with_no_members
     assert_equal 0, alice.teams_created.size
 


### PR DESCRIPTION
- Update the views to display team.name instead of team.slug.
- Add UI field to support defining name at team creation time.
- Update model to take name from provided options, defaulting to
  slug if not provided.
## Fixes #1012.

I didn't yet test this with an actual running server so I wouldn't merge this without actually testing it live :-)

How have people been running test servers where you have to login? Do you have to run it on Heroku or something so that it can have an actual oauth callback?
