### PR TITLE
Tell Bugsnag of Invalid Submission (closes #1719)

### DIFF
--- a/lib/api/routes/iterations.rb
+++ b/lib/api/routes/iterations.rb
@@ -29,6 +29,10 @@ module ExercismAPI
         attempt = Attempt.new(user, data['code'], data['path'])
 
         unless attempt.valid?
+          Bugsnag.before_notify_callbacks << lambda { |notif|
+            notif.add_tab(:data, {user: user.username, code: data['code'], path: data['path']})
+          }
+          Bugsnag.notify(Attempt::InvalidAttemptError.new("Invalid attempt submitted"))
           error = "unknown problem (track: #{attempt.file.track}, slug: #{attempt.file.slug}, path: #{data['path']})"
           halt 400, {error: error}.to_json
         end

--- a/lib/exercism/use_cases/attempt.rb
+++ b/lib/exercism/use_cases/attempt.rb
@@ -59,6 +59,8 @@ class Attempt
     @previous_submission ||= previous_submissions.first || NullSubmission.new(problem)
   end
 
+  class InvalidAttemptError < StandardError; end
+
   private
 
   def sanitize(code)


### PR DESCRIPTION
Add a custom "data" tab to the bugsnag message with the current
username, code, and path from the request for additional debugging
resources.

This can be tested locally with the following steps:
1. Register for bugsnag
2. Add BUGSNAG_API_KEY=your_key to the `.env` file at the project root
3. Make a curl request to the local dev server:

``` sh
$ curl
  -X POST
  --data '{ "key": "vdv961",
            "code": "some code \n more code ... \n and more code",
            "path": "/some/path"}'
  "localhost:4567/api/v1/user/assignments"
```

The custom data tab would be like in the below image.  Let me know if different info would be appropriate in that tab and I can change what gets included.
![bugsnag_notification](https://cloud.githubusercontent.com/assets/5103414/5365206/d1dfaab8-7fb7-11e4-8242-286f0977a398.png)
