### PR TITLE
go/accumulate: changed 'Allergies' to 'Accumulate', added tests

### DIFF
--- a/assignments/go/accumulate/accumulate_test.go
+++ b/assignments/go/accumulate/accumulate_test.go
@@ -10,6 +10,10 @@ func echo(c string) string {
 	return c
 }
 
+func capitalize(word string) string {
+	return strings.Title(word)
+}
+
 var tests = []struct {
 	expected    []string
 	given       []string
@@ -17,6 +21,8 @@ var tests = []struct {
 	description string
 }{
 	{[]string{}, []string{}, echo, "echo"},
+	{[]string{"echo", "echo", "echo", "echo"}, []string{"echo", "echo", "echo", "echo"}, echo, "echo"},
+	{[]string{"First", "Letter", "Only"}, []string{"first", "letter", "only"}, capitalize, "capitalize"},
 	{[]string{"HELLO", "WORLD"}, []string{"hello", "world"}, strings.ToUpper, "upcase"},
 }
 
@@ -24,7 +30,7 @@ func TestAccumulate(t *testing.T) {
 	for _, test := range tests {
 		actual := Accumulate(test.given, test.converter)
 		if fmt.Sprintf("%s", actual) != fmt.Sprintf("%s", test.expected) {
-			t.Fatalf("Allergies(%s, %#v): expected %s, actual %s", test.given, test.converter, test.expected, actual)
+			t.Fatalf("Accumulate(%s, %#v): expected %s, actual %s", test.given, test.converter, test.expected, actual)
 		} else {
 			t.Logf("PASS: %s %v", test.description, test.given)
 		}


### PR DESCRIPTION
In order to prevent gaming the test, I've added two more test cases to the Accumulate exercise in Go. The first new test actually checks to see if the echo function performs an echo operation when the given array is not empty. The second test checks to see if `strings.Title` will behave as expected when passed to `Accumulate`.

I also noticed that the error message on a fail started with "Allergies". This was possibly a copy/paste bug from another exercise.
