### PR TITLE
Allow local changes to db seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ get a feel for the rhythm that Test-Driven Development gives you.
   * create db user with: `createuser -s exercism`.
   * create database with: `createdb -O exercism exercism_development`.
 1. Run the database migrations with `rake db:migrate`.
+1. Fetch the seed data with `rake db:seeds:fetch`.
 1. Run the database seed with `rake db:seed`. If you want LOTS of data: `rake db:seed[1000]` or some other big number.
 1. Copy `config/env` to `.env`
 1. Edit `.env` to fill in the correct values, including the GitHub client id/secret procured earlier.

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -1,4 +1,5 @@
 namespace :db do
+  desc "Fetch seed data from github and save to db/seeds.sql"
   task "seeds:fetch", %s(debug) do |t, args|
     args.with_defaults(debug: ENV["DEBUG"])
     puts "fetching over the wire"
@@ -7,14 +8,12 @@ namespace :db do
       c.use Faraday::Adapter::NetHttp
     end
 
-    %w(schema migrations seeds).each do |file|
-      response = conn.get do |req|
-        req.url "/exercism/seeds/master/db/#{file}.sql"
-        req.headers['User-Agent'] = "github.com/exercism/exercism.io"
-      end
-      File.open("./db/#{file}.sql", 'w') do |f|
-        f.write response.body
-      end
+    response = conn.get do |req|
+      req.url "/exercism/seeds/master/db/seeds.sql"
+      req.headers['User-Agent'] = "github.com/exercism/exercism.io"
+    end
+    File.open("./db/seeds.sql", 'w') do |f|
+      f.write response.body
     end
   end
 
@@ -24,12 +23,7 @@ namespace :db do
     Bundler.require
     require 'exercism'
 
-    %x{dropdb exercism_development -U exercism}
-    %x{createdb -O exercism exercism_development -U exercism}
-    Rake::Task['db:seeds:fetch'].invoke
-    %w(schema migrations seeds).each do |file|
-      %x{psql -U exercism -d exercism_development -f db/#{file}.sql}
-    end
+    %x{psql -U exercism -d exercism_development -f db/seeds.sql}
 
     # Trigger generation of html body
     Comment.find_each { |comment| comment.save }


### PR DESCRIPTION
Before, `$ rake db:seed` recreated the database according to out-of-date schema.sql and seeds.sql files fetched from the internet.

This overwrote local database schema changes and local changes to seeds.sql.

This pull request adds schema.sql and seeds.sql to version control, allowing local changes. `$ rake db:seed` will now use the local seeds file rather than fetching it from the internet.

Other changes:

Delete seeds.sql sections which referred to db tables that no longer exist

When seeding database, do not drop and recreate the local database - instead
keep the existing local database

Automatically regenerate schema.sql after any local migration to ensure it
matches current database schema
