### PR TITLE
Refactor stats snapshot active record queries

### DIFF
--- a/lib/exercism/comment.rb
+++ b/lib/exercism/comment.rb
@@ -12,9 +12,11 @@ class Comment < ActiveRecord::Base
     true
   end
 
-  scope :reversed, ->{ order('created_at DESC') }
+  scope :reversed, ->{ order(created_at: :desc) }
   scope :received_by, ->(user) { where(submission_id: user.submissions.pluck(:id)) }
   scope :paginate_by_params, ->(params) { paginate(page: params[:page], per_page: params[:per_page] || 10) }
+
+  scope :except_on_submissions_by, ->(user) { joins(:submission).merge(Submission.excluding(user)) }
 
   def nitpicker
     user

--- a/lib/exercism/stats/snapshot.rb
+++ b/lib/exercism/stats/snapshot.rb
@@ -9,72 +9,47 @@ module Stats
     end
 
     def most_recent_submission_at
-      sql = "SELECT created_at FROM submissions WHERE user_id = #{user.id} ORDER BY created_at DESC LIMIT 1"
-      result = execute(sql)
-      time_of result["created_at"] if result
+      user.submissions.reversed.first.try(:created_at).try(:iso8601)
     end
 
     def most_recent_nitpick_at
-      sql = "SELECT created_at FROM comments WHERE user_id = #{user.id} ORDER BY created_at DESC LIMIT 1"
-      result = execute(sql)
-      time_of result["created_at"] if result
+      user.comments.reversed.first.try(:created_at).try(:iso8601)
     end
 
     def active_exercise_count
-      sql = "SELECT COUNT(id) AS tally FROM user_exercises WHERE user_id = #{user.id} AND state='pending'"
-      execute(sql)["tally"].to_i
+      user.exercises.where(state: 'pending').count
     end
 
     def hibernating_exercise_count
-      sql = "SELECT COUNT(id) AS tally FROM user_exercises WHERE user_id = #{user.id} AND state='hibernating'"
-      execute(sql)["tally"].to_i
+      user.exercises.where(state: 'hibernating').count
     end
 
     def completed_exercise_count
-      sql = "SELECT COUNT(id) AS tally FROM user_exercises WHERE user_id = #{user.id} AND state='done'"
-      execute(sql)["tally"].to_i
+      user.exercises.where(state: 'done').count
     end
 
     def total_nitpick_count
-      sql = "SELECT COUNT(c.id) AS tally FROM comments c INNER JOIN submissions s ON c.submission_id=s.id WHERE c.user_id = #{user.id} AND s.user_id != #{user.id}"
-      execute(sql)["tally"].to_i
+      user.comments.except_on_submissions_by(user).count
     end
 
     def total_submission_count
-      sql = "SELECT count(id) AS tally FROM submissions WHERE user_id=#{user.id}"
-      execute(sql)["tally"].to_i
+      user.submissions.count
     end
 
     def total_language_count
-      user.submissions.pluck(:language).uniq.count.to_i
+      user.submissions.pluck(:language).uniq.count
     end
 
     def recent_nitpick_count
-      sql = "SELECT COUNT(c.id) AS tally FROM comments c INNER JOIN submissions s ON c.submission_id=s.id WHERE c.user_id = #{user.id} AND s.user_id != #{user.id} AND c.created_at > '#{7.days.ago}'"
-      execute(sql)["tally"].to_i
+      user.comments.where('comments.created_at > ?', 7.days.ago).except_on_submissions_by(user).count
     end
 
     def recent_submission_count
-      sql = "SELECT count(id) AS tally FROM submissions WHERE user_id=#{user.id} AND created_at > '#{7.days.ago}'"
-      execute(sql)["tally"].to_i
+      user.submissions.recent.count
     end
 
     def recent_language_count
-      user.submissions.where('created_at > ?', 7.days.ago).pluck(:language).uniq.count
-    end
-
-    private
-
-    def connection
-      @connection ||= User.connection
-    end
-
-    def execute(sql)
-      connection.execute(sql).to_a.first
-    end
-
-    def time_of(timestamp)
-      Time.strptime(timestamp.gsub(/\.\d+$/, '') + " UTC", "%Y-%m-%d %H:%M:%S %Z").iso8601
+      user.submissions.recent.pluck(:language).uniq.count
     end
   end
 end

--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -2,7 +2,7 @@ class Submission < ActiveRecord::Base
   serialize :solution, JSON
   belongs_to :user
   belongs_to :user_exercise
-  has_many :comments, ->{ order 'created_at ASC' }, dependent: :destroy
+  has_many :comments, ->{ order(created_at: :asc) }, dependent: :destroy
 
   # I don't really want the notifications method,
   # just the dependent destroy
@@ -39,7 +39,7 @@ class Submission < ActiveRecord::Base
     pending.where('nit_count > 0').where('created_at < ?', cutoff)
   }
   scope :chronologically, -> { order('created_at ASC') }
-  scope :reversed, -> { order('created_at DESC') }
+  scope :reversed, -> { order(created_at: :desc) }
   scope :not_commented_on_by, ->(user) {
     joins("LEFT JOIN (SELECT submission_id FROM comments WHERE user_id=#{user.id}) AS already_commented ON submissions.id=already_commented.submission_id").
     where('already_commented.submission_id IS NULL')
@@ -69,6 +69,8 @@ class Submission < ActiveRecord::Base
   scope :excluding, ->(user) {
     where.not(user: user)
   }
+
+  scope :recent, -> { where('submissions.created_at > ?', 7.days.ago) }
 
   def self.completed_for(problem)
     done.where(language: problem.track_id, slug: problem.slug)


### PR DESCRIPTION
My previous pull request made `Stats::Snapshot` worse by sprinkling
calls to `#to_i` in with a lot of the methods. I can't actually figure
out if/where this class is still used in the application, but in case it
is, this pull request tries to undo that damage and make
`Stats::Snapshot` better off than it was before I touched it.
1. Use more active record hash conditions and less sql string snippets
2. Using symbols instead of strings for created_at queries. This produces:
   `SELECT * FROM comments ORDER BY comments.created_at DESC`
   as opposed to:
   `SELECT * FROM comments ORDER BY created_at DESC`
   which helps when joining to other tables that also have a created_at column
3. Simplify iso8601 time formatting method
4. Push some scopes further down, into the `Submission` and
   `UserExercise` classes, from where their logic can be more easily
   shared.
