### PR TITLE
Fix in nit_count update when submitter == user

### DIFF
--- a/lib/app/submissions.rb
+++ b/lib/app/submissions.rb
@@ -132,7 +132,7 @@ class ExercismApp < Sinatra::Base
     end
 
     nit.delete
-    submission.nit_count -= 1
+    submission.nit_count -= 1 unless current_user.owns?(submission)
     submission.save
     redirect "/submissions/#{key}"
   end

--- a/test/app/submissions_test.rb
+++ b/test/app/submissions_test.rb
@@ -224,6 +224,10 @@ class SubmissionsTest < MiniTest::Unit::TestCase
     delete "/submissions/#{submission.key}/nits/#{comment.id}", {}, login(bob)
     assert_equal 0, Comment.count
     assert_equal 0, submission.reload.nit_count
+    comment = Comment.create(user: submission.user, submission: submission, body: "ohai")
+    delete "/submissions/#{submission.key}/nits/#{comment.id}", {}, login(submission.user)
+    assert_equal 0, Comment.count
+    assert_equal 0, submission.reload.nit_count
   end
 
   def test_reopen_exercise


### PR DESCRIPTION
The nit_count shouldn't be updated when deleting a submitter's comment.

Fixes #1274.
