### PR TITLE
Set previous submission to pending after unsubmit

### DIFF
--- a/lib/exercism/use_cases/unsubmit.rb
+++ b/lib/exercism/use_cases/unsubmit.rb
@@ -12,6 +12,16 @@ class Unsubmit
 
   def unsubmit
     submission = @user.most_recent_submission
+    previous_version_num = submission.version - 1
+    previous_submission = Submission.where({ user_id: @user,
+                                             language: submission.language,
+                                             slug: submission.slug,
+                                             version: previous_version_num }).first
+
+    unless previous_submission.nil?
+      previous_submission.state = 'pending'
+      previous_submission.save
+    end
 
     raise NothingToUnsubmit.new  if submission.nil?
     raise SubmissionHasNits.new  if submission.this_version_has_nits?

--- a/test/api/assignments_test.rb
+++ b/test/api/assignments_test.rb
@@ -266,4 +266,15 @@ class AssignmentsApiTest < Minitest::Test
     end
   end
 
+  def test_unsubmit_sets_previous_submission_to_pending_if_exists
+    Exercism.stub(:current_curriculum, curriculum) do
+      Submission.create(user: @alice, code: 'CODE', state: 'superseded', language: 'ruby', slug: 'one', version: 1)
+      Submission.create(user: @alice, code: 'CODE', state: 'pending', language: 'ruby', slug: 'one', version: 2)
+
+      delete '/user/assignments', { key: @alice.key }
+
+      assert_equal 204, last_response.status
+      assert_equal 'pending', Submission.where({ version: 1 }).first.state
+    end
+  end
 end


### PR DESCRIPTION
An attempt at fixing #1181. 

The test doesn't seem right. Is it safe to assume that the first submission is 'superseded'?
