### PR TITLE
WIP Switch to Postgres for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.1.2
 script:
+  - 'createuser exercism --superuser && createdb -O exercism exercism_test'
   - 'RACK_ENV=test CI=1 bundle exec rake db:migrate test_with_coverage'
   - '( cd frontend && npm install && lineman spec-ci )'
   - "! git grep ' $' -- \\*.rb"

--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ user.submissions
 
 ## Testing
 
-1. Prepare the test environment with `RACK_ENV=test rake db:migrate`.
-2. Make sure that `mailcatcher` is running.
-3. Run the test suite with `rake` or `rake test`.
+1. Create test database with: `createdb -O exercism exercism_test`.
+2. Prepare the test environment with `RACK_ENV=test rake db:migrate`.
+3. Make sure that `mailcatcher` is running.
+4. Run the test suite with `rake` or `rake test`.
 
 To run a single test suite, you can do so with:
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,12 +1,16 @@
 ---
-test:
-  adapter: sqlite3
-  database: db/exercism_test.sqlite
-development:
+postgres: &postgres
   adapter: postgresql
   encoding: unicode
-  database: exercism_development
   pool: 5
   host: localhost
   username: exercism
   password: apples
+
+test:
+  <<: *postgres
+  database: exercism_test
+
+development:
+  <<: *postgres
+  database: exercism_development

--- a/db/migrate/201411241740_change_username_to_citext.rb
+++ b/db/migrate/201411241740_change_username_to_citext.rb
@@ -1,0 +1,11 @@
+class ChangeUsernameToCitext < ActiveRecord::Migration
+  def up
+    execute "CREATE EXTENSION citext"
+    change_column :users, :username, :citext
+  end
+
+  def down
+    change_column :users, :username, :string
+    execute "DROP EXTENSION citext"
+  end
+end

--- a/lib/db/config.rb
+++ b/lib/db/config.rb
@@ -27,10 +27,6 @@ module DB
         raise UnconfiguredEnvironment.new(error)
       end
 
-      if result['adapter'] == 'sqlite3'
-        result['database'] = relative_to_root(result['database'].split('/'))
-      end
-
       result
     end
 

--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -42,6 +42,7 @@ require 'exercism/language_track'
 
 require 'db/connection'
 DB::Connection.establish
+require 'exercism/active_record_citext'
 
 class Exercism
   def self.root

--- a/lib/exercism/active_record_citext.rb
+++ b/lib/exercism/active_record_citext.rb
@@ -1,0 +1,4 @@
+# from http://gray.fm/2013/09/17/unknown-oid-with-rails-and-postgresql/
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.tap do |klass|
+  klass::OID.register_type('citext', klass::OID::Identity.new)
+end

--- a/lib/exercism/stats/snapshot.rb
+++ b/lib/exercism/stats/snapshot.rb
@@ -22,41 +22,41 @@ module Stats
 
     def active_exercise_count
       sql = "SELECT COUNT(id) AS tally FROM user_exercises WHERE user_id = #{user.id} AND state='pending'"
-      execute(sql)["tally"]
+      execute(sql)["tally"].to_i
     end
 
     def hibernating_exercise_count
       sql = "SELECT COUNT(id) AS tally FROM user_exercises WHERE user_id = #{user.id} AND state='hibernating'"
-      execute(sql)["tally"]
+      execute(sql)["tally"].to_i
     end
 
     def completed_exercise_count
       sql = "SELECT COUNT(id) AS tally FROM user_exercises WHERE user_id = #{user.id} AND state='done'"
-      execute(sql)["tally"]
+      execute(sql)["tally"].to_i
     end
 
     def total_nitpick_count
       sql = "SELECT COUNT(c.id) AS tally FROM comments c INNER JOIN submissions s ON c.submission_id=s.id WHERE c.user_id = #{user.id} AND s.user_id != #{user.id}"
-      execute(sql)["tally"]
+      execute(sql)["tally"].to_i
     end
 
     def total_submission_count
       sql = "SELECT count(id) AS tally FROM submissions WHERE user_id=#{user.id}"
-      execute(sql)["tally"]
+      execute(sql)["tally"].to_i
     end
 
     def total_language_count
-      user.submissions.pluck(:language).uniq.count
+      user.submissions.pluck(:language).uniq.count.to_i
     end
 
     def recent_nitpick_count
       sql = "SELECT COUNT(c.id) AS tally FROM comments c INNER JOIN submissions s ON c.submission_id=s.id WHERE c.user_id = #{user.id} AND s.user_id != #{user.id} AND c.created_at > '#{7.days.ago}'"
-      execute(sql)["tally"]
+      execute(sql)["tally"].to_i
     end
 
     def recent_submission_count
       sql = "SELECT count(id) AS tally FROM submissions WHERE user_id=#{user.id} AND created_at > '#{7.days.ago}'"
-      execute(sql)["tally"]
+      execute(sql)["tally"].to_i
     end
 
     def recent_language_count

--- a/test/api/users_test.rb
+++ b/test/api/users_test.rb
@@ -8,14 +8,14 @@ class UsersApiTest < Minitest::Test
     ExercismAPI::App
   end
 
-  def test_query_users
-    User.create(username: 'alice', github_id: 1)
+  def test_query_users_is_case_insensitive
+    User.create(username: 'Alice', github_id: 1)
     User.create(username: 'mallory', github_id: 2)
     User.create(username: 'bob', github_id: 3)
 
     post '/user/find', { query: 'al' }
 
     result = last_response.body
-    assert_equal ['alice', 'mallory'], JSON.parse(result)
+    assert_equal ['Alice', 'mallory'], JSON.parse(result)
   end
 end

--- a/test/app/nitpick_test.rb
+++ b/test/app/nitpick_test.rb
@@ -23,7 +23,7 @@ class NitpickAppTest < Minitest::Test
   def generate_submission(track_id, exe)
     user = User.create({
       username: "#{track_id}_user",
-      github_id: track_id,
+      github_id: User.count,
       email: "#{track_id}_coder@example.com"
     })
     attempt = Attempt.new(user, "class Bob\nend", "#{track_id}/bob/bob.#{exe}").save

--- a/test/db/config_test.rb
+++ b/test/db/config_test.rb
@@ -11,14 +11,7 @@ class DB::ConfigTest < Minitest::Test
     assert_equal file, DB::Config.new('env').file
   end
 
-  def test_sets_the_database_setting_relative_to_root_if_sqlite
-    file = relative_to_root('config', 'database.yml')
-    db_connection_string = relative_to_root('db', 'exercism_test.sqlite')
-
-    assert_equal db_connection_string, DB::Config.new('test').options['database']
-  end
-
-  def test_dont_change_database_setting_if_anything_else
+  def test_database_name_comes_from_environment_by_default
     assert_equal 'exercism_development', DB::Config.new('development').options['database']
   end
 
@@ -31,8 +24,8 @@ class DB::ConfigTest < Minitest::Test
     file = relative_to_root('test', 'fixtures', 'database.yml')
     config = DB::Config.new('fake', file)
     options = {
-      'adapter' => 'sqlite3',
-      'database' => relative_to_root('db/betterful_fake')
+      'adapter' => 'postgresql',
+      'database' => 'betterful_fake'
     }
     assert_equal options, config.options
   end

--- a/test/exercism/cohort_test.rb
+++ b/test/exercism/cohort_test.rb
@@ -37,10 +37,10 @@ class CohortTest < Minitest::Test
     bob.reload
     cohort = Cohort.for(bob)
 
-    assert_equal %w(dave eve), cohort.members.map(&:username)
-    assert_equal ['alice'], cohort.managers.map(&:username)
+    assert_equal %w(dave eve), cohort.members.map(&:username).sort
+    assert_equal ['alice'], cohort.managers.map(&:username).sort
     assert_equal %w(alice dave eve), cohort.users.map(&:username).sort
-    assert_equal %w(alice dave), cohort.sees(problem).map(&:username)
+    assert_equal %w(alice dave), cohort.sees(problem).map(&:username).sort
   end
 
 end

