### PR TITLE
Change tab order on comment form so you can do tab + enter to submit

### DIFF
--- a/lib/app/views/submissions/submit_comment.erb
+++ b/lib/app/views/submissions/submit_comment.erb
@@ -9,19 +9,19 @@
 
   <form accept-charset="UTF-8" action="/submissions/<%= submission.key %>/nitpick" method="POST">
 
-  <% if current_user.owns?(submission) %>
-    <%= erb :"submissions/encourage_submitter", locals: {version: submission.version, nit_count: submission.nit_count} %>
-  <% else %>
-    <%= erb :"submissions/encourage_nitpicker", locals: {language: submission.language} %>
-  <% end %>
+    <% if current_user.owns?(submission) %>
+      <%= erb :"submissions/encourage_submitter", locals: {version: submission.version, nit_count: submission.nit_count} %>
+    <% else %>
+      <%= erb :"submissions/encourage_nitpicker", locals: {language: submission.language} %>
+    <% end %>
 
     <%= erb :"submissions/comment" %>
-     <span>parsed with <a href="https://help.github.com/articles/github-flavored-markdown" target="_blank">GitHub Flavoured Markdown</a></span>
     <% if current_user.owns?(submission) %>
       <button type="submit" name="nitpick" class="pull-right btn btn-primary">Submit Comment</button>
     <% else %>
       <button type="submit" name="nitpick" class="pull-right btn btn-primary">Nitpick</button>
     <% end %>
+    <span>Parsed with <a href="https://help.github.com/articles/github-flavored-markdown" target="_blank">GitHub Flavoured Markdown</a></span>
   </form>
 
 <% end %>


### PR DESCRIPTION
Previously the tab order was such that if you did tab + enter from the comment textarea it would result in following the link to the info about Github Flavored Markdown. I did this so many times I decided to suggest changing it.

I went ahead and left the layout the same, but changed the source order so that the tab order is reversed. Let me know if you think the physical order of the elements should change to make the tab order still left to right, and I can do that as well. (Of course I know a redesign is coming soon anyway).
