### PR TITLE
Sidebar overflow

### DIFF
--- a/lib/v1.0/public/css/main.css
+++ b/lib/v1.0/public/css/main.css
@@ -727,6 +727,7 @@ h1, h2, h3{
 .nav-list .nav-list.tree.detailed a{
   overflow: hidden;
   border-bottom: 1px solid #d9d9d9;
+  display: block;
   padding: 15px;
 }
 


### PR DESCRIPTION
Fixes 2 bugs in the sidebar:
- When a user had many notifications, the list overflowed out of the sidebar area
- The "Delete all read notifications" link was floating out of place

This PR adds a scrollbar to the sidebar when the notifications list is longer than the content area, and puts the delete notifications link back in its proper place.
