### PR TITLE
Simplify username finder queries

### DIFF
--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -35,11 +35,11 @@ class User < ActiveRecord::Base
   end
 
   def self.find_in_usernames(usernames)
-    where('LOWER(username) IN (?)', usernames.map(&:downcase))
+    where(username: usernames)
   end
 
   def self.find_by_username(username)
-    where('LOWER(username) = ?', username.downcase).first
+    find_by(username: username)
   end
 
   def onboarding_steps


### PR DESCRIPTION
citext making things simpler :-)

Before, LOWER(username) had to be called for SQL queries finding users
in order for a case-sensitive match to be used.

Now that the users.username column is citext, the case insensitive
matching is taken care of automatically by the database and we can thus
simplify the finder queries.

The case insensitive behaviour was already nicely tested in:

``` ruby
  def test_find_user_by_case_insensitive_username
    %w{alice bob}.each do |name| User.create username: name end
    assert_equal 'alice', User.find_by_username('ALICE').username
  end

  def test_find_a_bunch_of_users_by_case_insensitive_username
    %w{alice bob fred}.each do |name| User.create username: name end
    assert_equal ['alice', 'bob'], User.find_in_usernames(['ALICE', 'BOB']).map(&:username)
  end
```

And those tests continue to pass with this change.
