### PR TITLE
Ruby Proverb added test to avoid someone hardcoding the required lyrics.

### DIFF
--- a/assignments/ruby/proverb/proverb_test.rb
+++ b/assignments/ruby/proverb/proverb_test.rb
@@ -28,6 +28,14 @@ class ProverbTest < MiniTest::Unit::TestCase
     assert_equal expected, proverb.to_s
   end
 
+  def test_proverb_does_not_hard_code_the_rhyme_dictionary
+    skip
+    proverb = Proverb.new('key', 'value')
+    expected = "For want of a key the value was lost.\n" +
+      "And all for the want of a key."
+    assert_equal expected, proverb.to_s
+  end
+
   def test_the_whole_proverb
     skip
     chain = [


### PR DESCRIPTION
[stevenwu's solution](http://exercism.io/submissions/fadc475266c6eb665a3910d7) was to hard code a hash with all the known key/value pairs. So if there were any new items in the proverb his program wouldn't cope. Whereas a standard programmed solution would. I've added a test to stop this being a viable solution.

We must stop this _crushes paper cup for emphasis_ hehe ;-)

All tests pass on the example.rb solution and my own solution.
test_proverb_does_not_hard_code_the_rhyme_dictionary _fails_ when the code can't cope with an unknown key/value combination.

Rich
