### PR TITLE
Updated language list. Fixes #2199

### DIFF
--- a/lib/app/views/site/about.erb
+++ b/lib/app/views/site/about.erb
@@ -9,7 +9,7 @@
         <h4 class="header">Languages</h4>
         <p>
         Exercises are currently available in <%= languages %>.
-        Coming Up: Java, Rust, PHP, and C.
+        Coming Up: Rust, PHP, and C.
         </p>
       </div>
     </article>

--- a/lib/exercism/config.rb
+++ b/lib/exercism/config.rb
@@ -44,8 +44,8 @@ class Exercism
       @languages ||= tracks.select {|slug, name|
         %i(
           clojure coffeescript csharp cpp elixir erlang
-          fsharp go haskell javascript lua lisp objective-c
-          ocaml perl5 plsql python ruby scala swift
+          fsharp go haskell java javascript lua lisp objective-c
+          ocaml perl5 plsql python r ruby scala swift
         ).include?(slug)
       }
     end
@@ -55,7 +55,7 @@ class Exercism
     end
 
     def self.upcoming
-      ['D', 'ECMAScript', 'Java', 'Rust', 'PHP'] - current
+      ['D', 'ECMAScript', 'Rust', 'PHP'] - current
     end
   end
 end


### PR DESCRIPTION
Added Java and R to the language list on /about and /getting-started. Should now match the languages on help.exercism.io.