### PR TITLE
Fix N+1 queries on Nitpick page.

### DIFF
--- a/lib/app/presenters/workload.rb
+++ b/lib/app/presenters/workload.rb
@@ -42,14 +42,19 @@ class Workload
       scope = pending.where(slug: slug)
     end
 
-    @submissions = scope.select do |submission|
-      user.nitpicker_on?(submission.exercise)
+    unless user.mastery.include?(language)
+      scope = scope.where(slug: user.completed[language])
     end
+
+    @submissions = scope.includes(:user)
   end
 
   def available_exercises
-    Exercism.curriculum.in(language).exercises.select {|exercise|
-      user.nitpicker_on?(exercise)
+    exercises = Exercism.curriculum.in(language).exercises
+    return exercises if user.mastery.include?(language)
+
+    exercises.select {|exercise|
+      user.completed[language].include? exercise.slug
     }
   end
 
@@ -59,4 +64,3 @@ class Workload
     @pending ||= Submission.pending.where(language: language).unmuted_for(user)
   end
 end
-


### PR DESCRIPTION
Hey! So, I ran rack-mini-profiler and bullet on the app to find performance issues.

Found the nitpick page had a couple N+1's.

So, to fix them I:
- Added eager loading for `user` in `submissions`.
- Removed using `user.nitpicker_on?` in a loop. Because it was making 1 query per call.

**Fun stats:** 
http://localhost:4567/nitpick/javascript/word-count

_Before:_ [(profiler screenshot)](https://www.evernote.com/shard/s10/sh/2ae1cc08-3bee-4d95-9c71-bdf5936bb03e/d395e4f16b2b22b5e9cbbe18b0072af9/res/6fd33807-8e43-4341-a2db-ec38c86ec0a2.jpg?resizeSmall&width=832)
~ 112 queries. 
~ 700ms

_After_: [(profiler screenshot)](https://www.evernote.com/shard/s10/sh/a8754602-0bac-4425-9248-7b91ac0f0b98/6e0994d87b36c695d6cdf0c420cdf4d4/res/794e8d93-a1fb-414a-9a38-37aaeb821452.jpg?resizeSmall&width=832)
~ 12 queries. 
~ 100ms
