### PR TITLE
Corrected name of Angular model - fixes #881

### DIFF
--- a/lib/app/views/small_comment.erb
+++ b/lib/app/views/small_comment.erb
@@ -1,7 +1,7 @@
 <div ng-controller="MarkdownCtrl">
   <tabset>
     <tab heading="Write">
-      <textarea name="body" class="span6 comment small-comment" rows="5" ng-model="data.comment"></textarea>
+      <textarea name="body" class="span6 comment small-comment" rows="5" ng-model="data.body"></textarea>
     </tab>
     <tab heading="Preview" select="preview()">
       <div class="preview" ng-bind-html-unsafe="data.preview">


### PR DESCRIPTION
Comment preview was broken, but only when the small_comments template was used (the comment template was okay). This takes care of it.
