### PR TITLE
add missing `skip` to a ruby grade-school test file

### DIFF
--- a/assignments/ruby/grade-school/grade_school_test.rb
+++ b/assignments/ruby/grade-school/grade_school_test.rb
@@ -45,6 +45,7 @@ class SchoolTest < MiniTest::Unit::TestCase
   end
 
   def test_get_students_sorted_in_a_grade
+    skip
     school.add("Franklin", 5)
     school.add("Bradley", 5)
     school.add("Jeff", 1)


### PR DESCRIPTION
Unlike the other ruby tests I've come across, once the required ruby file is present, the grade-school test starts by raising eight errors instead of just one. Then, before the `test_an_empty_school` assertion passes, it'll complain about missing methods `add` and `grade` because the `test_get_students_sorted_in_a_grade` assertion isn't being skipped.
