### PR TITLE
Tiny refactoring of setting user's uuid key

### DIFF
--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -18,7 +18,7 @@ class User < ActiveRecord::Base
   has_many :unconfirmed_teams, through: :unconfirmed_team_memberships, source: :team
 
   before_save do
-    reset_key if !key
+    self.key ||= Exercism.uuid
     true
   end
 
@@ -136,10 +136,6 @@ class User < ActiveRecord::Base
 
   def completed_submissions_in(track_id)
     submissions.done.where(language: track_id)
-  end
-
-  def reset_key
-    self.key = SecureRandom.uuid.tr('-', '')
   end
 
   private

--- a/lib/exercism/user_exercise.rb
+++ b/lib/exercism/user_exercise.rb
@@ -13,6 +13,7 @@ class UserExercise < ActiveRecord::Base
 
   before_create do
     self.key ||= Exercism.uuid
+    true
   end
 
   def track_id


### PR DESCRIPTION
Remove tiny duplication of the functionality of Exercism.uuid
Explicitly return `true` from before_create callback as per:

http://stackoverflow.com/questions/4735141/rails-3-do-i-need-to-give-return-true-in-a-before-save-callback-for-an-object
and
http://blog.teksol.info/2010/09/28/unintented-consequences-the-pitfalls-of-activerecord-callbacks
