### PR TITLE
Fix test in clojure ETL exercise

### DIFF
--- a/assignments/clojure/etl/etl_test.clj
+++ b/assignments/clojure/etl/etl_test.clj
@@ -22,13 +22,13 @@
            "u"  1 "v"  4 "w" 4 "x" 8 "y" 4
            "z" 10 }
          (etl/transform {
-             1 (clojure.string/split "AEIOULNRST" #"")
-             2 (clojure.string/split "DG" #"")
-             3 (clojure.string/split "BCMP" #"")
-             4 (clojure.string/split "FHVWY" #"")
-             5 (clojure.string/split "K" #"")
-             8 (clojure.string/split "JX" #"")
-            10 (clojure.string/split "QZ" #"")
+             1 (re-seq #"\w" "AEIOULNRST")
+             2 (re-seq #"\w" "DG")
+             3 (re-seq #"\w" "BCMP")
+             4 (re-seq #"\w" "FHVWY")
+             5 (re-seq #"\w" "K")
+             8 (re-seq #"\w" "JX")
+            10 (re-seq #"\w" "QZ")
          }))))
 
 (run-tests)

--- a/assignments/clojure/etl/example.clj
+++ b/assignments/clojure/etl/example.clj
@@ -1,8 +1,8 @@
 (ns etl)
 (require '[clojure.string :refer [lower-case]])
 
-(defn transform [m]
+(defn transform [extract]
   (into {}
-    (apply concat (for [[k vs] m]
-      (for [v vs]
-        [(lower-case v) k])))))
+        (for [[score letters] extract
+              letter          letters]
+          [(lower-case letter) score])))


### PR DESCRIPTION
For some reason perhaps only known to Rich Hickey,

``` clojure
(clojure.string/split "abc" #"") ; => ["" "a" "b" "c"]
```

(i.e. includes an empty string). I don't think this is what we want for the ETL test - and in fact the current example solution does not pass the tests for this reason. I've updated the tests to use `re-seq` instead, which gets us the letters minus the blank space, and I've simplified the example solution a little as it didn't need nested for loops.
