### PR TITLE
Updated GitHub link text in footer

### DIFF
--- a/lib/app/views/application/footer/social.erb
+++ b/lib/app/views/application/footer/social.erb
@@ -2,7 +2,7 @@
   <li>
     <a href="https://github.com/exercism/exercism.io">
       <i class="fa fa-github fa-lg"></i>
-      Github
+      GitHub
     </a>
   </li>
   <li>


### PR DESCRIPTION
GitHub link on footer didn't match the GitHub case used across the rest of the site.