### PR TITLE
Point out that reduce is fine in Elixir accumulate

### DIFF
--- a/assignments/shared/accumulate.md
+++ b/assignments/shared/accumulate.md
@@ -15,3 +15,6 @@ Your code should be able to produce the collection of squares:
 Keep your hands off that collect/map/fmap/whatchamacallit functionality
 provided by your standard library!
 Solve this one yourself using other basic tools instead.
+
+Elixir specific: it's perfectly fine to use `Enum.reduce` or
+`Enumerable.reduce`.


### PR DESCRIPTION
The readme seemed to imply otherwise.

The root of this problem is of course that the Elixir version of the exercise is more complicated than the one in other languages because it should also work on ranges.
