### PR TITLE
Adding unique index on team slug.

### DIFF
--- a/lib/db/migrate/12_add_unique_index_on_team_slug.rb
+++ b/lib/db/migrate/12_add_unique_index_on_team_slug.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexOnTeamSlug < ActiveRecord::Migration
+  def change
+    add_index :teams, :slug, unique: true
+  end
+end


### PR DESCRIPTION
A validation at the model level might not be enough to prevent duplicate records in the db. Adding unique index fixes this case.

@jdiago pointed this out for me. I'm committing it for him.

This possibly fixes #1150
