### PR TITLE
Updated Lineman setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ You can view the emails sent in [MailCatcher](http://mailcatcher.me) in your bro
 [Lineman](http://linemanjs.com) watches for file changes and compiles them automatically. It is not
 required to be running for the server to run though.
 
-* Install Lineman with: `sudo npm install -g lineman`
+* Install Lineman with: `npm install -g lineman`
 * To run: `cd frontend` and start Lineman with `lineman run`
 
 ### SCSS


### PR DESCRIPTION
Doesn't seem like ```sudo``` is necessary for installing Lineman, but correct me if I'm wrong.