### PR TITLE
Adds ability for sharing to twitter for submitted exercise

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -5,6 +5,7 @@ require 'will_paginate/active_record'
 
 require 'app/presenters/workload'
 require 'app/presenters/profile'
+require 'app/presenters/sharing'
 
 require 'app/stats' # must come before 'app/user'
 require 'app/notifications'

--- a/lib/app/presenters/sharing.rb
+++ b/lib/app/presenters/sharing.rb
@@ -1,0 +1,5 @@
+class Sharing
+  def twitter_link(submission)
+    %{<a href="https://twitter.com/intent/tweet?text=I just submitted the #{submission.language} #{submission.slug} exercise at exercism.io. Leave me a nitpick at http://exercism.io/submissions/#{submission.key}" id='twitter-share'>Share with Twitter</a>}
+  end
+end

--- a/lib/app/submissions.rb
+++ b/lib/app/submissions.rb
@@ -42,7 +42,7 @@ class ExercismApp < Sinatra::Base
 
     title(submission.slug + " in " + submission.language + " by " + submission.user.username)
 
-    erb :"submissions/show", locals: {submission: submission}
+    erb :"submissions/show", locals: {submission: submission, sharing: Sharing.new}
   end
 
   # TODO: Submit to this endpoint rather than the `respond` one.

--- a/lib/app/views/submissions/show.erb
+++ b/lib/app/views/submissions/show.erb
@@ -1,6 +1,11 @@
 <div class="row">
   <div class="span11">
     <%= erb :"submissions/byline", locals: {exercise: submission.exercise, user: submission.user} %>
+    <p><% if current_user.owns?(submission) %>
+      <%= sharing.twitter_link(submission) %>
+    <% end %>
+    </p>
+
     <p>Submitted <%= ago(submission.created_at) %>.</p>
     <p><%= view_count_for(submission) %>.</p>
     <p>

--- a/test/app/presenters/sharing_test.rb
+++ b/test/app/presenters/sharing_test.rb
@@ -1,0 +1,27 @@
+require './test/test_helper'
+require 'app/presenters/sharing.rb'
+
+class SharingTest < MiniTest::Unit::TestCase
+
+  def submission
+    submission = Object.new
+
+    def submission.key
+      "123456789"
+    end
+
+    def submission.language
+      "ruby"
+    end
+
+    def submission.slug
+      "bob"
+    end
+
+    submission
+  end
+
+  def test_creates_twitter_sharing_link
+    assert_equal "<a href=\"https://twitter.com/intent/tweet?text=I just submitted the ruby bob exercise at exercism.io. Leave me a nitpick at http://exercism.io/submissions/123456789\" id='twitter-share'>Share with Twitter</a>", Sharing.new.twitter_link(submission)
+  end
+end


### PR DESCRIPTION
Adds ability for user to share with twitter when they submit an exercise.

"I just submitted the [submission language] [submission slug] at exercism.io. Leave me a nitpick at http://exercism.io/submissions/[submission.key]"

I created a presenter to do this, but would be more than willing to change how it's done if this isn't idiomatic, I'm fairly new to rails/big sinatra style applications. 
