### PR TITLE
Add users that haven't signed in to team

### DIFF
--- a/lib/app/routes/teams.rb
+++ b/lib/app/routes/teams.rb
@@ -46,7 +46,7 @@ module ExercismWeb
 
       post '/teams/:slug/members' do |slug|
         only_for_team_managers(slug, "You are not allowed to add team members.") do |team|
-          invitees = ::User.find_in_usernames(params[:usernames].to_s.scan(/[\w-]+/)) - team.all_members
+          invitees = ::User.find_or_create_in_usernames(params[:usernames].to_s.scan(/[\w-]+/)) - team.all_members
           team.recruit(params[:usernames])
           team.save
           notify(invitees, team)

--- a/lib/exercism/team.rb
+++ b/lib/exercism/team.rb
@@ -32,12 +32,12 @@ class Team < ActiveRecord::Base
   def defined_with(options)
     self.slug = options[:slug]
     self.name = options[:name]
-    self.unconfirmed_members = User.find_in_usernames(options[:usernames].to_s.scan(/\w+/)) if options[:usernames]
+    self.unconfirmed_members = User.find_or_create_in_usernames(options[:usernames].to_s.scan(/\w+/)) if options[:usernames]
     self
   end
 
   def recruit(usernames)
-    recruits = User.find_in_usernames(usernames.to_s.scan(/[\w-]+/)) - self.all_members
+    recruits = User.find_or_create_in_usernames(usernames.to_s.scan(/[\w-]+/)) - self.all_members
     self.unconfirmed_members += recruits
   end
 


### PR DESCRIPTION
Whenever we add someone to a team we make sure that they exist if they don't we create them.

Fixes #2124 

