### PR TITLE
Changed the width of 'pre' from fixed value to percentage so that it shows correctly in mobile view

### DIFF
--- a/frontend/app/css/style.css
+++ b/frontend/app/css/style.css
@@ -300,7 +300,7 @@ h2 .next-submission {
 .content-secondary-details pre {
   background: #fff;
   margin: 0 auto;
-  width: 580px;
+  width: 50%;
 }
 
 .clipboard-paste {

--- a/lib/app/public/css/app.css
+++ b/lib/app/public/css/app.css
@@ -7729,7 +7729,7 @@ h2 .next-submission {
 .content-secondary-details pre {
   background: #fff;
   margin: 0 auto;
-  width: 580px;
+  width: 50%;
 }
 
 .clipboard-paste {


### PR DESCRIPTION
I was looking at the website on my phone (Chrome on Nexus 5) and the 'Try it' section CSS was weird. It was something like: 

![exercismmobilebroken](https://cloud.githubusercontent.com/assets/667114/3422581/f5edbf20-ff4d-11e3-85b4-410c6f496ba2.jpg)
## Change

_The minor fix just changes the fixed width of the element to a relative 50% width. With this change, it will now look something like_:

![exercismmobilefixed](https://cloud.githubusercontent.com/assets/667114/3422580/f5ed5d1e-ff4d-11e3-8428-cb4f5d2416ef.jpg)

I've tested this with local exercism.io setup.

@kytrinyx
