### PR TITLE
Sort pending submissions in ascending order.

### DIFF
--- a/lib/app/presenters/workload.rb
+++ b/lib/app/presenters/workload.rb
@@ -39,7 +39,7 @@ class Workload
     when 'no-nits'
       scope = scope.where(nit_count: 0)
     else
-      scope = pending.where(slug: slug)
+      scope = scope.where(slug: slug)
     end
 
     unless user.mastery.include?(language)


### PR DESCRIPTION
I was looking at pending submissions on my Ruby nit dashboard and I noticed they were out of order. In a previous commit, https://github.com/exercism/exercism.io/commit/7340b151398fc8d4955b63a00dda06d479fce602#diff-1285afdb5b80a61053db16d1368cdb20L72 , I noticed that the ascending order of pending submissions were removed.

Seems like we would want to have the oldest pending submissions on the top so they don't become stale. What do you think?
