### PR TITLE
Sort participating users higher in user lookup

### DIFF
--- a/frontend/app/js/controllers/markdown_controller.coffee
+++ b/frontend/app/js/controllers/markdown_controller.coffee
@@ -6,10 +6,10 @@ angular.module('exercism').controller "MarkdownCtrl", ($scope, $http) ->
   $scope.$watch 'data.body', (body) ->
     if body && PATTERN.test(body)
       query = body.match(PATTERN)[0].replace('@', '')
-      $http.post "/api/v1/user/find",
-          $.param({ "query": query }),
-          headers:
-            "Content-Type": 'application/x-www-form-urlencoded'
+      submission_key = $('.md-markdown-preview textarea').attr('data-submission-key')
+      $http.get("/api/v1/user/find", {
+        params: { query: query, submission_key: submission_key }
+      })
       .success (data, status, headers) ->
         $('.comment').atwho({
           at: '@',

--- a/frontend/spec/controllers/markdown_controller_spec.coffee
+++ b/frontend/spec/controllers/markdown_controller_spec.coffee
@@ -35,8 +35,8 @@ describe "MarkdownCtrl", ->
       expect(@scope.data.preview).toEqual("test_response")
 
   describe "mentioning a user", ->
-    it "posts a search to the backend", ->
-      @$httpBackend.expectPOST("/api/v1/user/find", "query=al").respond(200, JSON.stringify(['alice']))
+    it "gets a list of matching users from the backend", ->
+      @$httpBackend.expectGET("/api/v1/user/find?query=al").respond(200, JSON.stringify(['alice']))
       spy = spyOn($.fn, 'atwho')
       @scope.data.body = '@al'
       @scope.$digest()

--- a/lib/api/routes/users.rb
+++ b/lib/api/routes/users.rb
@@ -1,13 +1,9 @@
 module ExercismAPI
   module Routes
     class Users < Core
-      post '/user/find' do
+      get '/user/find' do
         content_type :json
-        if params[:query]
-          User.where('username LIKE ?', '%' + params[:query] + '%').pluck(:username).to_json
-        else
-          "[]"
-        end
+        UserLookup.new(params).lookup.to_json
       end
     end
   end

--- a/lib/app/public/js/app.js
+++ b/lib/app/public/js/app.js
@@ -30376,14 +30376,14 @@ $(function() {
     PATTERN = /\B@[a-z0-9_-]+/gi;
     $scope.data || ($scope.data = {});
     $scope.$watch('data.body', function(body) {
-      var query;
+      var query, submission_key;
       if (body && PATTERN.test(body)) {
         query = body.match(PATTERN)[0].replace('@', '');
-        return $http.post("/api/v1/user/find", $.param({
-          "query": query
-        }), {
-          headers: {
-            "Content-Type": 'application/x-www-form-urlencoded'
+        submission_key = $('.md-markdown-preview textarea').attr('data-submission-key');
+        return $http.get("/api/v1/user/find", {
+          params: {
+            query: query,
+            submission_key: submission_key
           }
         }).success(function(data, status, headers) {
           return $('.comment').atwho({

--- a/lib/app/views/submissions/comment.erb
+++ b/lib/app/views/submissions/comment.erb
@@ -6,6 +6,7 @@
         name="body"
         class="comment form-control"
         rows="8"
+        data-submission-key="<%= submission.key %>"
         ng-model="data.body"
         <%= "ng-init=\"data.body='#{ng_esc(nit.body)}'\"" if defined? nit %>></textarea>
     </tab>

--- a/lib/app/views/submissions/submit_comment.erb
+++ b/lib/app/views/submissions/submit_comment.erb
@@ -2,7 +2,7 @@
 
   <%= erb :"submissions/feedback_guide", locals: { submission: submission } %>
 
-  <%= erb :"submissions/comment" %>
+  <%= erb :"submissions/comment", locals: { submission: submission } %>
 
   <button type="submit" name="nitpick" class="pull-right btn btn-primary btn-lg">
     <% if current_user.owns?(submission) || submission.exercise_completed? %>

--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -41,6 +41,7 @@ require 'exercism/user_exercise'
 require 'exercism/work'
 require 'exercism/log_entry'
 require 'exercism/language_track'
+require 'exercism/user_lookup'
 
 require 'db/connection'
 DB::Connection.establish

--- a/lib/exercism/user_lookup.rb
+++ b/lib/exercism/user_lookup.rb
@@ -1,0 +1,35 @@
+class UserLookup
+  def initialize(params)
+    @params = params
+  end
+
+  def lookup
+    if query.blank?
+      []
+    else
+      users_by_participation.pluck(:username)
+    end
+  end
+
+  private
+
+  def users_by_participation
+    users.order("id IN (#{commenter_ids}) DESC").order(:username)
+  end
+
+  def users
+    User.where('username LIKE ?', query + '%').limit(8)
+  end
+
+  def commenter_ids
+    Comment.select(:user_id).where(submission: submission).to_sql
+  end
+
+  def query
+    @params[:query]
+  end
+
+  def submission
+    Submission.find_by(key: @params[:submission_key])
+  end
+end


### PR DESCRIPTION
Closes #1805

When given a submission_id, order commenters higher than non-commenters
Match only by beginning of username, rather than anywhere in username
Change user lookup http request from POST to GET
All else being equal, sort alphabetically by username

At least two things I'm unsure of:
1. If passing the `submission_id` as I'm doing it (with the `data-sumission-id` attribute on an html element, and then looking it up in the DOM using Javascript) is the correct way of getting that info for the http request.
2. If it's ok to expose the `submission_id` in the html of the page delivered to the client, or if I should instead change it to use the `submission_key`.