### PR TITLE
Pass submission to 'submissions/comment' erb

### DIFF
--- a/lib/app/views/submissions/edit_nit.erb
+++ b/lib/app/views/submissions/edit_nit.erb
@@ -4,7 +4,7 @@
   </section>
   <section>
     <form action="/submissions/<%= submission.key %>/nits/<%= nit.id %>" method='POST'>
-      <%= erb :"submissions/comment", locals: {nit: nit} %>
+      <%= erb :"submissions/comment", locals: {nit: nit, submission: submission} %>
       <div>
         <button type="submit" class="btn btn-primary">Submit</button>
       </div>

--- a/test/acceptance/nits_test.rb
+++ b/test/acceptance/nits_test.rb
@@ -83,4 +83,13 @@ class NitsTest < AcceptanceTestCase
       assert_content "You haven't received any nitpicks yet"
     end
   end
+
+  def test_navigate_to_edit_nit_page
+    nit = submission.comments.create(user: @user, body: "Test nit given body")
+
+    with_login(@user) do
+      visit "/submissions/#{submission.key}/nits/#{nit.id}/edit"
+      assert_content "Edit Nitpick"
+    end
+  end
 end


### PR DESCRIPTION
I was receiving an exception while trying to navigate to the edit nit page:

```
NameError - undefined local variable or method `submission' for #<ExercismWeb::Routes::Comments:0x007f59ff806a28>
```

`submissions/comment.erb` is calling `submissions` but was not receiving it as a local.