### PR TITLE
Fixed language path for languages with non-URI chars

### DIFF
--- a/lib/app/views/submissions/header.erb
+++ b/lib/app/views/submissions/header.erb
@@ -2,7 +2,7 @@
   <h1 class="pull-left">
     <span class="submission-language">
       <a
-        href="<%= path_for(submission.problem.language) %>"
+        href="<%= path_for(submission.problem.track_id) %>"
         data-toggle="tooltip"
         data-placement="bottom"
         title="<%= submission.problem.language %>">

--- a/lib/app/views/submissions/toolbar.erb
+++ b/lib/app/views/submissions/toolbar.erb
@@ -15,7 +15,7 @@
       </a>
     <% end %>
     <a
-      href="<%= language_path_for_slug(submission.problem.language, submission.user_exercise.slug) %>"
+      href="<%= language_path_for_slug(submission.problem.track_id, submission.user_exercise.slug) %>"
       class="btn btn-default"
       data-toggle="tooltip"
       data-placement="bottom"


### PR DESCRIPTION
This PR fixes issue #2070: Incorrect links for languages with non-URI characters. I'm not a Ruby developer, so I'm not sure if I have structured the code correctly.
