### PR TITLE
Clean up ExercismWeb::Routes::Teams

### DIFF
--- a/lib/app/routes/teams.rb
+++ b/lib/app/routes/teams.rb
@@ -1,15 +1,16 @@
 module ExercismWeb
   module Routes
     class Teams < Core
-      get '/teams/?' do
-        please_login
 
+      before do
+        please_login
+      end
+
+      get '/teams/?' do
         erb :"teams/new", locals: {team: Team.new}
       end
 
       post '/teams/?' do
-        please_login
-
         team = Team.by(current_user).defined_with(params[:team])
         if team.valid?
           team.save
@@ -21,11 +22,7 @@ module ExercismWeb
       end
 
       get '/teams/:slug' do |slug|
-        please_login
-
-        team = Team.find_by_slug(slug)
-
-        if team
+        only_with_existing_team(slug) do |team|
 
           unless team.includes?(current_user)
             flash[:error] = "You may only view team pages for teams that you are a member of, or that you manage."
@@ -33,102 +30,47 @@ module ExercismWeb
           end
 
           erb :"teams/show", locals: {team: team, members: team.all_members.sort_by {|m| m.username.downcase}}
-        else
-          flash[:error] = "We don't know anything about team '#{slug}'"
-          redirect '/'
         end
       end
 
       delete '/teams/:slug' do |slug|
-        please_login
-
-        team = Team.find_by_slug(slug)
-
-        if team
-          unless team.managed_by?(current_user)
-            flash[:error] = "You are not allowed to delete the team."
-            redirect "/teams/#{slug}"
-          end
-
+        only_for_team_managers(slug, "You are not allowed to delete the team.") do |team|
           team.destroy
 
           flash[:success] = "Team #{slug} has been destroyed"
           redirect "/account"
-        else
-          flash[:error] = "We don't know anything about team '#{slug}'"
-          redirect '/'
         end
       end
 
       post '/teams/:slug/members' do |slug|
-        please_login
-
-        team = Team.find_by_slug(slug)
-
-        if team
-          unless team.managed_by?(current_user)
-            flash[:error] = "You are not allowed to add team members."
-            redirect "/teams/#{slug}"
-          end
-
+        only_for_team_managers(slug, "You are not allowed to add team members.") do |team|
           team.recruit(params[:usernames])
           team.save
           invitees = ::User.find_in_usernames(params[:usernames].to_s.scan(/[\w-]+/))
           notify(invitees, team)
 
           redirect "/teams/#{slug}"
-        else
-          flash[:error] = "We don't know anything about team '#{slug}'"
-          redirect '/'
         end
       end
 
       put '/teams/:slug/leave' do |slug|
-        please_login
-
-        team = Team.find_by_slug(slug)
-
-        if team
+        only_with_existing_team(slug) do |team|
           team.dismiss(current_user.username)
 
           redirect "/#{current_user.username}"
-        else
-          flash[:error] = "We don't know anything about team '#{slug}'"
-          redirect '/'
         end
       end
 
       delete '/teams/:slug/members/:username' do |slug, username|
-        please_login
-
-        team = Team.find_by_slug(slug)
-
-        if team
-          unless team.managed_by?(current_user)
-            flash[:error] = "You are not allowed to remove team members."
-            redirect "/teams/#{slug}"
-          end
-
+        only_for_team_managers(slug, "You are not allowed to remove team members.") do |team|
           team.dismiss(username)
 
           redirect "/teams/#{slug}"
-        else
-          flash[:error] = "We don't know anything about team '#{slug}'"
-          redirect '/'
         end
       end
 
       put '/teams/:slug' do |slug|
-        please_login
-
-        team = Team.find_by_slug(slug)
-
-        if team
-          unless team.managed_by?(current_user)
-            flash[:error] = "You are not allowed to edit the team."
-            redirect "/teams/#{slug}"
-          end
-
+        only_for_team_managers(slug, "You are not allowed to edit the team.") do |team|
           if team.defined_with(params[:team]).save
             redirect "/teams/#{team.slug}"
           else
@@ -139,11 +81,8 @@ module ExercismWeb
       end
 
       put '/teams/:slug/confirm' do |slug|
