### PR TITLE
Do not save submission if it has no slug

### DIFF
--- a/lib/exercism/use_cases/attempt.rb
+++ b/lib/exercism/use_cases/attempt.rb
@@ -28,6 +28,7 @@ class Attempt
   end
 
   def save
+    return false if slug.nil?
     user.submissions_on(exercise).each do |sub|
       sub.supersede!
       sub.unmute_all!

--- a/test/app/submissions_test.rb
+++ b/test/app/submissions_test.rb
@@ -282,4 +282,9 @@ class SubmissionsTest < MiniTest::Unit::TestCase
     assert_equal 'superseded', s1.reload.state
     assert_equal 'pending', s2.reload.state
   end
+
+  def test_do_not_save_submission_with_nil_slug
+    attempt = Attempt.new(alice, 'CODE', 'file.rb').save
+    assert_equal attempt, false
+  end
 end


### PR DESCRIPTION
This is what I have so far for #1463. `Attempt#save` returns `false` when you try to save a submission with no slug. Not sure if this should be an error message instead.

Currently, if a file has no file extension / language, there'll be an `UnknownLanguage` error on `#save`.
