### PR TITLE
Make the notifications area use the full width

### DIFF
--- a/lib/app/views/notifications/index.erb
+++ b/lib/app/views/notifications/index.erb
@@ -3,7 +3,7 @@
     <h1>Notifications (<%= inbox.count %>)</h1>
   </section>
   <div class="row">
-    <div class="span6">
+    <div class="span12">
 
       <% if inbox.has_notifications? %>
       <form action="/notifications/read" method='POST' style="float: right; margin: 18px 120px 0 0;">


### PR DESCRIPTION
I didn't see a particular reason to limit the width of the navigations to only half a page. This increases the size so that the text can use the full width.
