### PR TITLE
Adds info about installing coffee for node

### DIFF
--- a/lib/redesign/articles/help/setup/coffeescript.md
+++ b/lib/redesign/articles/help/setup/coffeescript.md
@@ -2,11 +2,12 @@
 
 Make sure you have [Node.js installed](http://nodejs.org/) [via package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)
 
-Install jasmine-node:
+Install jasmine-node and coffee:
 
 ```bash
-$ npm install jasmine-node -g
+$ npm install jasmine-node coffee -g
 ```
+
 
 Update your `PATH` to include the npm binaries by adding the following to either `~/.bash_profile` or `~/.zshrc`:
 


### PR DESCRIPTION
The page is titled "Installing Coffeescript", yet only node + jasmine was handled. Coffee doesn't come by default, so this could cause confusion for less experienced users
