### PR TITLE
Update scala.md

### DIFF
--- a/lib/v1.0/articles/help/setup/scala.md
+++ b/lib/v1.0/articles/help/setup/scala.md
@@ -1,7 +1,6 @@
-## Installing Scala
+## Installing [Scala](http://www.scala-lang.org)
 
 * [Download](http://www.java.com/en/) and install the Java runtime version 1.6 or later
-* [Download](http://www.scala-lang.org/download/) and install the latest version of Scala
 * [Download](http://www.scala-sbt.org/release/docs/Getting-Started/Setup.html) and install the Simple Build Tool (`sbt`)
 
 ## Running Tests


### PR DESCRIPTION
Removed an unnecessary step: Installing Scala.

SBT downloads all dependencies automatically including the scala compiler. The independently downloaded scala compiler by a user is not used in SBT by default.
