### PR TITLE
Remove already supported "Coming Up" Languages

### DIFF
--- a/lib/app/views/site/about.erb
+++ b/lib/app/views/site/about.erb
@@ -9,7 +9,7 @@
         <h4 class="header">Languages</h4>
         <p>
         Exercises are currently available in <%= languages %>.
-        Coming Up: Java, Rust, Erlang, PHP, C, and Common Lisp.
+        Coming Up: Java, Rust, PHP, and C.
         </p>
       </div>
     </article>


### PR DESCRIPTION
These were already listed in the "Exercises are currently available in: " section, so I removed them being duplicated in the "Coming Up:" section. Just wanted it to be a little more clear.