### PR TITLE
testall => test && test => test-assignment

### DIFF
--- a/assignments/javascript/Makefile
+++ b/assignments/javascript/Makefile
@@ -10,15 +10,16 @@ OUTDIR := $(shell mktemp -d "$(TMPDIR)/$(ASSIGNMENT).XXXXXXXXXX")
 # assignments
 ASSIGNMENTS = $(shell find . -type d -maxdepth 1 -mindepth 1 | xargs basename)
 
-test: node_modules
+test-assignment: node_modules
 	@echo "running tests for: $(ASSIGNMENT)"
 	@cp $(ASSIGNMENT)/$(PATTERN) $(OUTDIR)
 	@cp $(ASSIGNMENT)/example.js $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
 	@./node_modules/.bin/jasmine-node $(OUTDIR)/$(PATTERN)
 
-testall:
-	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) test || exit 1; done
+test:
+	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) test-assignment || exit 1; done
 
 node_modules: package.json
 	@npm prune
 	@npm install
+


### PR DESCRIPTION
For better semantics, changes JS test runner such that running `make test` runs all tests while `test-assignment` is used to test a specific assignment.
