### PR TITLE
Move date submitted to header section

### DIFF
--- a/lib/app/views/submissions/byline.erb
+++ b/lib/app/views/submissions/byline.erb
@@ -4,5 +4,5 @@
     <small>in <%= problem.language %></small>
   </h1>
   submitted by <%= gravatar_tag user.avatar_url, size: 30 %>
-  <%= profile_link(user) %>
+  <%= profile_link(user) %> <%= ago(created_at) %>.
 </section>

--- a/lib/app/views/submissions/show.erb
+++ b/lib/app/views/submissions/show.erb
@@ -1,11 +1,10 @@
 <div class="container">
-  <%= erb :"submissions/byline", locals: {problem: submission.problem, user: submission.user} %>
+  <%= erb :"submissions/byline", locals: {problem: submission.problem, user: submission.user, created_at: submission.created_at} %>
   <p><% if current_user.owns?(submission) %>
     <%= sharing.twitter_link(submission) %>
   <% end %>
   </p>
 
-  <p>Submitted <%= ago(submission.created_at) %>.</p>
   <p><%= view_count_for(submission) %>.</p>
   <p>
     Iteration <b><%= submission.version %></b> of <b><%= submission.user_exercise.iteration_count %></b>.


### PR DESCRIPTION
This PR moves the date submitted on a submission page to the header part, where the author is already displayed. This not only makes more sense textually "submitted by <...> at <...>", it also cleans up the page to have the actual code appear more to the top of the page.

Before:
![screen shot 2014-11-22 at 10 31 49](https://cloud.githubusercontent.com/assets/135246/5153654/d49f76da-7232-11e4-9cc9-eefa36c9428d.png)

After:
![screen shot 2014-11-22 at 10 31 04](https://cloud.githubusercontent.com/assets/135246/5153653/d1046044-7232-11e4-877f-6721f9955103.png)
