### PR TITLE
Adds a Code of Conduct & Link in Contributing Docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,14 @@
+# Contributor Code of Conduct
+## Version 0.4
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+If any participant in this project has issues or takes exception with a contribution, they are obligated to provide constructive feedback and never resort to personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+We promise to extend courtesy and respect to everyone involved in this project regardless of gender, gender identity, sexual orientation, ability or disability, ethnicity, religion, or level of experience.
+
+*This Code of Conduct is provided by the open sourced [Contributor Covenent](https://github.com/Bantik/contributor_covenant)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,9 @@ pull request that implements it. Tests would be wonderful.
 There are full instructions on getting the app running [in the
 README](https://github.com/exercism/exercism.io/blob/master/README.md).
 
+Please read and abide by the [Code of
+  Conduct](https://github.com/exercism/exercism.io/blob/master/CODE_OF_CONDUCT.md).
+
 Please try and stick to the [GitHub Ruby Style
 Guidelines](https://github.com/styleguide/ruby).
 


### PR DESCRIPTION
Coraline Ehmke gave a talk recently at Groupon's Geekfest about Diversity in Open Source Communities. She talked about how a Code of Conduct, when followed and applied, can help to foster openness and inclusivity in OSS. 

CoC's can act as signaling beacons to show that we care about contributions from everyone, and want to provide a safe space to learn, grow, and share knowledge. I know exercism was the first open source project I ever contributed to, and I would love for everyone to feel comfortable and able to contribute! :sparkling_heart: 
