### PR TITLE
Open a new window when sharing with Twitter

### DIFF
--- a/lib/app/presenters/sharing.rb
+++ b/lib/app/presenters/sharing.rb
@@ -1,5 +1,5 @@
 class Sharing
   def twitter_link(submission)
-    %{<a href="https://twitter.com/intent/tweet?text=I just submitted the #{submission.track_id} #{submission.slug} exercise at @exercism_io - Leave me a nitpick at http://exercism.io/submissions/#{submission.key}" id='twitter-share'>Share with Twitter</a>}
+    %{<a href="https://twitter.com/intent/tweet?text=I just submitted the #{submission.track_id} #{submission.slug} exercise at @exercism_io - Leave me a nitpick at http://exercism.io/submissions/#{submission.key}" id='twitter-share' target="_blank">Share with Twitter</a>}
   end
 end

--- a/test/app/presenters/sharing_test.rb
+++ b/test/app/presenters/sharing_test.rb
@@ -22,6 +22,6 @@ class SharingTest < Minitest::Test
   end
 
   def test_creates_twitter_sharing_link
-    assert_equal "<a href=\"https://twitter.com/intent/tweet?text=I just submitted the ruby bob exercise at @exercism_io - Leave me a nitpick at http://exercism.io/submissions/123456789\" id='twitter-share'>Share with Twitter</a>", Sharing.new.twitter_link(submission)
+    assert_equal "<a href=\"https://twitter.com/intent/tweet?text=I just submitted the ruby bob exercise at @exercism_io - Leave me a nitpick at http://exercism.io/submissions/123456789\" id='twitter-share' target=\"_blank\">Share with Twitter</a>", Sharing.new.twitter_link(submission)
   end
 end


### PR DESCRIPTION
Clicking the 'Share with Twitter' link should not cause the user to
leave the page. Set the link target to '_blank' so that the Twitter link
opens in a new window.

Fixes #1754
