### PR TITLE
Only set state to pending when last is deleted

### DIFF
--- a/lib/app/routes/exercises.rb
+++ b/lib/app/routes/exercises.rb
@@ -100,8 +100,7 @@ module ExercismWeb
 
         decrement_version(submission)
         prior = submission.prior
-        last_submission = submission.user_exercise.submissions.last
-        if prior && (submission == last_submission)
+        if prior && (submission.state == 'pending')
           prior.state = 'pending'
           prior.save
         end


### PR DESCRIPTION
If a user deletes a submission that's not the last one, the prior one gets a
`pending` state. This caused two submissions for the same exercise to appear
on the current_exercises list. This commit fixes this by making sure that the
submission getting deleted is the last one and then setting the state of the
prior one to `pending`.

Possible fix for #1792 
