### PR TITLE
Add test to javascript word count about counting special words

### DIFF
--- a/assignments/javascript/word-count/example.js
+++ b/assignments/javascript/word-count/example.js
@@ -1,12 +1,12 @@
 'use strict';
 
 module.exports = function (input) {
-  var counts = {};
+  var counts = Object.create(null);
   var tokens = String(input).match(/\b[a-z0-9]+\b/gi) || [];
 
   tokens.forEach(function (token) {
     var word = token.toLowerCase();
-    word in counts ? counts[word] += 1 : counts[word] =  1;
+    counts[word] = counts[word] ? counts[word] + 1 : 1;
   });
 
   return counts;

--- a/assignments/javascript/word-count/word-count_test.spec.js
+++ b/assignments/javascript/word-count/word-count_test.spec.js
@@ -2,32 +2,37 @@ var words = require('./word-count');
 
 describe("words()", function() {
   it("counts one word", function() {
-    var expectedCounts = { "word" : 1 };
+    var expectedCounts = { word: 1 };
     expect(words("word")).toEqual(expectedCounts);
   });
 
   xit("counts one of each", function() {
-    var expectedCounts = { "one": 1, "of": 1, "each": 1 };
+    var expectedCounts = { one: 1, of: 1, each: 1 };
     expect(words("one of each")).toEqual(expectedCounts);
   });
 
   xit("counts multiple occurrences", function() {
-    var expectedCounts = { "one" : 1, "fish" : 4, "two" : 1, "red" : 1, "blue" : 1 };
+    var expectedCounts = { one: 1, fish: 4, two: 1, red: 1, blue: 1 };
     expect(words("one fish two fish red fish blue fish")).toEqual(expectedCounts);
   });
 
   xit("ignores punctuation", function() {
-    var expectedCounts = { "car" : 1, "carpet" : 1, "as" : 1, "java" : 1, "javascript" : 1 };
+    var expectedCounts = { car: 1, carpet: 1, as: 1, java: 1, javascript: 1 };
     expect(words("car : carpet as java : javascript!!&@$%^&")).toEqual(expectedCounts);
   });
 
   xit("includes numbers", function() {
-    var expectedCounts = { "testing" : 2, "1" : 1, "2" : 1 };
+    var expectedCounts = { testing: 2, 1: 1, 2: 1 };
     expect(words("testing, 1, 2 testing")).toEqual(expectedCounts);
   });
 
   xit("normalizes case", function() {
-    var expectedCounts = { "go" : 3 };
+    var expectedCounts = { go: 3 };
     expect(words("go Go GO")).toEqual(expectedCounts);
+  });
+
+  xit("counts special words properly", function() {
+    var expectedCounts = { constructor: 2, prototype: 1, keys: 1 };
+    expect(words("constructor Constructor prototype keys")).toEqual(expectedCounts);
   });
 });


### PR DESCRIPTION
...specifically, words that are properties or methods on `Object.prototype`.

I think a good thing to point out in this exercise is that when you create a new JavaScript object with `{}` it inherits from `Object` so it has some properties and methods that one should be aware of. There are a couple of different techniques for avoiding naming collisions due to these inherited properties, and this exercise seems like a great opportunity to discuss those. What do you think?
