### PR TITLE
add `skip` to some ruby tests

### DIFF
--- a/assignments/ruby/clock/clock_test.rb
+++ b/assignments/ruby/clock/clock_test.rb
@@ -44,6 +44,7 @@ class ClockTest < MiniTest::Unit::TestCase
   end
 
   def test_wrap_around_backwards
+    skip
     clock = Clock.at(0, 30) - 60
     assert_equal "23:30", clock.to_s
   end

--- a/assignments/ruby/queen-attack/queen_attack_test.rb
+++ b/assignments/ruby/queen-attack/queen_attack_test.rb
@@ -118,6 +118,7 @@ O O O O O O O O
   end
 
   def test_can_attack_on_a_diagonal_slanted_the_other_way
+    skip
     queens = Queens.new(white: [6, 1], black: [1, 6])
     assert queens.attack?
   end


### PR DESCRIPTION
I found a handful of ruby assignments which aren't skipping all-but-one test:

```
~/workspace/exercism.io $ for TESTFILE in $(find assignments/ruby -name *_test.rb)
> do
>   TESTS=$(grep 'def test_' $TESTFILE | wc -l)
>   SKIPS=$(grep 'skip'      $TESTFILE | wc -l)
>   if (( $TESTS - $SKIPS > 1 ))
>   then
>     echo $TESTS tests but $SKIPS skipped in $TESTFILE
>   fi
> done
7 tests but 0 skipped in assignments/ruby/binary-search/binary_search_test.rb
8 tests but 6 skipped in assignments/ruby/clock/clock_test.rb
12 tests but 0 skipped in assignments/ruby/custom-set/custom_set_test.rb
10 tests but 0 skipped in assignments/ruby/food-chain/food_chain_test.rb
5 tests but 0 skipped in assignments/ruby/linked-list/linked_list_test.rb
5 tests but 0 skipped in assignments/ruby/palindrome-products/palindrome_products_test.rb
14 tests but 12 skipped in assignments/ruby/queen-attack/queen_attack_test.rb
10 tests but 0 skipped in assignments/ruby/rna-transcription/complement_test.rb
2 tests but 0 skipped in assignments/ruby/sieve/sieve_test.rb
5 tests but 0 skipped in assignments/ruby/simple-linked-list/simple_linked_list_test.rb
```

This PR just adds the one missing `skip` each to the clock and queen-attack tests. I haven't come across the assignments with 0 skipped yet; should they get `skip`s added as well?
