### PR TITLE
Allow team owner to destroy their team

### DIFF
--- a/frontend/app/js/app.coffee
+++ b/frontend/app/js/app.coffee
@@ -8,6 +8,12 @@ $ ->
     if confirm("Are you sure you want to dismiss #{username}")
       dismissTeamMember(username, slug)
 
+  $('#destroy_team').on 'click', ->
+    slug = $(@).data('team')
+
+    if confirm("Are you sure you want to delete " + slug + "?")
+      destroyTeam(slug);
+
   $('#edit_team').on 'click', (event) ->
     event.preventDefault()
     toggleTeamEdit()
@@ -24,6 +30,15 @@ toggleTeamEdit = ->
     members_box.slideUp ->
       delete_buttons.addClass('hidden')
       members_box.addClass('hidden')
+
+destroyTeam = (slug) ->
+  href = "/teams/" + slug
+  form = $('<form method="post" action="' + href + '"></form>')
+  method_input = '<input name="_method" value="delete" type="hidden"/>'
+
+  form.hide().append(method_input).appendTo('body')
+  form.submit()
+
 
 dismissTeamMember = (username, slug) ->
   href = "/teams/#{slug}/members/#{username}"

--- a/lib/app/teams.rb
+++ b/lib/app/teams.rb
@@ -37,6 +37,26 @@ class ExercismApp < Sinatra::Base
     end
   end
 
+  delete '/teams/:slug' do |slug|
+    please_login
+
+    team = Team.where(slug: slug).first
+
+    if team
+      unless team.creator == current_user
+        flash[:error] = "You are not allowed to delete the team."
+        redirect '/'
+      end
+
+      team.delete
+
+      redirect '/account'
+    else
+      flash[:error] = "We don't know anything about team '#{slug}'"
+      redirect '/'
+    end
+  end
+
   post '/teams/:slug/members' do |slug|
     please_login
 

--- a/lib/app/views/teams/show.erb
+++ b/lib/app/views/teams/show.erb
@@ -4,6 +4,7 @@
 
 <% if current_user == team.creator %>
   <a href="#" id="edit_team" class="btn btn-small">Edit</a>
+  <a href="#" id="destroy_team" class="btn btn-small btn-danger" data-team=<%= team.slug %>>Destroy</a>
 
   <div class="hidden" id="add_members">
     <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}/members" %>" method="POST">

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -172,4 +172,25 @@ class TeamsTest < Minitest::Test
 
     assert_response_status(302)
   end
+
+  def test_delete_team_without_being_creator
+    team = Team.by(alice).defined_with({slug: 'delete', usernames: "#{bob.username}"})
+    team.save
+
+    delete "/teams/#{team.slug}", {}, login(bob)
+
+    assert_response_status(302)
+    assert Team.exists?(slug: 'delete')
+  end
+
+  def test_delete_team_as_creator
+    team = Team.by(alice).defined_with({slug: 'delete', usernames: "#{bob.username}"})
+    team.save
+
+    delete "/teams/#{team.slug}", {}, login(alice)
+
+    assert_response_status(302)
+    refute Team.exists?(slug: 'delete')
+  end
+
 end


### PR DESCRIPTION
This takes care of #1011

I figured to make it very simple for now and later on add a better check like typing in the team's slug to confirm the delete. 
