### PR TITLE
WIP: Add test to assert state of submission changes

### DIFF
--- a/lib/exercism/use_cases/completion.rb
+++ b/lib/exercism/use_cases/completion.rb
@@ -10,11 +10,21 @@ class Completion
   end
 
   def save
+    supersede_old_submissions
     submission.state = 'done'
     submission.done_at = Time.now.utc
     submission.save
     user.reload
     Hack::UpdatesUserExercise.new(submission.user_id, submission.track_id, submission.slug).update
     self
+  end
+
+  private
+
+  def supersede_old_submissions
+    submission.user_exercise.submissions[0...-1].each do |old_submission|
+      old_submission.state = 'superseded'
+      old_submission.save
+    end
   end
 end

--- a/test/exercism/use_cases/completion_test.rb
+++ b/test/exercism/use_cases/completion_test.rb
@@ -3,18 +3,24 @@ require_relative '../../integration_helper'
 class CompletionTest < Minitest::Test
   include DBCleaner
 
-  attr_reader :submission, :user
+  attr_reader :submission, :user, :old_submission
   def setup
     super
     @user = User.create(username: 'bob', github_id: 1)
 
-    attempt = Attempt.new(user, 'CODE', 'one/one.rb').save
-    @submission = Submission.first
+    Attempt.new(user, 'CODE', 'one/one.rb').save
+    Attempt.new(user, 'CODE', 'one/one.rb').save
+
+    @old_submission = Submission.first
+    @submission = Submission.last
   end
 
   def test_complete_a_submission
     Completion.new(submission).save
     submission.reload
+    old_submission.reload
+
+    assert_equal 'superseded', old_submission.state
     assert_equal 'done', submission.state
     refute submission.done_at.nil?
   end


### PR DESCRIPTION
When a user closes an exercise for a submission that needs input check that the
submissions state is changed to done.
