### PR TITLE
Fix for Issue #1594

### DIFF
--- a/lib/exercism/config.rb
+++ b/lib/exercism/config.rb
@@ -5,7 +5,7 @@ class Exercism
         clojure: 'Clojure',
         coffeescript: 'CoffeeScript',
         csharp: 'C#',
-        elixir: 'Elixer',
+        elixir: 'Elixir',
         go: 'Go',
         haskell: 'Haskell',
         javascript: 'JavaScript',


### PR DESCRIPTION
Fix for Issue:  Elixir is spelled incorrectly in the help #1594