-        please_login
+        only_with_existing_team(slug) do |team|
 
-        team = Team.find_by_slug(slug)
-
-        if team
           unless team.unconfirmed_members.include?(current_user)
             flash[:error] = "You don't have a pending invitation to this team."
             redirect "/"
@@ -152,63 +91,69 @@ module ExercismWeb
           team.confirm(current_user.username)
 
           redirect "/teams/#{slug}"
+        end
+      end
+
+      post "/teams/:slug/managers" do |slug|
+        only_for_team_managers(slug, "You are not allowed to add managers to the team.") do |team|
+          user = ::User.find_by_username(params[:username])
+          unless user.present?
+            flash[:error] = "Unable to find user #{params[:username]}"
+            redirect "/teams/#{slug}"
+          end
+
+          team.managed_by(user)
+
+          redirect "/teams/#{slug}"
+        end
+      end
+
+      delete "/teams/:slug/managers" do |slug|
+        only_for_team_managers(slug, "You are not allowed to add managers to the team.") do |team|
+          user = ::User.find_by_username(params[:username])
+          team.managers.delete(user) if user
+
+          redirect "/teams/#{slug}"
+        end
+      end
+
+      post "/teams/:slug/disown" do |slug|
+        # please_login("/teams/#{slug}") ? What with this?
+
+        only_with_existing_team(slug) do |team|
+          if team.managers.size == 1
+            flash[:error] = "You can't quit when you're the only manager."
+            redirect "/teams/#{slug}"
+          else
+            team.managers.delete(current_user)
+            redirect "/account"
+          end
+        end
+      end
+
+      private
+
+      def only_for_team_managers(slug, message)
+        only_with_existing_team(slug) do |team|
+          if team.managed_by?(current_user)
+            yield team
+          else
+            flash[:error] = message
+            redirect "/teams/#{slug}"
+          end
+        end
+      end
+
+      def only_with_existing_team(slug)
+        team = Team.find_by_slug(slug)
+
+        if team
+          yield team
         else
           flash[:error] = "We don't know anything about team '#{slug}'"
           redirect '/'
         end
       end
-
-      post "/teams/:slug/managers" do |slug|
-        please_login
-
-        team = Team.find_by_slug(slug)
-
-        unless team.managed_by?(current_user)
-          flash[:error] = "You are not allowed to add managers to the team."
-          redirect "/teams/#{slug}"
-        end
-
-        user = ::User.find_by_username(params[:username])
-        unless user.present?
-          flash[:error] = "Unable to find user #{params[:username]}"
-          redirect "/teams/#{slug}"
-        end
-
-        team.managed_by(user)
-
-        redirect "/teams/#{slug}"
-      end
-
-      delete "/teams/:slug/managers" do |slug|
-        please_login
-
-        team = Team.find_by_slug(slug)
-
-        unless team.managed_by?(current_user)
-          flash[:error] = "You are not allowed to add managers to the team."
-          redirect "/teams/#{slug}"
-        end
-
-        user = ::User.find_by_username(params[:username])
-        team.managers.delete(user) if user
-        redirect "/teams/#{slug}"
-      end
-
-      post "/teams/:slug/disown" do |slug|
-        please_login("/teams/#{slug}")
-
-        team = Team.find_by_slug(slug)
-
-        if team.managers.size == 1
-          flash[:error] = "You can't quit when you're the only manager."
-          redirect "/teams/#{slug}"
-        else
-          team.managers.delete(current_user)
-          redirect "/account"
-        end
-      end
-
-      private
 
       def notify(invitees, team)
         invitees.each do |invitee|


### PR DESCRIPTION
Hi,

I think exercism is a really great project and I wanted to contribute a bit. I checked Code Climate and teams router seemed a low hanging fruit for improvements. I know Code Climate and DSL heavy things are not exactly best buddies, but I hope this improves not only the GPA but also readability of the code.

If the authorization messages for team managers could be unified this may end up even cleaner (by dropping second parameter to `only_for_team_managers`), but it may decrease user experience, so I'm not sure about that.

I'm only not certain about the change to the disown action, I'm not sure if the argument to `please_login` can be safely dropped (as far as I looked, and as far as tests go, it seems OK to drop it).
