### PR TITLE
Prettify the navbar when browsing on mobile devices.

### DIFF
--- a/frontend/app/css/style.css
+++ b/frontend/app/css/style.css
@@ -41,6 +41,16 @@ div.navbar-inner {
   padding-left: 2em;
 }
 
+@media (max-width: 979px) {
+  .navbar .nav > li:first-child > a {
+    margin-left: 0;
+  }
+}
+
+.navbar .navbar-inner > a.btn-navbar {
+  margin-top: 8px;
+}
+
 /*
 | Home
 --------------------------------- */

--- a/lib/app/public/css/app.css
+++ b/lib/app/public/css/app.css
@@ -7517,6 +7517,16 @@ div.navbar-inner {
   padding-left: 2em;
 }
 
+@media (max-width: 979px) {
+  .navbar .nav > li:first-child > a {
+    margin-left: 0;
+  }
+}
+
+.navbar .navbar-inner > a.btn-navbar {
+  margin-top: 8px;
+}
+
 /*
 | Home
 --------------------------------- */

--- a/lib/app/views/layout.erb
+++ b/lib/app/views/layout.erb
@@ -14,8 +14,15 @@
   <body>
     <div class='navbar navbar-static-top'>
       <div class='navbar-inner'>
-        <a class="brand" href="/"><img width="25" src="/img/e.png" /></a>
-        <%= erb :nav %>
+        <div class="container">
+          <a class="btn btn-navbar" data-toggle="collapse" data-target=".nav-collapse">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </a>
+          <a class="brand" href="/"><img width="25" src="/img/e.png" /></a>
+          <%= erb :nav %>
+        </div>
       </div>
     </div>
 

--- a/lib/app/views/layout.haml
+++ b/lib/app/views/layout.haml
@@ -22,6 +22,10 @@
 
     .navbar.navbar-static-top
       .navbar-inner
+        %a.btn.btn-navbar{"data-toggle" => 'collapse', "data-target" => '.nav-collapse'}
+          %span.icon-bar
+          %span.icon-bar
+          %span.icon-bar
         %a.brand{href: '/'}
           %img{width: '25', src: link_to('/img/e.png')}
         = erb :nav

--- a/lib/app/views/nav.erb
+++ b/lib/app/views/nav.erb
@@ -1,21 +1,22 @@
-<ul class="nav">
-  <li><a href="/about">About</a></li>
-  <li><a href="/getting-started">Getting Started</a></li>
-  <li><a href="http://help.exercism.io">Help</a></li>
-</ul>
+<div class="nav-collapse collapse">
+  <ul class="nav">
+    <li><a href="/about">About</a></li>
+    <li><a href="/getting-started">Getting Started</a></li>
+    <li><a href="http://help.exercism.io">Help</a></li>
+  </ul>
 
-<ul class="nav pull-right">
-  <% if !current_user.guest? %>
-    <%= erb :"nav/nitpicker_languages" %>
-    <%= erb :"nav/ongoing_exercises" %>
-    <%= erb :"nav/teams" %>
-    <%= erb :"nav/notifications" %>
-    <%= erb :"nav/account" %>
-  <% else %>
-    <li><a href="/login">Log in with GitHub</a></li>
-  <% end %>
-  <% if settings.development? %>
-    <%= erb :"nav/backdoor" %>
-  <% end %>
-</ul>
-
+  <ul class="nav pull-right">
+    <% if !current_user.guest? %>
+      <%= erb :"nav/nitpicker_languages" %>
+      <%= erb :"nav/ongoing_exercises" %>
+      <%= erb :"nav/teams" %>
+      <%= erb :"nav/notifications" %>
+      <%= erb :"nav/account" %>
+    <% else %>
+      <li><a href="/login">Log in with GitHub</a></li>
+    <% end %>
+    <% if settings.development? %>
+      <%= erb :"nav/backdoor" %>
+    <% end %>
+  </ul>
+</div>


### PR DESCRIPTION
When accessing exercism.io from a mobile device, the navbar wraps around the screen and doesn't look nice. Make it look better by using bootstrap's collapse plugin and collapsing the navbar when on mobile devices.

Here's a before screenshot using Chrome's mobile emulation:
![screen shot 2014-07-15 at 9 15 42 pm](https://cloud.githubusercontent.com/assets/77174/3593959/a91b9a3c-0c90-11e4-8bd2-4f6a13ab12cc.png)

Here's are two after screenshots (again using Chrome's mobile emulation)

Collapsed:
![screen shot 2014-07-15 at 9 16 52 pm](https://cloud.githubusercontent.com/assets/77174/3593968/d5df5dce-0c90-11e4-826a-2f0c32ae5cac.png)

Uncollapsed:
![screen shot 2014-07-15 at 9 17 17 pm](https://cloud.githubusercontent.com/assets/77174/3593970/d98ebd98-0c90-11e4-8cbd-2a137d8205aa.png)

Thanks! :heart:
