### PR TITLE
fix tilt warning

### DIFF
--- a/test/acceptance/static_page_test.rb
+++ b/test/acceptance/static_page_test.rb
@@ -1,4 +1,5 @@
 require_relative '../acceptance_helper'
+require 'haml'
 
 class StaticPageTest < AcceptanceTestCase
   def test_homepage_exists


### PR DESCRIPTION
Running the test suite produced the warning: "WARN: tilt autoloading 'haml' in a non thread-safe way; explicit require 'haml' suggested." Requiring haml in the test/acceptance/static_page_test gets rid of this warning.
