### PR TITLE
Add hibernated submissions to restore endpoint

### DIFF
--- a/lib/api/assignments.rb
+++ b/lib/api/assignments.rb
@@ -51,7 +51,7 @@ class ExercismAPI < Sinatra::Base
 
   get '/user/assignments/restore' do
     require_user
-    sql = "SELECT u.language, u.slug, s.code, s.filename FROM user_exercises u, submissions s WHERE u.id = s.user_exercise_id AND u.state = s.state AND u.state IN ('done', 'pending') AND u.user_id = %s" % current_user.id.to_s
+    sql = "SELECT u.language, u.slug, s.code, s.filename FROM user_exercises u, submissions s WHERE u.id = s.user_exercise_id AND u.state = s.state AND u.state IN ('done', 'pending', 'hibernating') AND u.user_id = %s" % current_user.id.to_s
     submitted = Submission.connection.execute(sql).map {|result| [result["language"], result["slug"], result["code"], result["filename"]]}
     handler = API::Assignments::Restore.new(submitted, curriculum)
     pg :assignments_compact, locals: {assignments: handler.assignments}

--- a/test/api/assignments_test.rb
+++ b/test/api/assignments_test.rb
@@ -72,9 +72,11 @@ class AssignmentsApiTest < MiniTest::Unit::TestCase
     Submission.create(user: alice, language: 'go', slug: 'one', code: 'CODE1GO', state: 'done', filename: 'one.go')
     Submission.create(user: alice, language: 'go', slug: 'two', code: 'CODE2GO', state: 'pending', filename: 'two.go')
     Submission.create(user: alice, language: 'ruby', slug: 'one', code: 'CODE1RB', state: 'pending', filename: 'one.rb')
+    Submission.create(user: alice, language: 'ruby', slug: 'two', code: 'CODE2RB', state: 'hibernating', filename: 'two.rb')
     Hack::UpdatesUserExercise.new(alice.id, 'go', 'one').update
     Hack::UpdatesUserExercise.new(alice.id, 'go', 'two').update
     Hack::UpdatesUserExercise.new(alice.id, 'ruby', 'one').update
+    Hack::UpdatesUserExercise.new(alice.id, 'ruby', 'two').update
 
     Exercism.stub(:curriculum, curriculum) do
 

--- a/test/fixtures/approvals/api_restore_assignment_data.approved.json
+++ b/test/fixtures/approvals/api_restore_assignment_data.approved.json
@@ -15,7 +15,16 @@
       "slug": "two",
       "files": {
         "README.md": "# Two\n\nThis is two.\n\n* two\n* two again\n\n\n## Source\n\nThe web. [view source](http://example.org)\n",
+        "two.rb": "CODE2RB",
         "two_test.rb": "require 'minitest/autorun'\nrequire_relative 'example'\nclass TwoTest < Minitest::Test\n  def test_two\n    assert_equal 2, Two.value\n  end\nend\n"
+      }
+    },
+    {
+      "track": "ruby",
+      "slug": "three",
+      "files": {
+        "README.md": "# Three\n\nThis is three.\n\n* three\n* three once more\n\n\n## Source\n\nOnline. [view source](http://www.example.org)\n",
+        "three_test.rb": "require 'minitest/autorun'\nrequire_relative 'example'\nclass ThreeTest < Minitest::Test\n  def test_three\n    assert_equal 3, Three.value\n  end\nend\n"
       }
     },
     {

--- a/test/fixtures/ruby/three/example.rb
+++ b/test/fixtures/ruby/three/example.rb
@@ -1,0 +1,4 @@
+Three = Object.new
+def Three.value
+  3
+end

--- a/test/fixtures/ruby/three/three_test.rb
+++ b/test/fixtures/ruby/three/three_test.rb
@@ -1,0 +1,7 @@
+require 'minitest/autorun'
+require_relative 'example'
+class ThreeTest < Minitest::Test
+  def test_three
+    assert_equal 3, Three.value
+  end
+end


### PR DESCRIPTION
Hibernating submissions currently are not restored using the restore endpoint.  This makes it difficult to retrieve those submissions when moving between machines, etc.

This PR adds hibernating submissions to the restore API endpoint such that they can be retrieved by the CLI tool.  It also adds an additional ruby exercise fixture to satisfy the upcoming exercises feature.

Thanks for adding restore, I love it :smile:
