### PR TITLE
Fix a grammar error

### DIFF
--- a/lib/app/helpers/submissions_helper.rb
+++ b/lib/app/helpers/submissions_helper.rb
@@ -32,7 +32,7 @@ module Sinatra
       return "" if liked_by.empty?
 
       everyone = liked_by.map {|user| "<a href='/#{user.username}'>@#{user.username}</a>"}
-      "#{sentencify(everyone)} thinks this looks great"
+      "#{sentencify(everyone)} think#{everyone.one? ? 's' : ''} this looks great"
     end
 
     def like_submission_button(submission, user)


### PR DESCRIPTION
If two or more people like a submission, the website would show

> Foo and Bar think<b>s</b> this looks great

With this commit, the third person of the _think_ verb is fixed:

> Foo and Bar think this looks great
