### PR TITLE
Update the Installing Elixir instructions on OS X.

### DIFF
--- a/lib/app/articles/help/setup/elixir.md
+++ b/lib/app/articles/help/setup/elixir.md
@@ -2,18 +2,10 @@
 
 ### Homebrew for Mac OS X
 
-Elixir requires Erlang R16B:
+Elixir requires Erlang:
 
 ```bash
-$ brew tap homebrew/versions
-$ brew install erlang-r16
-```
-
-If you have a previous Erlang version installed, unlink it and link the new one:
-
-```bash
-$ brew uninstall erlang
-$ brew link erlang-r16
+$ brew install erlang
 ```
 
 Update your homebrew to latest and install Elixir:


### PR DESCRIPTION
The `erlang` homebrew formula is R16, so the specified -r16 formula does not
exist.

Fixes #1243 .

Following a [the conversations](https://github.com/exercism/exercism.io/issues/1243#issuecomment-31429285) on #1243, I have simplified the instructions. Cheers!
