### PR TITLE
load variables from .env file

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -4,6 +4,9 @@ require 'bundler'
 Bundler.require
 I18n.enforce_available_locales = false
 
+require 'dotenv'
+Dotenv.load
+
 require 'app'
 require 'api'
 


### PR DESCRIPTION
Even though the setup instructions explain how to set the environment variables, it turns out there was never any place in the code that actually read the `.env` file.