### PR TITLE
Add dropdown for users whose identity you can assume (for development on...

### DIFF
--- a/lib/app/auth.rb
+++ b/lib/app/auth.rb
@@ -4,7 +4,7 @@ class ExercismApp < Sinatra::Base
     redirect root_path
   end
 
-  if ENV['RACK_ENV'] == 'development'
+  if settings.development?
     get '/backdoor' do
       if User.count == 0
         flash[:error] = "You'll want to run the seed script: `rake db:seed`"

--- a/lib/app/site.rb
+++ b/lib/app/site.rb
@@ -3,6 +3,9 @@ require 'v1.0/site/languages'
 class ExercismApp < Sinatra::Base
 
   get '/' do
+    if settings.development?
+      @assumable_users = User.all
+    end
     if current_user.guest?
       current = App::Site::Languages.new(Exercism::Config.current)
       upcoming = App::Site::Languages.new(Exercism::Config.upcoming)

--- a/lib/app/views/auth/backdoor.erb
+++ b/lib/app/views/auth/backdoor.erb
@@ -1,4 +1,10 @@
 <% if settings.development? %>
-  <li><a href="/backdoor?id=1">be admin</a></li>
-  <li><a href="/backdoor?id=-1">be user</a></li>
+  <li class="dropdown">
+  <a href="#" class="dropdown-toggle" data-toggle="dropdown">be user <b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <% for user in @assumable_users %>
+      <li><a href="/backdoor?id=<%= user.github_id %>"><%= user.username %></a></li>
+    <% end %>
+  </ul>
+  </li>
 <% end %>


### PR DESCRIPTION
...ly)

For issue #1437 

This is pretty simple. The only thing of note is that I @ the variable assumable_users so that I don't have to keep passing locals around and accounting for development mode unnecessarily and I removed the "be admin" button.

Here's what it looks like now:

![screen shot 2014-03-12 at 11 01 40 pm](https://f.cloud.github.com/assets/100039/2406633/07fabbce-aa75-11e3-8147-87c3b746a9b1.png)

What do you think as a starting point? 
