### PR TITLE
Fix link to the help page

### DIFF
--- a/lib/app/views/site/getting-started.haml
+++ b/lib/app/views/site/getting-started.haml
@@ -13,7 +13,7 @@
       Based on their comments, revise your code and resubmit.
     %p
       For information on installing the command-line client and setting up exercises check out
-      %a{:href => link_to('http://help.exercism.io/installing-the-cli.html')} the Help Section.
+      %a{:href => 'http://help.exercism.io/installing-the-cli.html'} the Help Section.
 
 %article.article-block
   %div.article-contents


### PR DESCRIPTION
String was already a link, calling `link_to` turned it into a local link (`http://exercism.io/http://help.exercism.io/installing-the-cli.html`)
