### PR TITLE
provide a litte more information on failing tests in anagram_test.go

### DIFF
--- a/assignments/go/anagram/anagram_test.go
+++ b/assignments/go/anagram/anagram_test.go
@@ -149,6 +149,8 @@ func TestDetectAnagrams(t *testing.T) {
 			msg := `
 				%s
 
+				Given %v
+				Candidates %v
 				Expected %v
 				Got %v
 				`


### PR DESCRIPTION
I added the subject and candidate strings to the output stanza for failing tests in anagram_test.go. I found it easier to implement the exercise when I had more info on the inputs. But maybe the point of the exercise is to implement it based on the readme or to get students to mess with the test file. If that is the case I have completely missed the point.
