### PR TITLE
Word count tests - leave on by default

### DIFF
--- a/assignments/go/word-count/word_count_test.go
+++ b/assignments/go/word-count/word_count_test.go
@@ -21,46 +21,39 @@ func TestEqual(t *testing.T) {
 }
 
 func TestNotEqual(t *testing.T) {
-	t.SkipNow()
 	h1 := Histogram{"word": 1}
 	h2 := Histogram{"word": 1, "games": 2}
 	assertNotEqual(t, h1, h2)
 }
 
 func TestCountOneWord(t *testing.T) {
-	t.SkipNow()
 	h := Histogram{"word": 1}
 	assertEqual(t, WordCount("word"), h)
 }
 
 func TestCountOneOfEach(t *testing.T) {
-	t.SkipNow()
 	h := Histogram{"one": 1, "of": 1, "each": 1}
 	assertEqual(t, WordCount("one of each"), h)
 }
 
 func TestCountMultipleOccurrences(t *testing.T) {
-	t.SkipNow()
 	actual := WordCount("one fish two fish red fish blue fish")
 	expected := Histogram{"one": 1, "fish": 4, "two": 1, "red": 1, "blue": 1}
 	assertEqual(t, actual, expected)
 }
 
 func TestIgnorePunctuation(t *testing.T) {
-	t.SkipNow()
 	actual := WordCount("car : carpet as java : javascript!!&@$%^&")
 	expected := Histogram{"car": 1, "carpet": 1, "as": 1, "java": 1, "javascript": 1}
 	assertEqual(t, actual, expected)
 }
 
 func TestIncludeNumbers(t *testing.T) {
-	t.SkipNow()
 	actual := WordCount("testing, 1, 2 testing")
 	expected := Histogram{"testing": 2, "1": 1, "2": 1}
 	assertEqual(t, actual, expected)
 }
 
 func TestNormalizeCase(t *testing.T) {
-	t.SkipNow()
 	assertEqual(t, WordCount("go Go GO"), Histogram{"go": 3})
 }


### PR DESCRIPTION
The need to un-skip tests might not be obvious during the exercise, choosing to leave all tests enabled by default.

Thank you,

  Tom
