### PR TITLE
Render custom view when 500 error is encountered. Attempts to fix #1628.

### DIFF
--- a/frontend/app/css/style.css
+++ b/frontend/app/css/style.css
@@ -12,6 +12,11 @@
   text-align: center;
 }
 
+.block-image {
+  display: block;
+  margin: 20px auto;
+}
+
 .screen-reader-text {
   position: absolute;
   top: -9999px;
@@ -116,6 +121,36 @@ h1.home-top-header {
 .content-secondary-details pre {
   background: #eee;
 }
+
+/*
+| Server Error
+--------------------------------- */
+
+.server-error-container {
+  margin: 70px auto;
+  max-width: 700px;
+}
+
+.server-error-container img {
+  height: 150px;
+  margin: 40px auto;
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  width: 150px;
+}
+
+.server-error-container p {
+  line-height: 30px;
+}
+
+.server-error-featured-message {
+  display: inline-block;
+  font-size: 18px;
+  font-style: italic;
+}
+
 
 
 /*APPLICATION*/

--- a/lib/app/public/css/app.css
+++ b/lib/app/public/css/app.css
@@ -7488,6 +7488,11 @@ td.gutter {
   text-align: center;
 }
 
+.block-image {
+  display: block;
+  margin: 20px auto;
+}
+
 .screen-reader-text {
   position: absolute;
   top: -9999px;
@@ -7592,6 +7597,36 @@ h1.home-top-header {
 .content-secondary-details pre {
   background: #eee;
 }
+
+/*
+| Server Error
+--------------------------------- */
+
+.server-error-container {
+  margin: 70px auto;
+  max-width: 700px;
+}
+
+.server-error-container img {
+  height: 150px;
+  margin: 40px auto;
+  transform: rotate(45deg);
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  width: 150px;
+}
+
+.server-error-container p {
+  line-height: 30px;
+}
+
+.server-error-featured-message {
+  display: inline-block;
+  font-size: 18px;
+  font-style: italic;
+}
+
 
 
 /*APPLICATION*/

--- a/lib/app/routes/core.rb
+++ b/lib/app/routes/core.rb
@@ -5,6 +5,12 @@ module ExercismWeb
         set :root, Exercism.relative_to_root('lib', 'app')
         set :environment, ENV.fetch('RACK_ENV') { :development }.to_sym
         set :method_override, true
+        # View 500 error page in development
+        # disable :show_exceptions
+      end
+
+      error 500 do
+        erb :"errors/internal"
       end
 
       use Rack::Flash

--- a/lib/app/views/errors/internal.erb
+++ b/lib/app/views/errors/internal.erb
@@ -1,0 +1,17 @@
+<div class="container">
+  <section class="contain-centered server-error-container">
+    <h1>Sorry! That's our fault!</h1>
+    <img src="/img/e.png" class="block-image">
+    <p>
+      If you'd like to provide information about this error or request help, please
+      visit our <a href="https://github.com/exercism/exercism.io/issues">GitHub issues page</a>.
+      You can also email Katrina directly at <a href="mailto:kytrinyx@exercism.io">kytrinyx@exercism.io</a>.
+      Finally, you can visit our docs website at <a href="http://help.exercism.io">help.exercism.io</a>.
+    </p>
+    <p>~</p>
+    <p class="server-error-featured-message">
+      The awesome folks at Bugsnag have captured this error and notified us
+      (<a href="https://bugsnag.com/blog/bugsnag-loves-open-source">for free</a>).
+    </p>
+  </section>
+</div>


### PR DESCRIPTION
This is an initial attempt at fixing the 500 error issue. In development, I had to disable :show_exceptions in the Sinatra configure block. (This has been commented out for production.) I'm not sure if this implementation will interfere with Bugsnag's error capturing.

![500](https://cloud.githubusercontent.com/assets/2092395/3518793/fd9b17be-0708-11e4-86f4-4672d009bd62.png)
