### PR TITLE
"login via github" => "log in via github"

### DIFF
--- a/lib/app/views/site/index.haml
+++ b/lib/app/views/site/index.haml
@@ -6,7 +6,7 @@
           %img.logo{src: link_to("/icons/logo.svg")}
           %h2.home-top-header The devil is in the details
           %p.home-top-subheader Crowd-sourced mentorship.
-          %a.btn-large.home{href: '/login'} login via github
+          %a.btn-large.home{href: '/login'} log in via github
 
 %div.container
   %section.content-primary.home


### PR DESCRIPTION
This makes the big button on the home page of exercism.io use the verb "log in" instead of the noun "login," which also matches the "Log in with GitHub" link in the top right corner of the site.
