### PR TITLE
Allow unauthenticated guests to view a submission

### DIFF
--- a/lib/app/presenters/workload.rb
+++ b/lib/app/presenters/workload.rb
@@ -1,23 +1,5 @@
 class NullWorkload
-  attr_reader :user, :track_id, :slug
-  def initialize(user, track_id, slug)
-    @user, @track_id, @slug = user, track_id, slug
-  end
-
-  def language
-    track_id
-  end
-
-  def breakdown
-    {}
-  end
-
-  def submissions
-    []
-  end
-
-  def available_exercises
-    []
+  def next_submission(submission)
   end
 end
 

--- a/lib/app/routes/core.rb
+++ b/lib/app/routes/core.rb
@@ -114,10 +114,6 @@ module ExercismWeb
         </li>}
         end
 
-        def show_pending_submissions?(language)
-          (!language && current_user.nitpicker?) || (language && current_user.nitpicks_trail?(language))
-        end
-
         def nitpicker_languages
           Exercism::Config.tracks.keys.map(&:to_s) & current_user.nitpicker_languages
         end

--- a/lib/app/views/nitpick/index.erb
+++ b/lib/app/views/nitpick/index.erb
@@ -3,14 +3,14 @@
     <br>
     <aside class="col-md-4">
       <nav>
-        <% if language && exercises.any? %>
-          <ul class="nav nav-stacked nav-bordered">
-            <% %w(recent last-week last-month last-quarter aging).each do |slug| %>
-              <%= dashboard_assignment_section_nav(language, slug) %>
-            <% end %>
-            <%= dashboard_assignment_section_nav(language, 'needs-input') %>
-          </ul>
-          <br />
+        <ul class="nav nav-stacked nav-bordered">
+          <% %w(recent last-week last-month last-quarter aging).each do |slug| %>
+            <%= dashboard_assignment_section_nav(language, slug) %>
+          <% end %>
+          <%= dashboard_assignment_section_nav(language, 'needs-input') %>
+        </ul>
+        <br />
+        <% if exercises.any? %>
           <ul class="nav nav-stacked nav-bordered">
             <% exercises.each do |exercise| %>
               <%= dashboard_assignment_nav(language, exercise.slug, breakdown[exercise.slug]) %>
@@ -22,9 +22,7 @@
     </aside>
 
     <main id="pending-submissions" class="col-md-8">
-    <% if show_pending_submissions?(language) %>
       <%= erb :"nitpick/pending", locals: {submissions: submissions, language: language} %>
-    <% end %>
     </main>
   </div>
 </div>

--- a/lib/app/views/nitpick/pending.erb
+++ b/lib/app/views/nitpick/pending.erb
@@ -1,11 +1,11 @@
+<h2>
+  <%= language_icon(language) %>
+  Pending Submissions
+</h2>
+
+<hr/>
+
 <% if submissions.any? %>
-  <h2>
-    <%= language_icon(language) %>
-    Pending Submissions
-  </h2>
-
-  <hr/>
-
   <div class="pending-submissions">
     <% submissions.each do |submission| %>
       <%= erb :"nitpick/pending_submission", locals: { submission: submission } %>

--- a/lib/exercism/guest.rb
+++ b/lib/exercism/guest.rb
@@ -45,5 +45,9 @@ class Guest
   def nitpicker?
     false
   end
+
+  def owns?(submission)
+    false
+  end
 end
 

--- a/test/app/submissions_test.rb
+++ b/test/app/submissions_test.rb
@@ -42,6 +42,12 @@ class SubmissionsTest < Minitest::Test
     assert_equal expected_status, last_response.status
   end
 
+  def test_guests_can_view_submissions
+    Attempt.new(alice, 'CODE', 'word-count/file.rb').save
+    get "/submissions/#{Submission.first.key}"
+    assert_response_status(200)
+  end
+
   def test_submission_view_count
     Attempt.new(alice, 'CODE', 'word-count/file.rb').save
     submission = Submission.first
@@ -50,7 +56,6 @@ class SubmissionsTest < Minitest::Test
 
     get "/submissions/#{submission.key}", {}, login(bob)
 
-    submission = Submission.first
     assert_equal 1, submission.view_count
   end
 
@@ -62,7 +67,6 @@ class SubmissionsTest < Minitest::Test
 
     get "/submissions/#{submission.key}"
 
-    submission = Submission.first
     assert_equal 0, submission.view_count
   end
 


### PR DESCRIPTION
Closes #1952

Related to (but does not close) #2125

Allow unauthenticated guests to view all the iterations of code and all
the nitpicks others have left on the submission page.

Allow unauthenticated guests to see a lot of links on the submission
page, to give them an idea of what they could do if they signed up.
Most of these links lead to a "you have to be logged in to do that"
page.

Show nitpick index page header and nav links even if no submissions are present
in list.  This improves the UX of that page a little and makes `NullWorkload` simpler.

This is what a submission page looks like now to an unauthenticated guest:
![unauthenticated_submission_view](https://cloud.githubusercontent.com/assets/5103414/5599310/63d40db4-9292-11e4-822b-987580ed0869.png)


--------

This is what the nitpick index page used to look like for someone who hadn't done exercises / nitpicked in that language:
![old_unkown_language](https://cloud.githubusercontent.com/assets/5103414/5599319/7695abd8-9292-11e4-8070-254ec43b0b3b.png)

--------

And this is what it looks like now in that situation:
![new_unkown_language](https://cloud.githubusercontent.com/assets/5103414/5599321/7fb36c5a-9292-11e4-97d0-095874fcf8cb.png)
