### PR TITLE
More small refactorings of Submission

### DIFF
--- a/lib/app/presenters/workload.rb
+++ b/lib/app/presenters/workload.rb
@@ -96,6 +96,6 @@ class Workload
   end
 
   def unmuted_submissions
-    Submission.excluding(user).unmuted_for(user).for_language(track_id)
+    Submission.not_submitted_by(user).unmuted_for(user).for_language(track_id)
   end
 end

--- a/lib/exercism/comment.rb
+++ b/lib/exercism/comment.rb
@@ -16,7 +16,7 @@ class Comment < ActiveRecord::Base
   scope :received_by, ->(user) { where(submission_id: user.submissions.pluck(:id)) }
   scope :paginate_by_params, ->(params) { paginate(page: params[:page], per_page: params[:per_page] || 10) }
 
-  scope :except_on_submissions_by, ->(user) { joins(:submission).merge(Submission.excluding(user)) }
+  scope :except_on_submissions_by, ->(user) { joins(:submission).merge(Submission.not_submitted_by(user)) }
 
   def nitpicker
     user

--- a/test/app/submissions_test.rb
+++ b/test/app/submissions_test.rb
@@ -31,10 +31,6 @@ class SubmissionsTest < Minitest::Test
     Attempt.new(alice, code, 'word-count/file.rb').save
   end
 
-  def create_submission
-    Submission.create!(user: User.create!)
-  end
-
   attr_reader :alice, :bob
   def setup
     super
@@ -437,19 +433,5 @@ class SubmissionsTest < Minitest::Test
     post "/submissions/#{s2.key}/done", {}, login(bob)
 
     assert_equal 'superseded', s1.reload.state
-  end
-
-  def test_not_commented_on_by
-    user = User.create!
-    commented_on_by_user = create_submission
-    Comment.create!(submission: commented_on_by_user, user: user, body: 'test')
-
-    commented_on_by_someone_else = create_submission
-    Comment.create!(submission: commented_on_by_someone_else, user: User.create!, body: 'test')
-
-    not_commented_on_at_all = create_submission
-
-    expected = [commented_on_by_someone_else, not_commented_on_at_all].sort
-    assert_equal expected, Submission.not_commented_on_by(user).sort
   end
 end


### PR DESCRIPTION
In preparation for #1699, some more refactoring the `Submission` class.

Visually differentiate activerecord scopes from other types of class methods by using the scope syntax
Replace `#exluding` scope with the identical `#not_submitted_by` scope.
Slightly reduce SQL string snippets
Beef up `#aging` test to make refactoring a little safer
Move not_commented_on_by test to test/exercism/... (where I realized I should have put it), instead of test/app/...