--- a/test/exercism/lifecycle_event_test.rb
+++ b/test/exercism/lifecycle_event_test.rb
@@ -20,7 +20,8 @@ class LifecycleEventTest < Minitest::Test
     LifecycleEvent.track('something_else', 1, now+5.minutes)
 
     assert_equal 2, LifecycleEvent.count
-    event1, event2 = LifecycleEvent.all
+    event1 = LifecycleEvent.find_by(key: 'something')
+    event2 = LifecycleEvent.find_by(key: 'something_else')
 
     assert_equal 'something', event1.key
     assert_equal 1, event1.user_id

--- a/test/exercism/use_cases/attempt_test.rb
+++ b/test/exercism/use_cases/attempt_test.rb
@@ -61,15 +61,17 @@ class AttemptTest < Minitest::Test
   def test_a_new_attempt_supersedes_the_previous_one
     Attempt.new(user, 'CODE 1', 'ruby/two/two.rb').save
     Attempt.new(user, 'CODE 2', 'ruby/two/two.rb').save
-    one, two = user.submissions
+    one = Submission.find_by(code: 'CODE 1')
+    two = Submission.find_by(code: 'CODE 2')
     assert_equal 'superseded', one.reload.state
     assert_equal 'pending', two.reload.state
   end
 
   def test_a_new_attempt_supersedes_the_previous_hibernating_one
-    submission = Submission.create(user: user, language: 'ruby', slug: 'two', created_at: Time.now, state: 'hibernating')
+    submission = Submission.create(user: user, code: 'CODE 1', language: 'ruby', slug: 'two', created_at: Time.now, state: 'hibernating')
     Attempt.new(user, 'CODE 2', 'ruby/two/two.rb').save
-    one, two = user.reload.submissions
+    one = Submission.find_by(code: 'CODE 1')
+    two = Submission.find_by(code: 'CODE 2')
     assert one.superseded?
     assert two.pending?
   end
@@ -85,9 +87,10 @@ class AttemptTest < Minitest::Test
   end
 
   def test_an_attempt_does_not_supersede_other_languages
-    Attempt.new(user, 'CODE', 'two/two.py').save
-    Attempt.new(user, 'CODE', 'two/two.rb').save
-    one, two = user.submissions
+    Attempt.new(user, 'CODE 1', 'two/two.py').save
+    Attempt.new(user, 'CODE 2', 'two/two.rb').save
+    one = Submission.find_by(code: 'CODE 1')
+    two = Submission.find_by(code: 'CODE 2')
     assert_equal 'pending', one.reload.state
     assert_equal 'pending', two.reload.state
   end
@@ -110,8 +113,8 @@ class AttemptTest < Minitest::Test
 
   def test_previous_submission_after_superseding
     Attempt.new(user, 'CODE 1', 'two/two.rb').save
+    one = Submission.find_by(code: 'CODE 1')
     attempt = Attempt.new(user, 'CODE 2', 'two/two.rb').save
-    one = user.submissions.first
     assert_equal attempt.previous_submission, one
   end
 

--- a/test/fixtures/database.yml
+++ b/test/fixtures/database.yml
@@ -1,4 +1,3 @@
----
 fake:
-  adapter: sqlite3
-  database: db/betterful_fake
+  adapter: postgresql
+  database: betterful_fake


### PR DESCRIPTION
- Allow case insensitive user queries as requested in #1805.
- Switch test database to Postgres; update README and tests

There are still two issues:
1. This test still fails sometimes: `NitpickAppTest#test_language_when_and_submission_present`. All the other tests I adjusted to not rely on implicit ordering of records pulled out of the db.  But this test file, I can't see where the implicit ordering is coming from. Any help appreciated! 
2. The test performance degradation.  As @SleeplessByte suggested, I logged long-running queries but didn't find any solid evidence (only 3 queries over 10 ms for the whole test suite, none over 30ms). I haven't made any progress on figuring out what's causing it.

I think there is a major gain in safety from testing on the same database as is used in production.  But I think the performance hit is a big deal, too.

It's definitely OK with me if we end up deciding not to merge this due to the test performance. What are everyone's thoughts?
