### PR TITLE
Refactor display of current/completed exercises

### DIFF
--- a/frontend/app/css/account.css
+++ b/frontend/app/css/account.css
@@ -1,0 +1,11 @@
+.completed-exercise {
+  line-height: 1.6em;
+
+}
+
+.completed-exercise a:after {
+  content: ", ";
+}
+.completed-exercise:last-child a:after {
+  content: ".";
+}

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -4,6 +4,7 @@ require 'will_paginate'
 require 'will_paginate/active_record'
 
 require 'app/presenters/workload'
+require 'app/presenters/profile'
 
 require 'app/auth'
 require 'app/client'
@@ -21,7 +22,6 @@ require 'app/exercises'
 require 'app/not_found'
 
 require 'app/helpers/fuzzy_time_helper'
-require 'app/helpers/github_link_helper'
 require 'app/helpers/gravatar_helper'
 require 'app/helpers/profile_helper'
 require 'app/helpers/site_title_helper'
@@ -45,7 +45,6 @@ class ExercismApp < Sinatra::Base
   helpers Sinatra::SiteTitleHelper
   helpers Sinatra::FuzzyTimeHelper
   helpers Sinatra::GravatarHelper
-  helpers Sinatra::GithubLinkHelper
   helpers Sinatra::ProfileHelper
   helpers Sinatra::MarkdownHelper
 

--- a/lib/app/helpers/github_link_helper.rb
+++ b/lib/app/helpers/github_link_helper.rb
@@ -1,8 +1,4 @@
 module Sinatra
   module GithubLinkHelper
-    def github_profile_link(user, link_text = nil)
-      link_text = user.username if link_text.nil?
-      '<a target="_blank" href="https://github.com/%s">%s</a>' % [user.username, link_text]
-    end
   end
 end

