### PR TITLE
Add test for JS anagram to reject same word regardless of case

### DIFF
--- a/assignments/javascript/anagram/anagram_test.spec.js
+++ b/assignments/javascript/anagram/anagram_test.spec.js
@@ -52,7 +52,7 @@ describe('Anagram', function() {
 
   xit("does not detect a word as its own anagram",function() {
     var detector = new Anagram("banana");
-    var matches = detector.match(['banana']);
+    var matches = detector.match(['Banana']);
     expect(matches).toEqual([]);
   });
 });

--- a/assignments/javascript/anagram/example.js
+++ b/assignments/javascript/anagram/example.js
@@ -2,7 +2,7 @@
   'use strict';
 
   function Anagram(word) {
-    this.word = word;
+    this.word = word.toLowerCase();
   }
 
   Anagram.prototype.match = function(words) {
@@ -11,8 +11,8 @@
     for(var i = 0; i < words.length; i++) {
       var currentWord = words[i];
 
-      if (currentWord.length == this.word.length && currentWord != this.word) {
-        var currentWordLetters = currentWord.split('').sort();
+      if (currentWord.length == this.word.length && currentWord.toLowerCase() != this.word) {
+        var currentWordLetters = currentWord.toLowerCase().split('').sort();
         var matchingWordLetters = this.word.split('').sort();
 
         var isMatch = true;


### PR DESCRIPTION
Previously a test word that differed only in case from the original word would be considered an anagram, while the exactly identical word would not. It seems like it should be case-insensitive, right?

I modified the example also in a super simple way to pass this additional requirement. I didn't bother refactoring at all, since I heard the examples are no longer intended to actually be good examples, just something that passes the tests.
