### PR TITLE
Sort ongoing by the last updated submission

### DIFF
--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -40,7 +40,7 @@ class User < ActiveRecord::Base
   end
 
   def ongoing
-    @ongoing ||= submissions.pending
+    @ongoing ||= active_submissions.order('updated_at DESC')
   end
 
   def submissions_on(exercise)

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -111,6 +111,22 @@ class UserTest < MiniTest::Unit::TestCase
     assert_equal ["s2"], user.ongoing.map(&:code)
   end
 
+  def test_user_ongoing_ordered_by_latest_updated
+    user = User.create
+    exercise = Exercise.new('ruby', 'one')
+
+    first = create_submission(exercise, :code => "s1", :updated_at => Date.yesterday)
+    second = create_submission(exercise, :code => "s2", :updated_at => Date.today)
+
+    user.submissions << second
+    user.submissions << first
+    user.save
+    user.reload
+
+    assert_equal second, user.ongoing.first
+    assert_equal first, user.ongoing.last
+  end
+
   def test_user_is_not_locksmith_by_default
     refute User.new.locksmith?
   end


### PR DESCRIPTION
This is a possible solution for bug #1369

This has the nice side-effect of retaining the same order in the navbar as it is in the dashboard. Which I think makes sense, show the "most recently updated" submissions.

Any thoughts?
