### PR TITLE
Cache apt and gem installs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,6 @@ script:
   - './test/erlang/check-exercises.sh'
 # - './test/scala/check-exercises.sh'
   - "! git grep ' $' -- \\*.rb | grep -v 'assignments/ruby/ocr-numbers/ocr_numbers_test.rb'"
+cache:
+  - bundler
+  - apt


### PR DESCRIPTION
We spend a lot of time in each travis run installing gems and apt
packages. We can speed this up a lot by caching them.
http://docs.travis-ci.com/user/caching/
