### PR TITLE
Suppress the logging of the seed fetch by default

### DIFF
--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -1,8 +1,9 @@
 namespace :db do
-  task "seeds:fetch" do
+  task "seeds:fetch", %s(debug) do |t, args|
+    args.with_defaults(debug: ENV["DEBUG"])
     puts "fetching over the wire"
     conn = Faraday.new(url: "https://raw.githubusercontent.com") do |c|
-      c.use Faraday::Response::Logger
+      c.use Faraday::Response::Logger if args.debug
       c.use Faraday::Adapter::NetHttp
     end
 


### PR DESCRIPTION
Add in handling of a task argument for the fetch task so that if the
logging is needed, you can run `rake db:seed DEBUG=true` or `rake
db:seeds:fetch DEBUG=true` in order add the logger to the Faraday
middleware stack.

With this change, here's the new output:
![screen shot 2014-07-30 at 11 17 30 pm](https://cloud.githubusercontent.com/assets/77174/3759931/018bba64-186a-11e4-9968-21424b7cf0bb.png)

And a snippet of the output when you run `rake db:seed DEBUG=true`:
![screen shot 2014-07-30 at 11 18 15 pm](https://cloud.githubusercontent.com/assets/77174/3759937/1a4717e2-186a-11e4-93f9-7dc31dd4c00a.png)

Thoughts? Happy to see this go either way. I think it's slightly dubious, but I did get to learn more about Rake, so it's not a total loss if it doesn't get merged in. :smiley:
