### PR TITLE
Give each view a page header.

### DIFF
--- a/frontend/app/css/typography.css
+++ b/frontend/app/css/typography.css
@@ -1,0 +1,39 @@
+/*
+---------------------------------
+| Exercism.IO # Typography
+---------------------------------
+*/
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Source Code Pro', sans-serif;
+  font-weight: 100;
+  margin-bottom: 15px;
+}
+
+h1 {
+  font-size: 32px;
+}
+
+h2 {
+  font-size: 30px;
+}
+
+h3 {
+  font-size: 28px;
+}
+
+h4 {
+  font-size: 26px;
+}
+
+h5 {
+  font-size: 24px;
+}
+
+h6 {
+  font-size: 22px;
+}
+
+p {
+  margin: 0 0 20px;
+}

--- a/lib/app/public/css/app.css
+++ b/lib/app/public/css/app.css
@@ -7787,4 +7787,44 @@ h2 .next-submission {
   height: 16px;
 }
 
+/*
+---------------------------------
+| Exercism.IO # Typography
+---------------------------------
+*/
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Source Code Pro', sans-serif;
+  font-weight: 100;
+  margin-bottom: 15px;
+}
+
+h1 {
+  font-size: 32px;
+}
+
+h2 {
+  font-size: 30px;
+}
+
+h3 {
+  font-size: 28px;
+}
+
+h4 {
+  font-size: 26px;
+}
+
+h5 {
+  font-size: 24px;
+}
+
+h6 {
+  font-size: 22px;
+}
+
+p {
+  margin: 0 0 20px;
+}
+
 /*# sourceMappingURL=app.css.map */

--- a/lib/app/routes/metadata.rb
+++ b/lib/app/routes/metadata.rb
@@ -14,7 +14,7 @@ module ExercismWeb
         _, response = Xapi.get("assignments", language, slug)
         exercise = JSON.parse(response)["assignments"].first
         text = exercise["files"].find {|key, value| key == "README.md"}.last
-        erb :"exercises/readme", locals: {text: text}
+        erb :"exercises/readme", locals: {text: text, exercise: exercise}
       end
     end
   end

--- a/lib/app/views/account/show.erb
+++ b/lib/app/views/account/show.erb
@@ -1,11 +1,12 @@
 <div class="container">
-  <h1>Account</h1>
+  <section class="page-header">
+    <h1>Account</h1>
+  </section>
   <div class="row">
     <div class="span8">
-
       <h2>Teams</h2>
       <% if profile.has_teams? %>
-        <ul>
+        <ul class="nav nav-tabs nav-stacked">
           <% profile.teams.each do |team| %>
             <li>
               <% if team.unconfirmed_members.include?(profile.user) %>
@@ -38,7 +39,7 @@
       <% end %>
 
       <h2>Exercises</h2>
-      <h3>Current</h3>
+      <h6>Current</h6>
       <% if profile.has_current_submissions? %>
         <table class="table table-bordered table-striped">
           <thead>
@@ -65,7 +66,7 @@
       <% end %>
 
       <% if profile.has_hibernating_submissions? %>
-        <h3>Hibernating</h3>
+        <h6>Hibernating</h6>
         <p>To make a hibernating exercise active again, either comment on it, or submit a new iteration.</p>
         <table class="table table-bordered table-striped">
           <thead>
@@ -89,32 +90,8 @@
         </table>
       <% end %>
 
-    </div>
-
-    <div class="span4">
-      <dl>
-        <dt>Api key:</dt>
-        <dd><%= current_user.key %></dd>
-      </dl>
-      <p>You can update your <%= gravatar_tag current_user.avatar_url %> Gravatar on
-        <a href="http://www.gravatar.com/">the Gravatar website.</a></p>
-      <p>
-        The following email address will be used to send you notifications. If you do not want notifications, delete your email address and click update.
-        <form action="/account/email" method="post">
-          <input type="hidden" name="_method" value="put" />
-          <div class="input-append">
-            <input type="email" id="email" name="email" placeholder="Email" value="<%= current_user.email %>" />
-            <input type="submit" name="update" value="Update" class="btn" />
-          </div>
-        </form>
-      </p>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="span12">
-      <h3>Completed</h3>
       <% if profile.has_completed_submissions? %>
