### PR TITLE
Submit button text: 'Discuss' -> 'Submit Comment' #metanitpick

### DIFF
--- a/lib/app/views/nitpick/submit_comment.erb
+++ b/lib/app/views/nitpick/submit_comment.erb
@@ -22,7 +22,7 @@
   <form accept-charset="UTF-8" action="/submissions/<%= submission.key %>/nitpick" method="POST">
     <%= erb :comment %>
     <% if current_user.owns?(submission) %>
-      <button type="submit" name="nitpick" class="pull-right btn btn-primary">Discuss</button>
+      <button type="submit" name="nitpick" class="pull-right btn btn-primary">Submit Comment</button>
     <% else %>
       <button type="submit" name="nitpick" class="pull-right btn btn-primary">Nitpick</button>
     <% end %>


### PR DESCRIPTION
I'm not convinced that my suggested replacement phrasing is ideal, but when I first clicked "Discuss" I was worried that I'd missed the Submit button, was being taken away to "discuss" the code (perhaps the discussion from that page but at its own URL or something?), and would have to retype my comment.
