### PR TITLE
Apply clearfix so the first nit's first line doesn't wrap

### DIFF
--- a/lib/app/views/submissions/show.erb
+++ b/lib/app/views/submissions/show.erb
@@ -102,7 +102,7 @@
       <% if submission.nit_count == 1 %>
         <h2>1 Nitpick
       <% else %>
-      <h2><%= submission.nit_count %> Nitpicks
+      <h2 class="clearfix"><%= submission.nit_count %> Nitpicks
       <% end %>
     <% end %>
       <% if can_mute?(submission, current_user) %>


### PR DESCRIPTION
The form element inside the h2 element has 20px bottom margin and it's
floating, which in this case means it's expanding outside of its
container and causing the text from the first nit to wrap around it.
This makes the first line of the first nit wrap about half way across
the line.

Just applied bootstrap's clearfix class to the h2 to make the h2 expand
to contain the form. I could have adjusted the bottom margin on the
form, too, but it seems ok, especially with 1.0 coming soon.

Here's a screenshot before:

![wrapping](https://f.cloud.github.com/assets/689382/2290258/f96bfb20-a017-11e3-90c1-aa0b822cc843.png)

And devtools showing the margin:

![devtools](https://f.cloud.github.com/assets/689382/2290259/01ee6878-a018-11e3-8c8e-88f5c6d317c8.png)

And after applying the clearfix:

![with-clearfix](https://f.cloud.github.com/assets/689382/2290260/08c8af1e-a018-11e3-80f5-e1eff05ad427.png)
