### PR TITLE
DRY up random key generation

### DIFF
--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -50,4 +50,8 @@ class Exercism
   def self.relative_to_root(*paths)
     File.expand_path(File.join(root, *paths), __FILE__)
   end
+
+  def self.uuid
+    SecureRandom.uuid.tr('-', '')
+  end
 end

--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -23,7 +23,7 @@ class Submission < ActiveRecord::Base
     self.nit_count      ||= 0
     self.version        ||= 0
     self.is_liked       ||= false
-    self.key            ||= generate_key
+    self.key            ||= Exercism.uuid
     true
   end
 
@@ -207,10 +207,6 @@ class Submission < ActiveRecord::Base
     viewers.count
   end
 
-  def generate_key
-    Digest::SHA1.hexdigest(secret)[0..23]
-  end
-
   def exercise_completed?
     user_exercise.completed?
   end
@@ -228,14 +224,6 @@ class Submission < ActiveRecord::Base
   end
 
   private
-
-  def secret
-    if ENV['SUBMISSION_SECRET']
-      "#{ENV['SUBMISSION_SECRET']} #{rand(10**10)}"
-    else
-      "There is solemn satisfaction in doing the best you can for #{rand(10**10)} billion people."
-    end
-  end
 
   # Experiment: Cache the iteration number so that we can display it
   # on the dashboard without pulling down all the related versions

--- a/lib/exercism/user_exercise.rb
+++ b/lib/exercism/user_exercise.rb
@@ -12,7 +12,7 @@ class UserExercise < ActiveRecord::Base
   scope :completed, ->{ where(state: 'done') }
 
   before_create do
-    self.key ||= generate_key
+    self.key ||= Exercism.uuid
   end
 
   def track_id
@@ -44,10 +44,6 @@ class UserExercise < ActiveRecord::Base
     update_attributes(is_nitpicker: true)
   end
 
-  def generate_key
-    Digest::SHA1.hexdigest(secret)[0..23]
-  end
-
   def completed?
     state == 'done'
   end
@@ -58,15 +54,5 @@ class UserExercise < ActiveRecord::Base
 
   def nit_count
     submissions.pluck(:nit_count).sum
-  end
-
-  private
-
-  def secret
-    if ENV['USER_EXERCISE_SECRET']
-      "#{ENV['USER_EXERCISE_SECRET']} #{rand(10**10)}"
-    else
-      "There is solemn satisfaction in doing the best you can for #{rand(10**10)} billion people."
-    end
   end
 end


### PR DESCRIPTION
- Make random key generation the responsibility of the new RandomKey class
- Remove that responsibility from ActiveRecord classes

Here are some things I like about this change:
- Closer to following single responsibility principle
- Removes duplication of code

Here are some things I am hesitant about:
- Am I requiring the file correctly in `lib/exercism.rb`?
- Is `lib/exercism/random_key.rb` the right place for the `RandomKey` file to live? (Since it's sort of like a utility, not really application-specific logic).
- Not sure how I feel about `RandomKey.generate` as a class method, vs. an instance method, or maybe `RandomKey` should actually be a module and not a class? Not sure about it.
- I didn't write any new tests because I consider this just a refactoring without changing behaviour.
