### PR TITLE
Update JavaScript word-count final test to only check for "constructor"

### DIFF
--- a/assignments/javascript/word-count/example.js
+++ b/assignments/javascript/word-count/example.js
@@ -1,12 +1,12 @@
 'use strict';
 
 module.exports = function (input) {
-  var counts = Object.create(null);
+  var counts = {};
   var tokens = String(input).match(/\b[a-z0-9]+\b/gi) || [];
 
   tokens.forEach(function (token) {
     var word = token.toLowerCase();
-    counts[word] = counts[word] ? counts[word] + 1 : 1;
+    counts[word] = counts.hasOwnProperty(word) ? counts[word] + 1 : 1;
   });
 
   return counts;

--- a/assignments/javascript/word-count/word-count_test.spec.js
+++ b/assignments/javascript/word-count/word-count_test.spec.js
@@ -31,8 +31,8 @@ describe("words()", function() {
     expect(words("go Go GO")).toEqual(expectedCounts);
   });
 
-  xit("counts special words properly", function() {
-    var expectedCounts = { constructor: 2, prototype: 1, keys: 1 };
-    expect(words("constructor Constructor prototype keys")).toEqual(expectedCounts);
+  xit("counts constructor", function() {
+    var expectedCounts = { constructor: 2 };
+    expect(words("constructor Constructor")).toEqual(expectedCounts);
   });
 });


### PR DESCRIPTION
My previous change to the tests implied that "prototype" and "keys" would cause the same issue as "constructor" in that an empty JavaScript object would return something other than `undefined` if you tried to access those properties. However, it turns out my assumption was incorrect, so I updated that final test to just test that the code correctly counts "constructor" as I know that special case exists. Sorry for the extra PR.  :/

``` javascript
$ node
> var counts = {};
> counts["constructor"]
[Function: Object]
> counts["prototype"]
undefined
> counts["keys"]
undefined
```

Also, I've noticed that in certain circumstances jasmine expects objects that it is comparing to have the `hasOwnProperty` method, and so in order to make sure the example will reliably pass the tests, I modified it slightly not to use `Object.create(null)`, but just `{}` and `hasOwnProperty` to ensure that the particular object instance has the property in question rather than using the square bracket syntax.
