### PR TITLE
Fix N+1’s on viewing submission.

### DIFF
--- a/lib/app/submissions.rb
+++ b/lib/app/submissions.rb
@@ -31,7 +31,7 @@ class ExercismApp < Sinatra::Base
   get '/submissions/:key' do |key|
     please_login
 
-    submission = Submission.find_by_key(key)
+    submission = Submission.includes(:user, comments: :user).find_by_key(key)
     unless submission
       flash[:error] = "We can't find that submission."
       redirect '/'


### PR DESCRIPTION
Fixes N+1's on viewing submission. Was doing 2 queries for each nitpick.

Bullet output:

```
N+1 Query detected
  Submission => [:user]
  Add to your finder: :include => [:user]
N+1 Query detected
  Comment => [:user]
  Add to your finder: :include => [:user]
```
