### PR TITLE
Fix layout styles

### DIFF
--- a/lib/v1.0/public/css/hacks.css
+++ b/lib/v1.0/public/css/hacks.css
@@ -5,14 +5,6 @@
  * Feb 1, 2014, and should therefore not be touched
  */
 
-.aside-show .col-md-9 .section-content {
-  background-color: #fff;
-}
-
-.aside-show .col-md-9 #section-header, .aside-show .col-md-9 #section-content {
-  margin-left: 0;
-}
-
 .nav-list .nav-list.tree li.unread a .cat, .nav-list .nav-list.tree li.unread a .topic {
   font-family: 'source_code_probold';
 }

--- a/lib/v1.0/public/css/main.css
+++ b/lib/v1.0/public/css/main.css
@@ -563,7 +563,7 @@ h1, h2, h3{
 
 /* Navigation */
 #menu-tree{
-  margin: 40px -15px 20px;
+  margin: 40px 0 20px;
 }
 
 .nav-list {
@@ -879,7 +879,6 @@ h1, h2, h3{
 /* Section Header Code */
 #section-header.section-header-code{
   background-color: #212121;
-  margin-left: -15px;
   margin-right: 0;
 }
 
@@ -1069,18 +1068,20 @@ h1, h2, h3{
   z-index: 100;
 }
 
-.aside-show .col-md-9{
+.aside-show .section-main {
   background-color: #fff;
   float: left;
   overflow: hidden;
   padding-left: 264px;
   padding-right: 0;
+  position: relative;
   width: 100%;
 }
 
 /* User Account */
 #user-account{
   margin: 30px 0;
+  padding: 0 15px;
 }
 
 #user-account p{
@@ -1164,7 +1165,7 @@ h1, h2, h3{
     width: 230px;
   }
 
-  .aside-show .col-md-9{
+  .aside-show .section-main{
     padding-left: 230px;
   }
 

--- a/lib/v1.0/views/layout.haml
+++ b/lib/v1.0/views/layout.haml
@@ -17,12 +17,12 @@
     - else
       .row.aside-show.unstyled
 
-        %aside#sidebar-first.col-md-3
+        %aside#sidebar-first
           = haml :"layout/sidebar/profile"
           = haml :"layout/sidebar/alerts"
           = haml :"layout/sidebar/menu"
 
-        .col-md-9.section-main
+        .section-main
           = haml :"layout/topnav_user"
           .section-content
             = yield


### PR DESCRIPTION
Previously, a couple of UI issues were brought up that I believe were symptomatic of some repetitive CSS and overwrites. This PR attempts to remove some redundancy and unnecessary classes.

**Before:**
- Negative margins being used in layout that shouldn't be necessary.
- Margins applied to multiple elements in the main content instead of on the wrapper. This adds complexity especially when you bring media queries in...You have to remember to change values in multiple places.
- Sidebar appeared to stretch, but didn't really. This is a minor quibble.
- Using some bootstrap classes like `col-md-3` but overwriting the styles in `main.css` anyway

![before](https://f.cloud.github.com/assets/522911/2305551/57043388-a25c-11e3-848a-9152a484c461.jpg)

**After:**
- Remove negative margins.
- Only apply layout rules to the 2 major layout elements: sidebar and main content.
- Sidebar stretches all the way to bottom of the page instead of _looking_ like it does.
- Removed the need for 2 of the rules in the `hacks.css` file. :smile: 
- Get rid of the bootstrap classes, apply rules to existing classes

![after](https://f.cloud.github.com/assets/522911/2305557/8420211a-a25c-11e3-9224-13cb27fcebad.jpg)

**Possible future improvements:**
- If we install a CSS preprocessor, we can make some of the numbers (e.g., 240px) into variables and make it more clear that the padding is equal to the sidebar width (right now it might not seem so obvious)
