### PR TITLE
fix find warnings and use tr instead of basename

### DIFF
--- a/assignments/javascript/Makefile
+++ b/assignments/javascript/Makefile
@@ -8,14 +8,13 @@ TMPDIR ?= "/tmp"
 OUTDIR := $(shell mktemp -d "$(TMPDIR)/$(ASSIGNMENT).XXXXXXXXXX")
 
 # assignments
-ASSIGNMENTS = $(shell find . -type d -maxdepth 1 -mindepth 1 | xargs basename | grep -v 'node_modules')
+ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | tr -d './' | grep -v 'node_modules')
 
 test-assignment: node_modules
 	@echo "running tests for: $(ASSIGNMENT)"
 	@cp $(ASSIGNMENT)/$(PATTERN) $(OUTDIR)
 	@cp $(ASSIGNMENT)/example.js $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
 	@./node_modules/.bin/jasmine-node --captureExceptions $(OUTDIR)/$(PATTERN)
-
 
 test:
 	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) test-assignment || exit 1; done


### PR DESCRIPTION
Attempt to mitigate the following CI warnings:

```
find: warning: you have specified the -maxdepth option after a non-option argument -type, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.
find: warning: you have specified the -mindepth option after a non-option argument -type, but options are not positional (-mindepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.
basename: extra operand `./point-mutations'
```

They don't seem to cause a build failure; however, they are annoying.
