### PR TITLE
propose simple valid date test for ruby leap year implementation

### DIFF
--- a/assignments/ruby/leap/example.rb
+++ b/assignments/ruby/leap/example.rb
@@ -1,26 +1,13 @@
+require 'date'
+
 class Year
 
-  attr_reader :number
-  def initialize(number)
-    @number = number
-  end
-
-  def leap?
-    (vanilla? && !century?) || exceptional_century?
-  end
-
-  private
-
-  def vanilla?
-    (number % 4) == 0
-  end
-
-  def century?
-    (number % 100) == 0
-  end
-
-  def exceptional_century?
-    (number % 400) == 0
+  def self.leap?(year)
+    begin
+      Date.new(year, 2, 29) and true
+    rescue
+      false
+    end
   end
 
 end

--- a/assignments/ruby/leap/leap_test.rb
+++ b/assignments/ruby/leap/leap_test.rb
@@ -3,22 +3,22 @@ require_relative 'year'
 
 class YearTest < MiniTest::Unit::TestCase
   def test_vanilla_leap_year
-    assert Year.new(1996).leap?
+    assert Year.leap? 1996
   end
 
   def test_any_old_year
     skip
-    refute Year.new(1997).leap?
+    refute Year.leap? 1997
   end
 
   def test_century
     skip
-    refute Year.new(1900).leap?
+    refute Year.leap? 1900
   end
 
   def test_exceptional_century
     skip
-    assert Year.new(2400).leap?
+    assert Year.leap? 2400
   end
 
 end


### PR DESCRIPTION
I realize that our spider senses tell us to turn up our "code smell" sensitivities when we see `begin..rescue`; however, since ruby does not have another way to say (unless I've missed it), "hey, is this set of numbers a valid date", I've opted for `begin..rescue` for concisness. My rationale is that I'll sacrifice whatever performance penalty (whether real or pedantic) for readability unless it becomes an issue.
