### PR TITLE
Fix closing html tag in help/cli

### DIFF
--- a/lib/app/views/help/cli.erb
+++ b/lib/app/views/help/cli.erb
@@ -61,7 +61,7 @@ gunzip -c path/to/exercism-linux-amd64.tgz | tar -xvf -
   <li>If you are using <code>bash</code>, look for a file named <code>.bash_profile</code> or <code>.bashrc</code>. If you have <code>zsh</code>, you will have a <code>.zshrc</code> file. Notice the dot at the beginning of the file name. This means that it is a <em>hidden file</em> and it won't show up if you just use <code>ls</code>. The flag <code>-a</code> tells <code>ls</code> to include the files whose names begin with a dot that it normally skips over.</li>
   <li>Open the config file using <kbd>open .bash_profile</kbd> (on a Mac), or <kbd>gedit .bash_profile</kbd> (on linux). If neither of those work, try <kbd>nano .bash_profile</kbd>.</li>
   <li>Add <code>export PATH=~/bin:$PATH</code> to the end of the config file, then save and close it.</li>
-  <li>The new configuration will not be active in your current terminal window, so you need to either open a new terminal window, or reload the configuration file into the existing window (known as "sourcing" a file): <kbd>source ~/.bash_profile<code>.</li>
+  <li>The new configuration will not be active in your current terminal window, so you need to either open a new terminal window, or reload the configuration file into the existing window (known as "sourcing" a file): <kbd>source ~/.bash_profile</kbd>.</li>
 </ol>
 
 <p><a href="/help/understanding-path">Read more about <code>PATH</code></a> if this is unfamiliar territory.</p>


### PR DESCRIPTION
This fixes the display errors currently viewable at http://exercism.io/help/how-to-access-exercises.
## Before:

![screen shot 2013-12-17 at 9 00 27 am](https://f.cloud.github.com/assets/170351/1764779/0da37368-672c-11e3-8b93-d86e93f54074.png)
## After:

![screen shot 2013-12-17 at 9 00 47 am](https://f.cloud.github.com/assets/170351/1764782/125281ba-672c-11e3-9060-4d332929fe25.png)
