### PR TITLE
Prevent haskell/grains test from missing overflow condition.

### DIFF
--- a/assignments/haskell/grains/grains_test.hs
+++ b/assignments/haskell/grains/grains_test.hs
@@ -14,22 +14,25 @@ main :: IO ()
 main = exitProperly $ runTestTT $ TestList
        [ TestList grainsTests ]
 
+i :: Integral a => a -> Integer
+i = fromIntegral
+
 grainsTests :: [Test]
 grainsTests =
   [ testCase "square 1" $
-    1 @=? square 1
+    1 @=? i (square 1)
   , testCase "square 2" $
-    2 @=? square 2
+    2 @=? i (square 2)
   , testCase "square 3" $
-    4 @=? square 3
+    4 @=? i (square 3)
   , testCase "square 4" $
-    8 @=? square 4
+    8 @=? i (square 4)
   , testCase "square 16" $
-    32768 @=? square 16
+    32768 @=? i (square 16)
   , testCase "square 32" $
-    2147483648 @=? square 32
+    2147483648 @=? i (square 32)
   , testCase "square 64" $
-    9223372036854775808 @=? square 64
+    9223372036854775808 @=? i (square 64)
   , testCase "total grains" $
-    18446744073709551615 @=? total
+    18446744073709551615 @=? i total
   ]


### PR DESCRIPTION
Set types of the values in to Integer with will remove automatic
infering to lower type and thus overflow in both tests and program.