--- a/lib/app/presenters/profile.rb
+++ b/lib/app/presenters/profile.rb
@@ -1,0 +1,78 @@
+class Profile
+
+  def initialize(user, current_user=user)
+    @user = user
+    @current_user = current_user
+  end
+
+  def username
+    user.username
+  end
+
+  def has_current_submissions?
+    current.any?
+  end
+
+  def has_completed_submissions?
+    user.completed_exercises.any?
+  end
+
+  def teams
+    user.teams | user.teams_created
+  end
+
+  def has_teams?
+    teams.any?
+  end
+
+  def has_nitpicked?
+    user.comments.any?
+  end
+
+  def nitpicks
+    user.comments
+  end
+
+  def current
+    user.active_submissions
+  end
+
+  def completed_in(language)
+    user.completed_submissions_in(language)
+  end
+
+  def languages
+    user.worked_in_languages
+  end
+
+  def github_link
+    %{<a target="_blank" href="https://github.com/#{user.username}">#{user.username}</a>}
+  end
+
+  def submission_link(submission)
+   %{<a href="/submissions/#{submission.key}">#{submission.name}</a>}
+  end
+
+  def no_current_sumbissions_message
+    if narcissistic?
+      "You have not submitted any exercises lately."
+    else
+      "#{username} has not submitted any exercises lately."
+    end
+  end
+
+  def no_completed_sumbissions_message
+    if narcissistic?
+      "You have not completed any exercises yet."
+    else
+      "#{username} has not completed any exercises yet."
+    end
+  end
+
+  def narcissistic?
+    current_user.is?(user.username)
+  end
+
+  attr_reader :user, :current_user
+
+end

--- a/lib/app/users.rb
+++ b/lib/app/users.rb
@@ -4,7 +4,7 @@ class ExercismApp < Sinatra::Base
     please_login
 
     title('account')
-    erb :account
+    erb :account, locals: { profile: Profile.new(current_user) }
   end
 
   get '/:username' do |username|
@@ -13,7 +13,7 @@ class ExercismApp < Sinatra::Base
 
     if user
       title(user.username)
-      erb :user, locals: {user: user, current: user.current_exercises, completed: user.completed_exercises}
+      erb :user, locals: { profile: Profile.new(user, current_user) }
     else
       status 404
       erb :not_found

--- a/lib/app/views/account.erb
+++ b/lib/app/views/account.erb
@@ -1,46 +1,55 @@
+<h1>Account</h1>
 <div class="row">
   <div class="span8">
-    <h1>Account</h1>
 
     <h2>Teams</h2>
-    <% if (current_user.teams | current_user.teams_created).any? %>
+    <% if profile.has_teams? %>
       <ul>
-        <% (current_user.teams | current_user.teams_created).each do |team| %>
+        <% profile.teams.each do |team| %>
           <li><a href="/teams/<%= team.slug %>"><%= team.slug %></a></li>
         <% end %>
       </ul>
     <% end %>
     <p>Create a <a href="/teams">new team</a>.</p>
 
-    <% if current_user.comments.any? %>
-      <p>You've left <a href="/user/history"><%= current_user.comments.count %> nits</a>.</p>
+    <% if profile.has_nitpicked? %>
+      <p>You've left <a href="/user/history"><%= profile.nitpicks.count %> nits</a>.</p>
     <% end %>
 
     <h2>Exercises</h2>
-
     <h3>Current</h3>
-    <% if current_user.active_submissions.none? %>
-      <p>You have not submitted any exercises lately.</p>
+    <% if profile.has_current_submissions? %>
+      <table class="table table-bordered table-striped">
+        <thead>
+          <tr>
+            <th>Exercise</th>
+            <th>Language</th>
+            <th>Iteration</th>
+            <th>Nits</th>
+          </tr>
+        </thead>
+        <tbody>
+        <% profile.current.each do |submission| %>
+          <tr>
+            <td><%= profile.submission_link(submission) %></td>
+            <td><%= submission.language.titleize %></td>
+            <td><%= submission.version %></td>
+            <td><%= submission.nit_count %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p><%= profile.no_current_sumbissions_message %></p>
     <% end %>
-
-    <ul>
-      <% current_user.active_submissions.each do |submission| %>
-        <li>
-          <a href="<%= ['', 'submissions', submission.key].join('/') %>"><%= submission.language.titleize %>: <%= submission.name %></a>
-        </li>
-      <% end %>
-    </ul>
   </div>
-
   <div class="span4">
     <dl>
       <dt>Api key:</dt>
       <dd><%= current_user.key %></dd>
     </dl>
-
     <p>You can update your <%= gravatar_tag current_user.avatar_url %> Gravatar on
       <a href="http://www.gravatar.com/">the Gravatar website.</a></p>
-
     <p>
       The following email address will be used to send you notifications. If you do not want notifications, delete your email address and click update.
       <form action="/account/email" method="post">
@@ -56,27 +65,34 @@
 
 <div class="row">
   <div class="span12">
-  <h3>Completed</h3>
-  <% if current_user.submissions.done.count.zero? %>
-    <p>You have not completed any exercises.</p>
-  <% else %>
+    <h3>Completed</h3>
+    <% if profile.has_completed_submissions? %>
+      <table class="table table-bordered table-striped">
+        <col />
+        <col width="100%" />
+        <thead>
+          <tr>
+            <th>Language</th>
+            <th>Exercises</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% profile.languages.each do |language| %>
+            <tr>
+              <td><%= language.titleize %></td>
+              <td>
+                <% profile.completed_in(language).each do |submission| %>
+                  <span class="completed-exercise">
+                    <%= profile.submission_link(submission) %>
+                  </span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p><%= profile.no_completed_sumbissions_message %></p>
+    <% end %>
   </div>
 </div>
-
-<div class="row">
-  <% current_user.worked_in_languages.each do |language| %>
-  <div class="span2">
-    <h5><%= language.titleize %></h5>
-    <ul>
-      <% current_user.completed_submissions_in(language).each do |submission| %>
-      <li>
-      <a href="<%= ['', 'submissions', submission.related_submissions.last.key].join('/') %>"><%= submission.name %></a>
-      <br>
-      <a href="<%= ['', 'completed', submission.language, submission.slug, 'random'].join('/') %>">gallery &raquo;</a>
-      </li>
-      <% end %>
-    </ul>
-  </div>
-  <% end %>
-</div>
-<% end %>

--- a/lib/app/views/submission.erb
+++ b/lib/app/views/submission.erb
@@ -17,6 +17,9 @@
       Iteration <b><%= submission.version %></b> of <b><%= submission.versions_count %></b>.
       <% if submission.user.completed?(submission.exercise) %>
         This exercise has been completed.
+        <% if submission.user.is?(current_user.username) %>
+          See <a href="<%= ['', 'completed', submission.language, submission.slug, 'random'].join('/') %>">someone else's solution</a> to this exercise.
+        <% end %>
       <% else %>
         This exercise is still in progress.
       <% end %>

--- a/lib/app/views/user.erb
+++ b/lib/app/views/user.erb
@@ -1,56 +1,69 @@
 <div class="row">
   <div class="span8">
-    <h1><%= user.username %></h1>
-    <p>GitHub Profile: <%= github_profile_link(user) %></p>
+
+    <h1><%= profile.username %></h1>
+    <p>GitHub Profile: <%= profile.github_link %></p>
 
     <h3>Exercises</h3>
 
     <h4>Current</h4>
-    <% if current.none? %>
-      <p><%= user.username %> has not submitted any exercises lately.</p>
+    <% if profile.has_current_submissions? %>
+      <table class="table table-bordered table-striped">
+        <thead>
+          <tr>
+            <th>Exercise</th>
+            <th>Language</th>
+            <th>Iteration</th>
+            <th>Nits</th>
+          </tr>
+        </thead>
+        <tbody>
+        <% profile.current.each do |submission| %>
+          <tr>
+            <td><%= profile.submission_link(submission) %></td>
+            <td><%= submission.language.titleize %></td>
+            <td><%= submission.version %></td>
+            <td><%= submission.nit_count %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
     <% else %>
+      <p><%= profile.no_current_sumbissions_message %></p>
     <% end %>
-
-    <ul>
-      <% current.each do |exercise| %>
-        <li>
-          <% if current_user.is?(user.username) || current_user.nitpicker_on?(exercise) %>
-            <a href="<%= ['', 'submissions', user.latest_submission_on(exercise).key].join('/') %>"><%= exercise.language.titleize %>: <%= exercise.name %></a>
-          <% else %>
-            <%= exercise.language.titleize %>: <%= exercise.name %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
   </div>
 </div>
 
 <div class="row">
   <div class="span12">
     <h4>Completed</h4>
-    <% if completed.none? %>
-    <p><%= user.username %> has not completed any exercises.</p>
+    <% if profile.has_completed_submissions? %>
+      <table class="table table-bordered table-striped">
+        <col />
+        <col width="100%" />
+        <thead>
+          <tr>
+            <th>Language</th>
+            <th>Exercises</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% profile.languages.each do |language| %>
+            <tr>
+              <td><%= language.titleize %></td>
+              <td>
+                <% profile.completed_in(language).each do |submission| %>
+                  <span class="completed-exercise">
+                    <%= profile.submission_link(submission) %>
+                  </span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p><%= profile.no_completed_sumbissions_message %></p>
     <% end %>
   </div>
-</div>
-
-<div class="row">
-  <% completed.each do |language, exercises| %>
-  <div class="span2">
-    <h5><%= language.titleize %></h5>
-    <ul>
-      <% exercises.each do |exercise| %>
-      <li>
-      <% if current_user.is?(user.username) || current_user.nitpicker_on?(exercise) %>
-      <a href="<%= ['', 'submissions', user.latest_submission_on(exercise).key].join('/') %>"><%= exercise.name %></a>
-      <br>
-      <a href="<%= ['', 'completed', exercise.language, exercise.slug, 'random'].join('/') %>">gallery &raquo;</a>
-      <% else %>
-      <%= exercise.name %>
-      <% end %>
-      </li>
-      <% end %>
-    </ul>
-  </div>
-  <% end %>
 </div>

--- a/test/app/presenters/profile_test.rb
+++ b/test/app/presenters/profile_test.rb
@@ -1,0 +1,46 @@
+require './test/test_helper'
+require 'app/presenters/profile.rb'
+require 'mocha'
+
+class ProfileTest < Minitest::Test
+
+  def setup
+    super
+    user1.stubs(:is?).with(user1.username).returns(true)
+    user1.stubs(:is?).with(user2.username).returns(false)
+    user2.stubs(:is?).with(user2.username).returns(true)
+    user2.stubs(:is?).with(user1.username).returns(false)
+  end
+
+  def user1
+    @user1 ||= stub(username: 'Lucy')
+  end
+
+  def user2
+    @user2 ||= stub(username: 'Trevor')
+  end
+
+  def profile
+    Profile.new(user1, user2)
+  end
+
+  def narcissistic_profile
+    Profile.new(user1)
+  end
+
+  def test_no_current_submissions_message
+    assert_equal "Lucy has not submitted any exercises lately.", profile.no_current_sumbissions_message
+  end
+
+  def test_narcissistic_no_current_submissions_message
+    assert_equal "You have not submitted any exercises lately.", narcissistic_profile.no_current_sumbissions_message
+  end
+
+  def test_no_completed_submissions_message
+    assert_equal "Lucy has not completed any exercises yet.", profile.no_completed_sumbissions_message
+  end
+
+  def test_narcissistic_no_completed_submissions_message
+    assert_equal "You have not completed any exercises yet.", narcissistic_profile.no_completed_sumbissions_message
+  end
+end


### PR DESCRIPTION
I couldn't work out a way to have the `gallery >>` links next to each submission that worked with any alternative layout I could come up with, so added an alternative route to get to them. When viewing one of your completed exercises, you are now provided with a link to "See someone else's solution to this exercise."  I'm not sure how big a deal this is so let me know if you need an alternative solution!

There's quite a lot of duplication between the user and account pages - perhaps the account page could be limited to the gravatar, api key and email settings, and a link to the user page added to the user's menu under the heading of "profile" or similar?

Anyway, in summary:
- Use tables instead of `ul`'s for display of completed exercises.
- Add "View someone else's solution to this exercise" link to the completed exercise page (to replace gallery links).
- Create "Profile" presenter to clean up view code for account and user pages.

Closes #1151
