### PR TITLE
Clean up PHP test process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ tmp
 # JavaScript
 node_modules
 
+# PHP
+phpunit.phar
+
 # OCaml
 *.native
 _build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
   - '( cd frontend && npm install && lineman spec-ci )'
   - '( export PATH=/opt/hp-2013.2.0.0/bin:$PATH; runhaskell ./test/haskell/check-exercises.hs )'
   - 'make test --directory=assignments/javascript'
+  - 'make test --directory=assignments/php'
   - './test/rust/check-exercises.sh'
   - './test/python/check-exercises.py'
   - './test/erlang/check-exercises.sh'

--- a/assignments/php/Makefile
+++ b/assignments/php/Makefile
@@ -1,0 +1,28 @@
+ASSIGNMENT ?= ""
+ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | tr -d './' | sort)
+
+# output directories
+TMPDIR ?= "/tmp"
+OUTDIR := $(shell mktemp -d "$(TMPDIR)/$(ASSIGNMENT).XXXXXXXXXX")
+
+# language specific config (tweakable per language)
+FILEEXT := "php"
+EXAMPLE := "example.$(FILEEXT)"
+TSTFILE := "$(ASSIGNMENT)_test.$(FILEEXT)"
+
+# phpunit test lib
+phpunit.phar:
+	@wget https://phar.phpunit.de/phpunit.phar
+	@chmod +x phpunit.phar
+
+# single test
+test-assignment: phpunit.phar
+	@echo "running tests for: $(ASSIGNMENT)"
+	@cp $(ASSIGNMENT)/$(TSTFILE) $(OUTDIR)
+	@cp $(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
+	@./phpunit.phar $(OUTDIR)/$(TSTFILE)
+
+# all tests
+test:
+	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
+

--- a/assignments/php/trinary/example.php
+++ b/assignments/php/trinary/example.php
@@ -1,5 +1,7 @@
 <?php
 
+error_reporting(-1);
+
 class Trinary
 {
   const BASE = 3;

--- a/assignments/php/trinary/trinary_test.php
+++ b/assignments/php/trinary/trinary_test.php
@@ -1,77 +1,59 @@
 <?php
 
-require realpath(__DIR__ . '/example.php');
+require realpath(__DIR__ . '/trinary.php');
 
 class TrinaryTest extends PHPUnit_Framework_TestCase
 {
 
-  /**
-   * @test
-   */
+  /** @test */
   public function _1_is_decimal_1()
   {
     $this->assertEquals(1, (new Trinary('1'))->toDecimal());
   }
 
-  /**
-   * @skip
-   */
+  /** @skip */
   public function _2_is_decimal_2()
   {
     $this->assertEquals(2, (new Trinary('2'))->toDecimal());
   }
 
-  /**
-   * @skip
-   */
+  /** @skip */
   public function _10_is_decimal_3()
   {
     $this->assertEquals(3, (new Trinary('10'))->toDecimal());
   }
 
-  /**
-   * @skip
-   */
+  /** @skip */
   public function _11_is_decimal_4()
   {
     $this->assertEquals(4, (new Trinary('11'))->toDecimal());
   }
 
-  /**
-   * @skip
-   */
+  /** @skip */
   public function _100_is_decimal_9()
   {
     $this->assertEquals(9, (new Trinary('100'))->toDecimal());
   }
 
-  /**
-   * @skip
-   */
+  /** @skip */
   public function _112_is_decimal_14()
   {
     $this->assertEquals(14, (new Trinary('112'))->toDecimal());
   }
 
-  /**
-   * @skip
-   */
+  /** @skip */
   public function _222_is_decimal_26()
   {
     $this->assertEquals(26, (new Trinary('222'))->toDecimal());
   }
 
-  /**
-   * @skip
-   */
+  /** @skip */
   public function _1122000120_is_decimal_32091()
   {
     $this->assertEquals(32091, (new Trinary('1122000120'))->toDecimal());
   }
 
-  /**
-   * @skip
-   */
+  /** @skip */
   public function _invalid_trinary_is_decimal_0()
   {
     $this->assertEquals(0, (new Trinary('carrot'))->toDecimal());

--- a/assignments/php/wordy/wordy_test.php
+++ b/assignments/php/wordy/wordy_test.php
@@ -1,6 +1,6 @@
 <?php
 
-require realpath(__DIR__ . '/example.php');
+require realpath(__DIR__ . '/wordy.php');
 
 class WordProblemTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
### Summary
- drop `phpunit.phar`.
- `make` driven test.
- add PHP tests to travis configuration.
### Examples

```
# run all tests
% make test

# run specific test
% make test-assignment=trinary
```
