### PR TITLE
Make submissions show as work for locksmiths

### DIFF
--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -85,6 +85,15 @@ class User < ActiveRecord::Base
     (completed.keys + current.keys).include?(language) || locksmith_in?(language)
   end
 
+  def nitpickables
+    mastered_slugs = self.mastery.map do |language|
+      [language, Exercism.current_curriculum.trails[language.to_sym].slugs]
+    end
+    return Hash[mastered_slugs].merge(self.completed) do |key, a, b|
+      (a + b).uniq
+    end
+  end
+
   def current_exercises
     current.to_a.map {|cur| Exercise.new(*cur)}
   end

--- a/lib/exercism/work.rb
+++ b/lib/exercism/work.rb
@@ -14,7 +14,7 @@ class Work
   private
 
   def shuffled
-    user.completed.to_a.shuffle.flat_map do |(language, slugs)|
+    user.nitpickables.to_a.shuffle.flat_map do |(language, slugs)|
       slugs = rand < 0.7 ? slugs.reverse : slugs.shuffle
       slugs.map { |slug| [language, slug] }
     end

--- a/test/exercism/work_test.rb
+++ b/test/exercism/work_test.rb
@@ -22,6 +22,14 @@ class WorkTest < Minitest::Test
     assert_equal submission, Work.new(alice).random
   end
 
+  def test_work_where_alice_is_locksmith
+    alice = User.create(username: 'alice', mastery: ['ruby'])
+    bob = User.create(username: 'bob')
+    submission = Submission.create(user: bob, language: 'ruby', slug: 'word-count')
+
+    assert_equal submission, Work.new(alice).random
+  end
+
   def test_no_completed_exercises
     user = User.create(completed: {})
     work = Work.new(user)


### PR DESCRIPTION
This fixes #1051.

`Work#shuffled` got the list of eligible work items from `User#completed` which does not take the mastery flags / locksmith system into account.
