### PR TITLE
Add http:// prefix to redirect_uri param for GitHub auth, closes #1237

### DIFF
--- a/lib/app/helpers/session_helper.rb
+++ b/lib/app/helpers/session_helper.rb
@@ -14,7 +14,7 @@ module Sinatra
     end
 
     def redirect_uri(return_path)
-      "&redirect_uri=#{site_root}/github/callback#{return_path}"
+      "&redirect_uri=http://#{site_root}/github/callback#{return_path}"
     end
 
     def login(user)


### PR DESCRIPTION
This closes #1237

The GitHub OAuth API docs specify that a `redirect_uri` param include the scheme prefix (eg, `http://` ). Check out: http://developer.github.com/v3/oauth/#redirect-urls for details and examples.

You can actually see this fix working in production by taking the following steps:
1. Log out of Exercism
2. Go to a submission-specific URL, for example http://exercism.io/submissions/14e9cec1407cac4e34e2129f 
3. Right-click on the "Log in via GitHub" button, and copy the link
4. Paste the URL into your address bar, and where it says `...&redirect_uri=exercism.io...`, add "http://", so that it says `...&redirect_uri=http://exercism.io...`
5. Click enter to follow that link, and see the glory of the functioning redirect_uri param!

Let me know if you think this requires test coverage in and of itself.
