### PR TITLE
Only use buttons for submissions with reviews or comments

### DIFF
--- a/frontend/app/css/style.css
+++ b/frontend/app/css/style.css
@@ -244,3 +244,14 @@ a code {
   padding-top: 20px;
   color: #999;
 }
+
+.btn-no-link, .btn-no-link:hover {
+  color: black;
+  cursor: default;
+  text-decoration: none;
+}
+
+.btn-deemphasized, .btn-deemphasized:hover {
+  background-image: none;
+  background-color: #fcfcfc;
+}

--- a/lib/app/views/submissions/show.erb
+++ b/lib/app/views/submissions/show.erb
@@ -27,9 +27,9 @@
     <p> View iteration:
       <% submission.user_exercise.submissions.each do |s| %>
         <% if s == submission %>
-          <span style="padding: 10px;"><%= s.version %></span>
+          <span class="btn btn-link btn-no-link"><%= s.version %></span>
         <% elsif s.comments.to_a.length == 0  && submission.user_exercise.submissions.last != s %>
-          <a href="/submissions/<%= s.key %>" style="padding: 10px;"> <%= s.version %></a>
+          <a class="btn btn-deemphasized" href="/submissions/<%= s.key %>"> <%= s.version %></a>
         <% else %>
           <a class="btn btn-default" href="/submissions/<%= s.key %>"> <%= s.version %></a>
         <% end %>


### PR DESCRIPTION
The rationale being that some people iteratively send in their
exercises, without awaiting comments. This makes it really hard to
judge if you're looking at submission 8 whether a whole discussion has
already been had, or whether no discussion has been had at all.

![screenshot](https://f.cloud.github.com/assets/624143/1832361/e3a8b068-73b1-11e3-8afa-3e4c95c11c5f.png)
