### PR TITLE
Correct snippet syntax in JavaScript setup article

### DIFF
--- a/lib/app/articles/help/setup/javascript.md
+++ b/lib/app/articles/help/setup/javascript.md
@@ -24,7 +24,7 @@ $ jasmine-node bob_test.spec.js
 
 ## Making Your First Node Module
 
-To create a module that can be loaded with `var Bob = require(./bob);`, put this code in `bob.js`:
+To create a module that can be loaded with `var Bob = require('./bob');`, put this code in `bob.js`:
 
 ```javascript
 var Bob = function() {};


### PR DESCRIPTION
require(/.bob) was missing some quotes.
