### PR TITLE
Random solution page tweaks

### DIFF
--- a/lib/app/views/code/random.erb
+++ b/lib/app/views/code/random.erb
@@ -1,15 +1,16 @@
 <div class="row">
   <div class="code span12">
     <h1>
-      <%= submission.exercise.language.capitalize %>:
+      <%= submission.language.capitalize %>:
       <%= submission.exercise.name %>
     </h1>
     <p>
-    This is how <%= profile_link(submission.user, "@#{submission.user.username}") %> solved <%= submission.exercise.name %> in <%= submission.exercise.language %>. Interested? Read the <a href="/submissions/<%= submission.key %>">related discussion</a>.
-    <% if total > 1 %>
-
-    See one of the <a href="/code/<%= submission.language %>/<%= submission.slug %>/random">other <%= total %> implementations</a> of <%= submission.exercise.name %> in <%= submission.language %>.
+    <% if total == 1 %>
+    You are seeing the only available implementation of the exercise.
+    <% elsif total > 1 %>
+    Take a look at one of the <a href="/code/<%= submission.language %>/<%= submission.slug %>/random"><%= total %> available implementations</a> of the exercise.
     <% end %>
+    This is how <%= profile_link(submission.user, "@#{submission.user.username}") %> solved <%= submission.exercise.name %> in <%= submission.language.capitalize %>. Interested? Read the <a href="/submissions/<%= submission.key %>">related discussion</a>.
     </p>
     <div style="padding-top: 2px;">
       <%= md(submission.code, submission.language) %>


### PR DESCRIPTION
Implemented what we talked about in the other pull request:
- Changed capitalization of language name.
- Now the text changes depending on the total number of implementations for the exercise.

I keep thinking that it can be weird for the user to see his own solution, because the text says that another solution will be shown by clicking the link and in the case of a low number of solutions it may not be true, e.g. if there is only another solution we could click the link and likely see our own solution again, which could be confusing (though probably many users would look a the url and figure it's random, but still it would be incoherent with the text). While doing this in my local environment it was very apparent, because the exercises had very few implementations.

Another alternative would be changing the text so it doesn't make a reference to 'other' implementations, like "Take a look at one of the X available implementations" or something similar.
