### PR TITLE
Fix exercism/exercism.io#1901 broken links 

### DIFF
--- a/lib/app/views/site/getting-started.haml
+++ b/lib/app/views/site/getting-started.haml
@@ -17,7 +17,7 @@
     %div.article-contents
       %h2.header Exercises
       %p
-        Fetch the current exercises using the [command-line client](http://help.exercism.io/installing-the-cli.html). Exercises consisting of a test suite and a README are available in
+        Fetch the current exercises using the <a href="http://help.exercism.io/installing-the-cli.html">command-line client</a>. Exercises consisting of a test suite and a README are available in
         = succeed "." do
           = languages
       %p
@@ -31,7 +31,7 @@
     %div.article-contents
       %h2.header Nitpicking
       %p
-        Think deeply about [how code can be improved](http://help.exercism.io/nitpicking-code.html).
+        Think deeply about <a href="http://help.exercism.io/nitpicking-code.html">how code can be improved</a>.
       %p
         One particularly well-kept secret is that looking at someone's code with an eye towards finding ways of improving it can teach you more about writing readable code than receiving feedback on your own code.
       %p


### PR DESCRIPTION
Haml is not MarkDown.
