### PR TITLE
Fix broken markup in submissions#show

### DIFF
--- a/lib/app/views/submissions/show.erb
+++ b/lib/app/views/submissions/show.erb
@@ -96,7 +96,7 @@
         <%= md(submission.code, submission.track_id) %>
       </div>
       <div id="submission-code" style="display:none">
-        <%= submission.code %>
+        <%= h submission.code %>
       </div>
       <br/>
     </div>


### PR DESCRIPTION
Markup broke when submission included `<object>`
Fix #1836 
