### PR TITLE
Fixing invalid test for 10 digits with letters

### DIFF
--- a/assignments/ruby/phone-number/phone_number_test.rb
+++ b/assignments/ruby/phone-number/phone_number_test.rb
@@ -52,7 +52,7 @@ class PhoneNumberTest < MiniTest::Unit::TestCase
 
   def test_invalid_when_10_digits_with_extra_letters
     skip
-    number = PhoneNumber.new("1a2a3a5a6a7a8a9a0a").number
+    number = PhoneNumber.new("1a2a3a4a5a6a7a8a9a0a").number
     assert_equal "0000000000", number
   end
 


### PR DESCRIPTION
`test_invalid_when_10_digits_with_extra_letters` is broken since it should test for 10 digits, but instead tests for 9.
