### PR TITLE
add explanation of when nitpicking is available

### DIFF
--- a/lib/v1.0/articles/help/nitpick.md
+++ b/lib/v1.0/articles/help/nitpick.md
@@ -2,6 +2,8 @@
 
 **A practical guide to providing better feedback on solutions to exercises.**
 
+> You will not see the Nitpick menu until you have finished at least one exercise. You will only have the opportunity to nitpick exercises you have finished. Finishing an exercise is not the same thing as submitting it -- you need to go to your exercise page and indicate that you are done and don't want any more feedback to mark it as finished.
+
 When reviewing exercism submissions, it is possible and encouraged to share advice and insight on the style and approach of a given implementation.
 
 Nitpicks should provide positive and constructive criticism, subtly nudging a coder toward progressively better implementations of an exercise.


### PR DESCRIPTION
In the context of the current file, wasn't sure if this notice belonged at the top or as a footnote. Since there was already an end quote, I put it at the top -- reading the remaining info will be more pertinent once you have the ability to nitpick. But I'm open to any changes you'd like.
