### PR TITLE
Use the right order of args in elixir list-ops reduce

### DIFF
--- a/assignments/elixir/list-ops/example.exs
+++ b/assignments/elixir/list-ops/example.exs
@@ -37,9 +37,9 @@ defmodule ListOps do
   end
 
   @type acc :: any
-  @spec reduce(list, acc, ((acc, any) -> acc)) :: acc
+  @spec reduce(list, acc, ((any, acc) -> acc)) :: acc
   def reduce([], acc, _), do: acc
-  def reduce([h|t], acc, f), do: reduce(t, f.(acc, h), f)
+  def reduce([h|t], acc, f), do: reduce(t, f.(h, acc), f)
 
   @spec append(list, list) :: list
   def append(a, b), do: do_append(reverse(a), b)
@@ -48,5 +48,5 @@ defmodule ListOps do
   defp do_append([h|t], b), do: do_append(t, [h|b])
 
   @spec concat([[any]]) :: [any]
-  def concat(ll), do: reverse(ll) |> reduce([], &(append(&2, &1)))
+  def concat(ll), do: reverse(ll) |> reduce([], &(append(&1, &2)))
 end

--- a/assignments/elixir/list-ops/list-ops_test.exs
+++ b/assignments/elixir/list-ops/list-ops_test.exs
@@ -71,6 +71,10 @@ defmodule ListOpsTest do
       L.reduce(Enum.to_list(1..1_000_000), 0, &(&1+&2))
   end
 
+  test "reduce with non-commutative function" do
+    assert 0 == L.reduce([1,2,3,4], 10, fn x, acc -> acc - x end)
+  end
+
   test "append of empty lists" do
     assert [] == L.append([], [])
   end

--- a/assignments/elixir/list-ops/list_ops.exs
+++ b/assignments/elixir/list-ops/list_ops.exs
@@ -27,7 +27,7 @@ defmodule ListOps do
   end
 
   @type acc :: any
-  @spec reduce(list, acc, ((acc, any) -> acc)) :: acc
+  @spec reduce(list, acc, ((any, acc) -> acc)) :: acc
   def reduce(l, acc, f) do
 
   end


### PR DESCRIPTION
The function passed to reduce should take args `element, acc`, not `acc,
element` to be consistent with `Enum.reduce`.
