### PR TITLE
Add jquery to v1.0 layout

### DIFF
--- a/lib/v1.0/views/layout/head.haml
+++ b/lib/v1.0/views/layout/head.haml
@@ -12,5 +12,6 @@
   %link{:href =>  link_to("/css/language-colors.css"), :rel => "stylesheet"}/
   %link{:href =>  link_to("/css/easydropdown.css"), :rel => "stylesheet"}/
   %link{:href =>  link_to("/favicon.ico"), :rel => "shortcut icon"}/
+  %script{:src => link_to("/js/vendor/jquery-1.10.1.min.js")}
   %script{:src => link_to("/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js")}
   %script{:src => link_to("/js/vendor/jquery.easydropdown.min.js")}


### PR DESCRIPTION
I'm getting errors both locally and remotely regarding jQuery not
being found. Which appears to be the case. I just added a reference
to it first. Maybe I'm missing something, but it does get rid of the
errors.
