### PR TITLE
Change column name 'Iterations' to 'Current Iteration' on accounts page.

### DIFF
--- a/lib/app/views/account/show.erb
+++ b/lib/app/views/account/show.erb
@@ -42,7 +42,7 @@
             <tr>
               <th>Exercise</th>
               <th>Language</th>
-              <th>Iterations</th>
+              <th>Current Iteration</th>
               <th>Nits</th>
             </tr>
           </thead>
@@ -69,7 +69,7 @@
             <tr>
               <th>Exercise</th>
               <th>Language</th>
-              <th>Iterations</th>
+              <th>Current Iteration</th>
               <th>Nits</th>
             </tr>
           </thead>


### PR DESCRIPTION
Fixes #2226 
Current iteration info of each exercise is shown on accounts page.
The column name `Iterations` seemed to denote total number of
iterations. Change it to `Current Iteration`.