### PR TITLE
sort ASSIGNMENTS list so tests run in alpha order

### DIFF
--- a/assignments/javascript/Makefile
+++ b/assignments/javascript/Makefile
@@ -8,7 +8,7 @@ TMPDIR ?= "/tmp"
 OUTDIR := $(shell mktemp -d "$(TMPDIR)/$(ASSIGNMENT).XXXXXXXXXX")
 
 # assignments
-ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | tr -d './' | grep -v 'node_modules')
+ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | tr -d './' | grep -v 'node_modules' | sort)
 
 test-assignment: node_modules
 	@echo "running tests for: $(ASSIGNMENT)"
@@ -17,7 +17,7 @@ test-assignment: node_modules
 	@./node_modules/.bin/jasmine-node --captureExceptions $(OUTDIR)/$(PATTERN)
 
 test:
-	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) test-assignment || exit 1; done
+	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
 
 node_modules: package.json
 	@npm prune


### PR DESCRIPTION
- sort ASSIGNMENTS list so tests run in alpha order
- force make to quietly change directories (for CI output)
