### PR TITLE
Make elixir word-count test unicode, hyphens, underscores

### DIFF
--- a/assignments/elixir/word-count/example.exs
+++ b/assignments/elixir/word-count/example.exs
@@ -6,7 +6,7 @@ defmodule Words do
       |> summarize
   end
 
-  defp to_words(sentence), do: List.flatten Regex.scan(%r{\w+}, sentence)
+  defp to_words(sentence), do: List.flatten Regex.scan(%r/[\p{L}\p{N}-]+/, sentence)
 
   defp summarize(words) do
     Enum.reduce words, HashDict.new, &add_count/2

--- a/assignments/elixir/word-count/word_count_test.exs
+++ b/assignments/elixir/word-count/word_count_test.exs
@@ -33,6 +33,21 @@ defmodule WordsTest do
     assert Words.count("testing, 1, 2 testing") == expected
   end
 
+  test "hyphens" do
+    expected = HashDict.new [{"co-operative", 1}]
+    assert Words.count("co-operative") == expected
+  end
+
+  test "ignore underscores" do
+    expected = HashDict.new [{"two", 1}, {"words", 1}]
+    assert Words.count("two_words") == expected
+  end
+
+  test "German" do
+    expected = HashDict.new [{"götterfunken", 1}, {"schöner", 1}, {"freude", 1}]
+    assert Words.count("Freude schöner Götterfunken") == expected
+  end
+
   test "normalize case" do
     expected = HashDict.new [{"go", 3}]
     assert Words.count("go Go GO") == expected


### PR DESCRIPTION
This is closer to the intention of counting real world words.
It also makes `\w` not work, which is good as it forces people to think about
what a word is.
