### PR TITLE
Automatically add team creator to team

### DIFF
--- a/lib/app/routes/teams.rb
+++ b/lib/app/routes/teams.rb
@@ -14,6 +14,8 @@ module ExercismWeb
         team = Team.by(current_user).defined_with(params[:team])
         if team.valid?
           team.save
+          team.recruit(current_user.username)
+          team.confirm(current_user.username)
           notify(team.unconfirmed_members, team)
           redirect "/teams/#{team.slug}"
         else

--- a/lib/app/views/teams/member_submissions.erb
+++ b/lib/app/views/teams/member_submissions.erb
@@ -9,7 +9,12 @@
     <% if member == current_user %>
       <form action="<%= "/teams/#{team.slug}/leave" %>" method="post" class="team-leave-form" style="float: left; padding-right: 10px">
         <input type="hidden" name="_method" value="put" />
-        <input type="submit" name="update" value="Leave" class="btn btn-xs btn-danger"  />
+        <input type="submit" name="update" value="Leave" class="btn btn-xs btn-danger"
+        <% if team.managed_by?(current_user) %>
+          data-toggle="tooltip" data-placement="top"
+          title="If you leave, you will stay on as manager but your exercises will no longer show up."
+        <% end %>
+        />
       </form>
     <% end %>
   </h5>


### PR DESCRIPTION
This is a fix for issue #2091 
The creator of a team is now automatically added to the team. I also added a tooltip to the "leave" button which explains that if the creator leaves the team, they will stay on as a manager but their exercises won't show up.