+        <h6>Completed</h6>
         <table class="table table-bordered table-striped">
           <col />
           <col width="100%" />
@@ -142,6 +119,26 @@
       <% else %>
         <p><%= profile.no_completed_sumbissions_message %></p>
       <% end %>
+
+    </div>
+
+    <div class="span4">
+      <dl>
+        <dt>Api key:</dt>
+        <dd><%= current_user.key %></dd>
+      </dl>
+      <p>You can update your <%= gravatar_tag current_user.avatar_url %> Gravatar on
+        <a href="http://www.gravatar.com/">the Gravatar website.</a></p>
+      <p>
+        The following email address will be used to send you notifications. If you do not want notifications, delete your email address and click update.
+        <form action="/account/email" method="post">
+          <input type="hidden" name="_method" value="put" />
+          <div class="input-append">
+            <input type="email" id="email" name="email" placeholder="Email" value="<%= current_user.email %>" />
+            <input type="submit" name="update" value="Update" class="btn" />
+          </div>
+        </form>
+      </p>
     </div>
   </div>
 </div>

--- a/lib/app/views/auth/please_login.erb
+++ b/lib/app/views/auth/please_login.erb
@@ -1,6 +1,7 @@
 <div class="container">
-  <h1>Please login</h1>
+  <section class="page-header">
+    <h1>Please Log In</h1>
+  </section>
   <p>You need to authenticate via github in order to go there.</p>
-
   <p><a class='btn btn-large btn-success home' href="<%= login_url(return_path) %>">Log in via GitHub</a></p>
 </div>

--- a/lib/app/views/code/random.erb
+++ b/lib/app/views/code/random.erb
@@ -1,11 +1,13 @@
 <div class="container">
+  <section class="page-header">
+    <h1>
+      <%= submission.language.capitalize %>:
+      <%= submission.exercise.name %>
+    </h1>
+  </section>
   <div class="row">
     <div class="code span12">
-      <h1>
-        <%= submission.language.capitalize %>:
-        <%= submission.exercise.name %>
-      </h1>
-      <p>
+      <p class="well">
       <% if total == 1 %>
       You are seeing the only available implementation of the exercise.
       <% elsif total > 1 %>

--- a/lib/app/views/exercises/readme.erb
+++ b/lib/app/views/exercises/readme.erb
@@ -1,3 +1,9 @@
 <div class="container">
+  <section class="page-header">
+  <h1>
+    README:
+    <small><%= exercise["slug"] %> in <%= exercise["track"] %></small>
+  </h1>
+  </section>
   <%= md(text) %>
 </div>

--- a/lib/app/views/exercises/test_suite.erb
+++ b/lib/app/views/exercises/test_suite.erb
@@ -1,4 +1,8 @@
 <div class="container">
-  <h1><%= slug%> in <%= language %></h1>
+  <section class="page-header">
+    <h1>Test Suite:
+      <small><%= slug %> in <%= language %></small>
+    </h1>
+  </section>
   <%= md(text, language) %>
 </div>

--- a/lib/app/views/layout.erb
+++ b/lib/app/views/layout.erb
@@ -7,6 +7,7 @@
     <meta content='' name='description'>
     <meta content='' name='author'>
     <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet">
+    <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro:300,400,700' rel='stylesheet' type='text/css'>
     <link href='/icons/favicon.ico?v=4' rel='shortcut icon'>
     <link href='/css/app.css?v=2' rel='stylesheet'>
   </head>

