### PR TITLE
Updated notifications email. Fixes #2209

### DIFF
--- a/lib/services/email/notifications.erb
+++ b/lib/services/email/notifications.erb
@@ -1,6 +1,7 @@
 Hi <%= name %>,
 
-<%= subject %> waiting for you at Exercism.io.
+You have <%= notifications_count %> waiting for you at Exercism.io.
+<%= site_root %>/notifications
 <% notifications.each do |notification| %>
 <%= notification.language %>: <%= notification.slug %> (<%= site_root %><%= notification.link %>)
 <%= notification.regarding %> <%= from(notification.creator) %> <%= ago(notification.created_at) %>

--- a/lib/services/email/notifications.html.erb
+++ b/lib/services/email/notifications.html.erb
@@ -1,6 +1,6 @@
 <p>Hi <%= name %>,</p>
 
-<p><%= subject %> waiting for you at Exercism.io.<p>
+<p>You have <a href="<%= site_root %>/notifications"><%= notifications_count %></a> waiting for you at Exercism.io.<p>
 <% if truncated? %>
 <p>Here are the most recent ones:</p>
 <% end %>

--- a/lib/services/notification_message.rb
+++ b/lib/services/notification_message.rb
@@ -9,9 +9,14 @@ class NotificationMessage < Message
     @site_root = options.fetch(:site_root) { 'http://exercism.io' }
   end
 
+  def notifications_count
+    # "5 notifications"
+    "#{unread_notifications.count} #{'notification'.pluralize(notifications.count)}"
+  end
+
   def subject
     # "You have 5 notifications"
-    "You have #{unread_notifications.count} #{'notification'.pluralize(notifications.count)}"
+    "You have #{notifications_count}"
   end
 
   def recipient


### PR DESCRIPTION
Took a stab at adding the notifications link to notification emails.  Appears to be working correctly in MailCatcher.