### PR TITLE
Update Clojure curriculum to include missing assignments

### DIFF
--- a/lib/exercism/curriculum/clojure.rb
+++ b/lib/exercism/curriculum/clojure.rb
@@ -7,8 +7,10 @@ class Exercism
         grade-school robot-name leap etl meetup space-age grains
         gigasecond triangle scrabble-score roman-numerals
         binary prime-factors raindrops allergies
-        atbash-cipher
+        atbash-cipher bank-account
         crypto-square kindergarten-garden robot-simulator queen-attack
+        accumulate binary-search-tree difference-of-squares hexadecimal
+        largest-series-product
       )
     end
 


### PR DESCRIPTION
Clojure was missing a number of implemented assignments in the curriculum file. (I didn't realize they needed to be added there to show up.) So added those in.
