### PR TITLE
Dockerize exercism.io app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.1.5
+
+RUN mkdir /exercism
+
+WORKDIR /exercism
+
+ADD Gemfile /exercism/Gemfile
+ADD Gemfile.lock /exercism/Gemfile.lock
+
+RUN bundle install

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,7 +3,7 @@ postgres: &postgres
   adapter: postgresql
   encoding: unicode
   pool: 5
-  host: localhost
+  host: db
   username: exercism
   password: apples
 

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:9.4
+
+ADD scripts/init_db.sh /docker-entrypoint-initdb.d/

--- a/db/scripts/init_db.sh
+++ b/db/scripts/init_db.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo "******CREATING DATABASE******"
+gosu postgres postgres --single <<- EOSQL
+   CREATE DATABASE exercism_development;
+EOSQL
+echo ""
+echo "******DATABASE CREATED*******"

--- a/fig.yml
+++ b/fig.yml
@@ -1,0 +1,19 @@
+db:
+  build: ./db
+  environment:
+    POSTGRES_USER: exercism
+    POSTGRES_PASSWORD: apples
+
+web:
+  build: .
+  links:
+    - db
+  command: foreman start
+  volumes:
+    - .:/exercism
+  ports:
+    - "4567:4567"
+  environment:
+    EXERCISM_GITHUB_CLIENT_ID: your_git_client_id
+    EXERCISM_GITHUB_CLIENT_SECRET: your_git_client_secret
+    PORT: 4567


### PR DESCRIPTION
I think this is the basic docker setup that can be used for fast development... All we need is docker and fig(http://www.fig.sh/install.html)...

For Starting app
1) Clone the app git clone git@github.com:exercism/exercism.io.git
2) Install Docker and fig
3) Run fig up

Then we should be able to access the app on http://localhost:4567.. We might need to run fig run web rake db:migrate for creating tables though



