### PR TITLE
Go: Add Histogram type def in word-count test

### DIFF
--- a/assignments/go/word-count/word_count_test.go
+++ b/assignments/go/word-count/word_count_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 )
 
+type Histogram map[string]int
+
 var testCases = []struct {
 	description string
 	input       string


### PR DESCRIPTION
Running the test gives the user an error that `Histogram` is undefined,
which seems confusing. Especially as a Go newbie, one is likely to
assume there's something wrong with their installation (e.g. is
Histogram a built-in package that I should have?)
