### PR TITLE
JavaScript test runner

### DIFF
--- a/assignments/javascript/.gitignore
+++ b/assignments/javascript/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/assignments/javascript/Makefile
+++ b/assignments/javascript/Makefile
@@ -1,0 +1,24 @@
+# language specific config (you can tweak per language)
+ASSIGNMENT ?= ""
+FILEEXT := "js"
+PATTERN := "$(ASSIGNMENT)_test.spec.$(FILEEXT)"
+
+# output directory
+TMPDIR ?= "/tmp"
+OUTDIR := $(shell mktemp -d "$(TMPDIR)/$(ASSIGNMENT).XXXXXXXXXX")
+
+# assignments
+ASSIGNMENTS = $(shell find . -type d -maxdepth 1 -mindepth 1 | xargs basename)
+
+test: node_modules
+	@echo "running tests for: $(ASSIGNMENT)"
+	@cp $(ASSIGNMENT)/$(PATTERN) $(OUTDIR)
+	@cp $(ASSIGNMENT)/example.js $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
+	@./node_modules/.bin/jasmine-node $(OUTDIR)/$(PATTERN)
+
+testall:
+	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) test || exit 1; done
+
+node_modules: package.json
+	@npm prune
+	@npm install

--- a/assignments/javascript/package.json
+++ b/assignments/javascript/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "javascript",
+  "version": "0.0.0",
+  "description": "JavaScript assignments",
+  "private": true,
+  "scripts": {
+    "test": "make test"
+  },
+  "engines": {
+    "node": "~>0.10.5"
+  },
+  "devDependencies": {
+    "jasmine-node": "~1.11.0"
+  }
+}


### PR DESCRIPTION
## Summary

Provides a `Makefile` for running JavaScript tests either individually (per assignment) or as a full suite (all assignments) for CI.
## API

Run all tests:

```
% cd assignments/javascript
% make testall
```

Run a specific test

```
% cd assignments/javascript
% make test ASSIGNMENT=allergies
```
## CI

I have not hooked this up to the `.travis.yml` file since some tests fail with `make testall` given some assignments do not follow a consistent directory/file naming convention. I will address that separately.
