### PR TITLE
Cleanup JS test process

### DIFF
--- a/assignments/javascript/Makefile
+++ b/assignments/javascript/Makefile
@@ -1,25 +1,28 @@
-# language specific config (you can tweak per language)
+# assignments
 ASSIGNMENT ?= ""
-FILEEXT := "js"
-PATTERN := "$(ASSIGNMENT)_test.spec.$(FILEEXT)"
+IGNOREDIRS := "node_modules"
+ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | tr -d './' | sort | grep -Ev $(IGNOREDIRS))
 
-# output directory
+# output directories
 TMPDIR ?= "/tmp"
 OUTDIR := $(shell mktemp -d "$(TMPDIR)/$(ASSIGNMENT).XXXXXXXXXX")
 
-# assignments
-ASSIGNMENTS = $(shell find . -maxdepth 1 -mindepth 1 -type d | tr -d './' | grep -v 'node_modules' | sort)
+# language specific config (tweakable per language)
+FILEEXT := "js"
+EXAMPLE := "example.$(FILEEXT)"
+TSTFILE := "$(ASSIGNMENT)_test.spec.$(FILEEXT)"
 
-test-assignment: node_modules
-	@echo "running tests for: $(ASSIGNMENT)"
-	@cp $(ASSIGNMENT)/$(PATTERN) $(OUTDIR)
-	@cp $(ASSIGNMENT)/example.js $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
-	@./node_modules/.bin/jasmine-node --captureExceptions $(OUTDIR)/$(PATTERN)
-
-test:
-	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
-
+# development dependencies
 node_modules: package.json
 	@npm prune
 	@npm install
+
+test-assignment: node_modules
+	@echo "running tests for: $(ASSIGNMENT)"
+	@cp $(ASSIGNMENT)/$(TSTFILE) $(OUTDIR)
+	@cp $(ASSIGNMENT)/$(EXAMPLE) $(OUTDIR)/$(ASSIGNMENT).$(FILEEXT)
+	@./node_modules/.bin/jasmine-node --captureExceptions $(OUTDIR)/$(TSTFILE)
+
+test:
+	@for assignment in $(ASSIGNMENTS); do ASSIGNMENT=$$assignment $(MAKE) -s test-assignment || exit 1; done
 

--- a/assignments/javascript/package.json
+++ b/assignments/javascript/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "test": "make test"
   },
-  "engines": {
-    "node": "~>0.10.5"
-  },
   "devDependencies": {
-    "jasmine-node": "~1.11.0"
+    "jasmine-node": "*"
   }
 }


### PR DESCRIPTION
- Remove deprecated `engines` key from package.json.
- Change `jasmin-node` to always use latest (life is just easier that way).
- Refactor `Makefile` (better variables, better organization, etc.)
