### PR TITLE
Fixes #2154 (404 after logging in with github)

### DIFF
--- a/lib/app/routes/exercises.rb
+++ b/lib/app/routes/exercises.rb
@@ -66,6 +66,10 @@ module ExercismWeb
         end
       end
 
+      get %r{/submissions/(?<key>\w+)/(nitpick$|(\+?un)?like$|(\+?un)?mute$)} do |key|
+        redirect "/submissions/#{key}"
+      end
+
       post '/submissions/:key/done' do |key|
         please_login("You have to be logged in to do that")
         submission = Submission.find_by_key(key)

--- a/lib/app/routes/github_callback.rb
+++ b/lib/app/routes/github_callback.rb
@@ -22,7 +22,7 @@ module ExercismWeb
           if path.nil? || path.empty?
             redirect root_path
           else
-            redirect [root_path, path].compact.join('/')
+            redirect File.join([root_path, path].compact)
           end
         end
       end

--- a/test/app/submissions_test.rb
+++ b/test/app/submissions_test.rb
@@ -438,4 +438,22 @@ class SubmissionsTest < Minitest::Test
 
     assert_equal 'superseded', s1.reload.state
   end
+
+  def test_redirects_to_submission_page_when_comment_like_or_mute_with_get
+    data = {
+      user: bob,
+      code: 'code',
+      language: 'ruby',
+      slug: 'word-count'
+    }
+
+    sub = Submission.create(data.merge(state: 'needs_input', created_at: Time.now - 5))
+
+    %w(nitpick like unlike mute unmute).each do |action|
+      get "/submissions/#{sub.key}/#{action}", {}, login(bob)
+
+      assert_response_status(302)
+      assert_equal "http://example.org/submissions/#{sub.key}", last_response.location
+    end
+  end
 end


### PR DESCRIPTION
It happens because the github callback makes a GET request, and this path responds to POST (since we were trying to post a nitpick - note that `POST /submissions/:key/nitpick` was our last action before the app requires login)

I noticed, a few weeks ago, that it also happens when trying to like/unlike or mute/unmute a submission when you are not logged in or the session is expired.

To solve this, I implemented the missing GET routes and made a redirect to the submission page (https://github.com/josuelima/exercism.io/compare/exercism:master...master#diff-9a49b3ebc7cdcea3905de6879bfff474R69)

I've also made a small change in the redirect at github callback (https://github.com/josuelima/exercism.io/commit/54e88ffb8fadd81439a29ebc911836b60d90a2ec#diff-e52ecb093dfc858532ef2f30c5f7e476R25). It was using array join to concatenate the paths and was generating urls with double slashes, since the array pieces starts with /
![double](http://s9.postimg.org/jlwhhj9tr/double_slashes.png)

Now it's using `File.join`, which takes care of removing double slashes.