### PR TITLE
Language on submission page is now a link

### DIFF
--- a/lib/app/views/submissions/byline.erb
+++ b/lib/app/views/submissions/byline.erb
@@ -1,7 +1,7 @@
 <section class="page-header">
   <h1>
     <%= problem.name %>
-    <small>in <%= problem.language %></small>
+    <small>in <a href="<%= path_for(problem.language) %>"><%= problem.language %></a></small>
   </h1>
   submitted by <%= gravatar_tag user.avatar_url, size: 30 %>
   <%= profile_link(user) %>


### PR DESCRIPTION
On a [submission page](http://exercism.io/submissions/c7667d22d4d6492c939827661891498b), the language of the exercise is listed. To make it easier to browse other submissions, this PR makes the language a link.