--- a/lib/app/views/layout.haml
+++ b/lib/app/views/layout.haml
@@ -12,6 +12,7 @@
     %meta{:content => "", :name => "description"}/
     %meta{:content => "width=device-width, initial-scale=1.0", :name => "viewport"}/
     %link{:href => href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css", :rel => "stylesheet"}/
+    %link{:href => href="http://fonts.googleapis.com/css?family=Source+Code+Pro:300,400,700", :rel => "stylesheet"}/
     %link{:href => link_to("/css/app.css?v=2"), :rel => "stylesheet"}/
     %link{:href => link_to("/icons/favicon.ico?v=4"), :rel => "shortcut icon"}/
   %body

--- a/lib/app/views/looks/index.erb
+++ b/lib/app/views/looks/index.erb
@@ -1,15 +1,24 @@
 <div class="container">
-  <h3>Recently Viewed</h3>
-
-  <% if looks.empty? %>
-    <p>No exercises viewed in the past 2 days.</p>
-  <% else %>
-    <ul>
-      <% looks.each do |look| %>
-        <li>
-          <a href="<%= look.path %>"><%= look.name %></a> (<%= look.language %>) by <%= look.username %>
-        </li>
-      <% end %>
-    </ul>
-  <% end %>
+  <section class="page-header">
+    <h1>Recently Viewed</h1>
+  </section>
+  <section>
+    <div class="row">
+      <div class="span6">
+        <% if looks.empty? %>
+          <p>No exercises viewed in the past 2 days.</p>
+        <% else %>
+          <ul class="nav nav-tabs nav-stacked">
+            <% looks.each do |look| %>
+              <li>
+                <a href="<%= look.path %>">
+                  <%= look.name %> (<%= look.language %>) by <%= look.username %>
+                </a>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+    </div>
+  </section>
 </div>

--- a/lib/app/views/not_found.erb
+++ b/lib/app/views/not_found.erb
@@ -1,6 +1,9 @@
 <div class="container">
-  <h1>404 - Not Found</h1>
-
-  <p>We don't have that but we have some other really nice things.</p>
-  <p>Perhaps you were looking for some long-form explanations about <a href="/about">what exercism is about</a> or <a href="/help/nitpick">how to nitpick</a>?</p>
+  <section class="page-header">
+    <h1>404 - Not Found</h1>
+  </section>
+  <section>
+    <p>We don't have that but we have some other really nice things.</p>
+    <p>Perhaps you were looking for some long-form explanations about <a href="/about">what exercism is about</a> or <a href="/help/nitpick">how to nitpick</a>?</p>
+  </section>
 </div>

--- a/lib/app/views/notifications/index.erb
+++ b/lib/app/views/notifications/index.erb
@@ -1,4 +1,7 @@
 <div class="container">
+  <section class="page-header">
+    <h1>Notifications (<%= inbox.count %>)</h1>
+  </section>
   <div class="row">
     <div class="span6">
 
@@ -10,15 +13,13 @@
       </form>
       <% end %>
 
-      <h2>Notifications (<%= inbox.count %>)</h2>
-
       <% unless inbox.has_stuff? %>
         <p>Notifications tell you about new comments or iterations in conversations that you are participating in. If you are on a team, you will also get notifications about activity from your team members.</p>
         <p>At the moment this is not configurable.</p>
         <p>You will also receive system-level alerts here, such as team invitations or notifications about feature changes on the site.</p>
       <% end %>
 
-      <p>Are you looking for a discussion you recently viewed? There's a <a href="/looks">list of these</a> available.</p>
+      <p class="well">Are you looking for a discussion you recently viewed? There's a <a href="/looks">list of these</a> available.</p>
 
       <% if inbox.has_alerts? %>
         <ul style="list-style-type: none; margin: 0;">
@@ -28,7 +29,9 @@
             <form action="/notifications/alert-<%= alert.id %>" method='POST' style="float: right; padding-left: 10px;">
               <input type="hidden" name="_method" value="delete">
               <div>
-                <button type="submit" class="btn btn-danger" name="delete">x</button>
+                <button type="submit" class="btn btn-danger" name="delete">
+                  <i class="icon-remove"></i> 
+                </button>
               </div>
             </form>
             <%= alert.text %>

--- a/lib/app/views/site/about.erb
+++ b/lib/app/views/site/about.erb
@@ -1,11 +1,13 @@
 <div class="container">
+  <section class="page-header">
+    <h1>About</h1>
+  </section>
   <section class="main">
     <article class="article-block">
       <div class="article-contents">
-        <h2 class="header">About</h2>
         <p>Exercism provides a space to have thoughtful conversations about code. Explore simplicity, idiomatic language features, and expressive readable code.</p>
 
-        <h4>Practice</h4>
+        <h2>Practice</h2>
         <ul class="list">
           <li>
             Practice writing expressive code.
@@ -18,11 +20,11 @@
           </li>
         </ul>
 
-        <h4>Conversations</h4>
+        <h2>Conversations</h2>
         <p>The code is a conversation starter. The interesting part begins when you begin having discussions with your peers about the nuances that you see. What do you like? What do they dislike? What are the trade-offs? How can the code be improved?</p>
         <p>Curious about what this might look like? <a href="/conversations/1">See this conversation</a> that happened on the Ruby track.</p>
 
-        <h4>Open Source</h4>
+        <h2>Open Source</h2>
         <p>Contributing to open source can be very intimidating. It's scary to put your code in front of strangers. It's terrifying to be presented with problems that you probably don't understand, and don't know how to trouble-shoot.</p>
       </div>
     </article>

--- a/lib/app/views/site/dashboard.erb
+++ b/lib/app/views/site/dashboard.erb
@@ -22,19 +22,20 @@
     <h3>Wondering where to start?</h3>
     <p>The <a href="http://help.exercism.io">help site</a> should get you going. If you get stuck, <a href="mailto:kytrinyx@exercism.io">email me</a>!</p>
   <% else %>
-
+  <section class="page-header">
+    <h1>Dashboard</h1>
+  </section>
   <div class="row">
     <div class="span4">
       <% if current_user.ongoing.any? %>
         <h4>Current Exercises</h4>
-        <ul>
+        <ul class="nav nav-tabs nav-stacked">
           <% current_user.ongoing.each do |submission| %>
             <li>
-              <p>
-                <a href="/submissions/<%= submission.key %>">
-                  <%= submission.language.capitalize + ': ' + submission.slug %>
-                </a> (iteration: <%= submission.version %>, nits: <%= submission.nit_count %>)
-              </p>
+              <a href="/submissions/<%= submission.key %>">
+                <%= submission.language.capitalize + ': ' + submission.slug %>
+                (iteration: <%= submission.version %>, nits: <%= submission.nit_count %>)
+              </a>
             </li>
           <% end %>
         </ul>

--- a/lib/app/views/site/getting-started.haml
+++ b/lib/app/views/site/getting-started.haml
@@ -1,4 +1,6 @@
 %div.container
+  %section.page-header
+    %h1 Getting Started
   %article.article-block
     %div.article-contents
       %h2.header Exercises

--- a/lib/app/views/site/privacy.erb
+++ b/lib/app/views/site/privacy.erb
@@ -1,14 +1,13 @@
 <div class="container">
-  <h1>Privacy</h1>
-
-  <p>This is not a legal document, it's an overview of what personal information we have and why.</p>
-
-  <p>When you sign up with github, we save your email address (if it is public), your github user id, your github username, and the link to your gravatar picture.</p>
-
-  <p>You may delete your email address on your account page.</p>
-
-  <p>We use your email address to send notifications (for example, when someone nitpicks your code).</p>
-
-  <p>That's it. We will never, ever give your email address to anyone, because that would be a real jerk-move.</p>
+  <section class="page-header">
+    <h1>Privacy</h1>
+  </section>
+  <section>
+    <p>This is not a legal document, it's an overview of what personal information we have and why.</p>
+    <p>When you sign up with github, we save your email address (if it is public), your github user id, your github username, and the link to your gravatar picture.</p>
+    <p>You may delete your email address on your account page.</p>
+    <p>We use your email address to send notifications (for example, when someone nitpicks your code).</p>
+    <p>That's it. We will never, ever give your email address to anyone, because that would be a real jerk-move.</p>
+  </section>
 </div>
 

--- a/lib/app/views/stats/show.erb
+++ b/lib/app/views/stats/show.erb
@@ -1,5 +1,7 @@
 <div class="container">
-  <h1><%= namify(trail) %></h1>
+  <section class="page-header">
+    <h1>Stats: <small><%= namify(trail) %></small></h1>
+  </section>
 
   <ul class="nav nav-tabs">
     <% languages.each do |language| %>

--- a/lib/app/views/submissions/byline.erb
+++ b/lib/app/views/submissions/byline.erb
@@ -1,8 +1,8 @@
-<h1>
-  <%= exercise.slug %>
-  <small>in <%= exercise.language %></small>
-</h1>
-<p>
-  <%= gravatar_tag user.avatar_url, size: 30 %>
+<section class="page-header">
+  <h1>
+    <%= exercise.slug %>
+    <small>in <%= exercise.language %></small>
+  </h1>
+  submitted by <%= gravatar_tag user.avatar_url, size: 30 %>
   <%= profile_link(user) %>
-</p>
+</section>

--- a/lib/app/views/submissions/edit_nit.erb
+++ b/lib/app/views/submissions/edit_nit.erb
@@ -1,15 +1,19 @@
 <div class="container">
-  <form action="/submissions/<%= submission.key %>/nits/<%= nit.id %>" method='POST'>
-    <textarea name="body" class="span6 offset3" rows="10"><%= nit.body %></textarea>
-    <div>
-      <button type="submit" class="btn btn-primary">Submit</button>
-    </div>
-  </form>
-
-  <form action="/submissions/<%= submission.key %>/nits/<%= nit.id %>" method='POST'>
-    <input type="hidden" name="_method" value="delete">
-    <div>
-      <button type="submit" class="btn btn-danger" name="delete">Delete</button>
-    </div>
-  </form>
+  <section class="page-header">
+    <h1>Edit Nitpick</h1>
+  </section>
+  <section>
+    <form action="/submissions/<%= submission.key %>/nits/<%= nit.id %>" method='POST'>
+      <textarea name="body" class="span6 offset3" rows="10"><%= nit.body %></textarea>
+      <div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+      </div>
+    </form>
+    <form action="/submissions/<%= submission.key %>/nits/<%= nit.id %>" method='POST'>
+      <input type="hidden" name="_method" value="delete">
+      <div>
+        <button type="submit" class="btn btn-danger" name="delete">Delete</button>
+      </div>
+    </form>
+  </section>
 </div>

--- a/lib/app/views/teams/new.erb
+++ b/lib/app/views/teams/new.erb
@@ -1,15 +1,35 @@
 <div class="container">
-  <h1>Create a Team</h1>
-  <form accept-charset="UTF-8" action="/teams" method="POST">
-    <% team.errors.full_messages.each do |error| %>
-    <p class="error"><%= error %></p>
-    <% end %>
-    <label for="team_slug">Slug</label>
-    <input type="text" name="team[slug]" id="team_slug" placeholder="e.g. gocowboys" value="<%= team.slug %>">
-    <label for="team_name">Name (optional; defaults to slug)</label>
-    <input type="text" name="team[name]" id="team_name" placeholder="e.g. Go Cowboys" value="<%= team.name %>">
-    <label for="team_usernames">Usernames (comma-separated list)</label>
-    <textarea name="team[usernames]" id="team_usernames" placeholder="e.g. kytrinyx, seeflanigan, rubysolo, theotherzach"><%= team.usernames.join(", ") %></textarea>
-    <button type="submit" class="btn btn-primary">Save</button>
-  </form>
+  <section class="page-header">
+    <h1>Create a Team</h1>
+  </section>
+  <section>
+    <div class="row">
+      <div class="span8">
+        <form accept-charset="UTF-8" action="/teams" method="POST">
+          <% team.errors.full_messages.each do |error| %>
+          <p class="error"><%= error %></p>
+          <% end %>
+          <div class="control-group">
+            <label class="control-label" for="team_slug">Slug</label>
+            <div class="controls">
+              <input type="text" name="team[slug]" id="team_slug" placeholder="e.g.,  gocowboys" value="<%= team.slug %>">
+            </div>
+          </div>
+          <div class="control-group">
+            <label class="control-group" for="team_name">Name (optional; defaults to slug)</label>
+            <div class="controls">
+              <input type="text" name="team[name]" id="team_name" placeholder="e.g.,  Go Cowboys" value="<%= team.name %>">
+            </div>
+          </div>
+          <div class="control-group">
+            <label class="control-group" for="team_usernames">Usernames (comma-separated list)</label>
+            <div class="controls">
+              <textarea rows="5" name="team[usernames]" id="team_usernames" placeholder="e.g.,  kytrinyx, seeflanigan, rubysolo, theotherzach"><%= team.usernames.join(", ") %></textarea>
+            </div>
+          </div>
+          <button type="submit" class="btn btn-primary">Save</button>
+        </form>
+      </div>
+    </div>
+  </section>
 </div>

--- a/lib/app/views/teams/show.erb
+++ b/lib/app/views/teams/show.erb
@@ -1,8 +1,7 @@
 <div class="container">
-  <h1>
-    Team <%= h(team.name) %>
-  </h1>
-
+  <section class="page-header">
+    <h1>Team <%= h(team.name) %></h1>
+  </section>
   <% if team.managed_by?(current_user) %>
     <a href="#" id="edit_team" class="btn btn-small">Edit</a>
     <a href="#" id="destroy_team" class="btn btn-small btn-danger" data-team=<%= team.slug %>>Destroy</a>

--- a/lib/app/views/user/history.erb
+++ b/lib/app/views/user/history.erb
@@ -1,5 +1,7 @@
 <div class="container">
-  <h2>Your Nits</h2>
+  <section class="page-header">
+    <h1>Your Nits</h1>
+  </section>
 
   <% if nitpicks.any? %>
     <table class="table table-bordered table-striped">

--- a/lib/app/views/user/nitstats.erb
+++ b/lib/app/views/user/nitstats.erb
@@ -1,8 +1,12 @@
 <div class="container">
+  <section class="page-header">
+    <h1>Nit Stats: <small><%= user.username %></small></h1>
+  </section>
   <div class="row">
     <div class="span8">
-      <h1>Nit Stats - <%= user.username %></h1>
-      <h3>Nits picked v. nits received over the past 30 days</h3>
+      <p class="well">
+        Nits picked v. nits received over the past 30 days
+      </p>
       <ul class="graph-legend">
         <li class="nits-picked">Nits picked</li>
         <li class="nits-received">Nits received</li>

--- a/lib/app/views/user/show.erb
+++ b/lib/app/views/user/show.erb
@@ -1,13 +1,12 @@
 <div class="container">
+  <section class="page-header">
+    <h1><%= profile.username %></h1>
+  </section>
   <div class="row">
     <div class="span8">
-
-      <h1><%= profile.username %></h1>
       <p>GitHub Profile: <%= profile.github_link %></p>
-
       <h3>Exercises</h3>
-
-      <h4>Current</h4>
+      <h6>Current</h6>
       <% if profile.has_current_submissions? %>
         <table class="table table-bordered table-striped">
           <thead>
@@ -34,10 +33,9 @@
       <% end %>
     </div>
   </div>
-
   <div class="row">
     <div class="span12">
-      <h4>Completed</h4>
+      <h6>Completed</h6>
       <% if profile.has_completed_submissions? %>
         <table class="table table-bordered table-striped">
           <col />


### PR DESCRIPTION
I thought it might be nice to give each view a dedicated "page header." This allows the view to clearly communicate its purpose with some header text. I elected to use the "Source Code Pro" font for headers, as it is used on the help subdomain. I don't think a page header is necessary for every view (especially as the UI evolves), but it may be helpful for the time being.
#### Before

![before](https://cloud.githubusercontent.com/assets/2092395/3490448/948e9c72-056a-11e4-8ef0-fd88fb208f86.png)
#### After

![after](https://cloud.githubusercontent.com/assets/2092395/3490449/9b269eb8-056a-11e4-8245-19bfe1c0fdcf.png)
