### PR TITLE
Hash assignment using 'students' confusingly, unnecessary ||= in initializer. Grade has || when a default_value has been set in initi.

### DIFF
--- a/assignments/ruby/grade-school/example.rb
+++ b/assignments/ruby/grade-school/example.rb
@@ -9,8 +9,8 @@ class School
     db[grade] << student
   end
 
-  def grade(grade)
-    db[grade]
+  def grade(level)
+    db[level]
   end
 
   def sort


### PR DESCRIPTION
Removed confusing reference to Students in Hash initializer - db used throughout class and students overloaded as used to describe the hashes values. 
Initializer becomes assignment and not ||= since @db will always be nil in the initialize method. 
Removed grade's || [] as the hash has a default value already set i n initialize method.
