### PR TITLE
Removing non-terminology

### DIFF
--- a/assignments/ruby/leap/leap_test.rb
+++ b/assignments/ruby/leap/leap_test.rb
@@ -2,11 +2,11 @@ require 'minitest/autorun'
 require_relative 'year'
 
 class YearTest < MiniTest::Unit::TestCase
-  def test_vanilla_leap_year
+  def test_leap_year
     assert Year.new(1996).leap?
   end
 
-  def test_any_old_year
+  def test_non_leap_year
     skip
     refute Year.new(1997).leap?
   end
@@ -16,7 +16,7 @@ class YearTest < MiniTest::Unit::TestCase
     refute Year.new(1900).leap?
   end
 
-  def test_exceptional_century
+  def test_fourth_century
     skip
     assert Year.new(2400).leap?
   end


### PR DESCRIPTION
I see a lot of people copying those terms. I feel they are a bit misleading. I intently avoided quadricennial, and use a more generic sounding term, so people can think of their own terminology.
