### PR TITLE
End list of completed exercises with a period instead of a comma

### DIFF
--- a/lib/app/public/sass/base/components/exercise.scss
+++ b/lib/app/public/sass/base/components/exercise.scss
@@ -4,6 +4,6 @@
     content: ", ";
   }
   &:last-child a:after {
-    content: ", ";
+    content: ".";
   }
 }


### PR DESCRIPTION
In the list of completed exercises on the account page the exercises are delimited by ", " and probably should be ended with either a period or no punctuation. I think this is how it used to be and maybe the ", " at the end was accidentally introduced in the big sass conversion.
