### PR TITLE
Add lineman build task to copy generated files

### DIFF
--- a/frontend/config/application.coffee
+++ b/frontend/config/application.coffee
@@ -20,10 +20,21 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
   # enableSass: true
 
   # configure lineman to load additional angular related npm tasks
-  loadNpmTasks: [ "grunt-ngmin" ]
+  loadNpmTasks: [ "grunt-ngmin"]
+
   # task override configuration
   prependTasks:
     dist: ["ngmin"]         # ngmin should run in dist only
+
+  watch:
+    scripts:
+      files: ["generated/**"],
+      tasks: ['copy:dev']
+
+  copy:
+    dev:
+      files: [expand: true, cwd: 'generated', src: ['css/**', 'js/**', '!**/spec.js', 
+              '!**/*.less*', '!**/*.coffee*', '!**/*.*.map'], dest: '../lib/app/public' ]
 
   # configuration for grunt-ngmin, this happens _after_ concat once, which is the ngmin ideal :)
   ngmin: {


### PR DESCRIPTION
- Override `copy:dev` to copy generated assets to `public/`
- Add a task to `watch` to run `copy:dev` when any of the generated assets change.

This is to address issues in development with: https://github.com/exercism/exercism.io/commit/65e9b45a5469df8e13a0146fd82f42bcb5fb1066

Seems to work locally when I change some css. With this fix I _think_ we can delete the committed assets in `public`.
