### PR TITLE
Update AR and AS to 4.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,9 @@ source "http://rubygems.org"
 
 ruby "2.0.0"
 
-gem 'activerecord', '~> 4.0'
+gem 'activesupport', '~> 4.0.4'
+gem 'activerecord', '~> 4.0.4'
+
 gem 'faraday'
 gem 'haml', require: false
 gem 'sass'
@@ -36,4 +38,3 @@ group :test, :development do
   gem 'sqlite3'
   gem 'timecop', require: false
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (4.0.3)
-      activesupport (= 4.0.3)
+    activemodel (4.0.4)
+      activesupport (= 4.0.4)
       builder (~> 3.1.0)
-    activerecord (4.0.3)
-      activemodel (= 4.0.3)
+    activerecord (4.0.4)
+      activemodel (= 4.0.4)
       activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.3)
+      activesupport (= 4.0.4)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.3)
-    activesupport (4.0.3)
-      i18n (~> 0.6, >= 0.6.4)
+    activesupport (4.0.4)
+      i18n (~> 0.6, >= 0.6.9)
       minitest (~> 4.2)
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
@@ -20,7 +20,7 @@ GEM
       nokogiri (~> 1.6)
       thor (~> 0.18)
     arel (4.0.2)
-    atomic (1.1.15)
+    atomic (1.1.16)
     builder (3.1.4)
     coderay (1.1.0)
     coveralls (0.7.0)
@@ -55,7 +55,7 @@ GEM
     minitest (4.7.5)
     mocha (1.0.0)
       metaclass (~> 0.0.1)
-    multi_json (1.9.0)
+    multi_json (1.9.2)
     multipart-post (2.0.0)
     newrelic_rpm (3.7.3.199)
     nokogiri (1.6.1)
@@ -100,7 +100,7 @@ GEM
     term-ansicolor (1.2.2)
       tins (~> 0.8)
     thor (0.18.1)
-    thread_safe (0.2.0)
+    thread_safe (0.3.1)
       atomic (>= 1.1.7, < 2)
     tilt (1.4.1)
     timecop (0.7.1)
@@ -108,7 +108,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.38)
+    tzinfo (0.3.39)
     will_paginate (3.0.5)
     will_paginate-bootstrap (1.0.0)
       will_paginate (>= 3.0.3)
@@ -117,7 +117,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 4.0)
+  activerecord (~> 4.0.4)
+  activesupport (~> 4.0.4)
   approvals
   coveralls
   database_cleaner


### PR DESCRIPTION
Before updating ruby to 2.1.1 (#1522) . We need to make sure we are running AR, AS 4.0.4+.

read this http://blog.sorah.jp/2014/03/10/hash-reject-regression-in-ruby211
