### PR TITLE
Clickable url on comment email

### DIFF
--- a/lib/services/email/comment.erb
+++ b/lib/services/email/comment.erb
@@ -4,9 +4,9 @@ Your submission on <%= exercise.name %> in <%= exercise.language %> has received
 
 <%= nitpick %>
 
-Visit <%= site_root %>/submissions/<%= submission.key %> to find out more.
+Visit http://<%= site_root %>/submissions/<%= submission.key %> to find out more.
 
 --
-If you'd like to stop receiving email notifications, go to http://exercism.io/<%= submission.user.username %> and delete your email address.
+If you'd like to stop receiving email notifications, go to http://<%= site_root %>/<%= submission.user.username %> and delete your email address.
 
 Do you have thoughts? Ideas? Criticism? I'd love to hear from you. Hit reply to send me an email.


### PR DESCRIPTION
Having a valid url makes some email clients to create a linkable url each is useful (at least for me).

Also changed the profile url to use `site_root`
