### PR TITLE
Address duplicate team member bug. Fixes #1742.

### DIFF
--- a/lib/app/routes/teams.rb
+++ b/lib/app/routes/teams.rb
@@ -44,9 +44,9 @@ module ExercismWeb
 
       post '/teams/:slug/members' do |slug|
         only_for_team_managers(slug, "You are not allowed to add team members.") do |team|
+          invitees = ::User.find_in_usernames(params[:usernames].to_s.scan(/[\w-]+/)) - team.all_members
           team.recruit(params[:usernames])
           team.save
-          invitees = ::User.find_in_usernames(params[:usernames].to_s.scan(/[\w-]+/))
           notify(invitees, team)
 
           redirect "/teams/#{slug}"

--- a/lib/exercism/team.rb
+++ b/lib/exercism/team.rb
@@ -37,7 +37,8 @@ class Team < ActiveRecord::Base
   end
 
   def recruit(usernames)
-    self.unconfirmed_members += User.find_in_usernames(usernames.to_s.scan(/[\w-]+/))
+    recruits = User.find_in_usernames(usernames.to_s.scan(/[\w-]+/)) - self.all_members
+    self.unconfirmed_members += recruits
   end
 
   def dismiss(username)

--- a/lib/exercism/team_membership.rb
+++ b/lib/exercism/team_membership.rb
@@ -2,6 +2,8 @@ class TeamMembership < ActiveRecord::Base
   belongs_to :team
   belongs_to :user
 
+  validates :user, uniqueness: { scope: :team }
+
   before_create do
     self.confirmed = false
     true

--- a/test/exercism/team_test.rb
+++ b/test/exercism/team_test.rb
@@ -128,11 +128,11 @@ class TeamTest < Minitest::Test
   def test_team_does_not_recruit_duplicates
     team = Team.by(alice).defined_with(slug: 'awesome', usernames: ['bob'])
     team.save
+    member_count = team.all_members.count
     team.confirm(bob.username)
-    assert_equal 1, team.members.size
-
     team.recruit(bob.username)
-    assert_equal 1, team.members.size
+
+    assert_equal member_count, team.all_members.count
   end
 
   def test_team_member_dismiss


### PR DESCRIPTION
Fixes duplicate recruits test and adds scoped uniqueness validation to
TeamMembership. Also adds guard to Team#recruit to remove existing
members from invitees. Performs this same subtraction when sending out
notifications in routes/teams.
