### PR TITLE
coffee wordy: Wrapping functions in `expect` testing error 

### DIFF
--- a/assignments/coffeescript/wordy/wordy_test.spec.coffee
+++ b/assignments/coffeescript/wordy/wordy_test.spec.coffee
@@ -60,9 +60,9 @@ describe 'Word Problem', ->
 
   xit 'too advanced', ->
     problem = new WordProblem('What is 53 cubed?')
-    expect(problem.answer).toThrow(problem.ERROR.tooComplicated)
+    expect(-> problem.answer()).toThrow(problem.ERROR.tooComplicated)
 
   xit 'irrelevant', ->
     problem = new WordProblem('Who is the president of the United States?')
-    expect(problem.answer).toThrow(problem.ERROR.tooComplicated)
+    expect(-> problem.answer()).toThrow(problem.ERROR.tooComplicated)
 


### PR DESCRIPTION
If you are calling `problem.answer` method as is, it's scope is
global and can not access instance variables in `problem` object.
Therfore, this test will be always returning success.
