### PR TITLE
Reversed the Test Syntax

### DIFF
--- a/assignments/javascript/binary/binary_test.spec.js
+++ b/assignments/javascript/binary/binary_test.spec.js
@@ -3,35 +3,35 @@ var Binary = require('./binary');
 describe('binary', function() {
 
   it('1 is decimal 1', function() {
-    expect(1).toEqual(new Binary('1').toDecimal());
+    expect(new Binary('1').toDecimal()).toEqual(1);
   });
 
   xit('10 is decimal 2', function() {
-    expect(2).toEqual(new Binary('10').toDecimal());
+    expect(new Binary('10').toDecimal()).toEqual(2);
   });
 
   xit('11 is decimal 3', function() {
-    expect(3).toEqual(new Binary('11').toDecimal());
+    expect(new Binary('11').toDecimal()).toEqual(3);
   });
 
   xit('100 is decimal 4', function() {
-    expect(4).toEqual(new Binary('100').toDecimal());
+    expect(new Binary('100').toDecimal()).toEqual(4);
   });
 
   xit('1001 is decimal 9', function() {
-    expect(9).toEqual(new Binary('1001').toDecimal());
+    expect(new Binary('1001').toDecimal()).toEqual(9);
   });
 
   xit('11010 is decimal 26', function() {
-    expect(26).toEqual(new Binary('11010').toDecimal());
+    expect(new Binary('11010').toDecimal()).toEqual(26);
   });
 
   xit('10001101000 is decimal 1128', function() {
-    expect(1128).toEqual(new Binary('10001101000').toDecimal());
+    expect(new Binary('10001101000').toDecimal()).toEqual(1128);
   });
 
   xit('carrot is decimal 0', function() {
-    expect(0).toEqual(new Binary('carrot').toDecimal());
+    expect(new Binary('carrot').toDecimal()).toEqual(0);
   });
 
 });


### PR DESCRIPTION
Many other tests in the JavaScript track pass the expect() function a value based on the written code by the user in their js file.  The toEqual() function is normally passed a hard-coded value, pre-determined when the test was written..

This test reversed the pattern, passing expect the hard-coded values and toEqual() the value of the users code written in their js file.

I was helping a friend with this problem and he was confused with the test.  When I re-wrote the test for him in this format (the format he was used to based on previous tests) it made a lot more sense to him.  

Hope this helps!
