### PR TITLE
Testing equivalence of maps in Go

### DIFF
--- a/assignments/go/word-count/word_count_test.go
+++ b/assignments/go/word-count/word_count_test.go
@@ -2,6 +2,7 @@ package wc
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -47,7 +48,7 @@ func TestWordCount(t *testing.T) {
 		expected := fmt.Sprintf("%v", tt.output)
 		actual := fmt.Sprintf("%v", WordCount(tt.input))
 
-		if expected != actual {
+		if !reflect.DeepEqual(tt.output, WordCount(tt.input)) {
 			t.Fatalf("%s\n\tExpected: %v\n\tGot: %v", tt.description, expected, actual)
 		} else {
 			t.Logf("PASS: %s - WordCount(%s)", tt.description, tt.input)


### PR DESCRIPTION
You can't compare the two maps with !=, because it compares the string representation of the maps, so it will work only randomly (if the values are printed in the same order).

reference: http://stackoverflow.com/questions/21745073/testing-equivalence-of-maps-in-go-with-the-same-contents-but-the-test-failed
