### PR TITLE
Change user exercise's state when someone comments

### DIFF
--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -202,6 +202,10 @@ class Submission < ActiveRecord::Base
     user_exercise.hibernating?
   end
 
+  def exercise_pending?
+    user_exercise.pending?
+  end
+
   def prior
     @prior ||= related.where(version: version-1).first
   end

--- a/lib/exercism/use_cases/creates_comment.rb
+++ b/lib/exercism/use_cases/creates_comment.rb
@@ -22,7 +22,7 @@ class CreatesComment
     @comment = submission.comments.create(user: commenter, body: body)
     unless @comment.new_record?
       submission.unmute_all!
-      submission.state = 'pending' if submission.hibernating?
+      submission.user_exercise.reopen! if submission.hibernating?
       submission.mute(commenter)
       unless submission.user == commenter
         submission.nit_count += 1

--- a/lib/exercism/user_exercise.rb
+++ b/lib/exercism/user_exercise.rb
@@ -53,6 +53,10 @@ class UserExercise < ActiveRecord::Base
     state == 'hibernating'
   end
 
+  def pending?
+    state == 'pending'
+  end
+
   def nit_count
     submissions.pluck(:nit_count).sum
   end

--- a/test/exercism/use_cases/creates_comment_test.rb
+++ b/test/exercism/use_cases/creates_comment_test.rb
@@ -73,10 +73,18 @@ class CreatesCommentTest < Minitest::Test
   def test_nitpicking_hibernating_exercise_sets_it_to_pending
     submission.state = 'hibernating'
     submission.save
+
     nitpicker = User.new(username: 'alice')
+    UserExercise.create(
+      user: nitpicker,
+      state: 'hibernating',
+      submissions: [ submission ]
+    )
+
     nitpick = CreatesComment.new(submission.id, nitpicker, 'a comment').create
     submission.reload
     assert submission.pending?
+    assert submission.exercise_pending?
   end
 
   def test_do_not_change_state_of_completed_submission


### PR DESCRIPTION
Whenever we comment on a hibernating `Submission` we must also make sure that we change `UserExercise`'s state too. Previously, `UserExercise`'s state stayed as hibernating which is why users were seeing alerts despite commenting.  

Fixes #2179 