### PR TITLE
Fix for double posting comments with ⌘+Enter

### DIFF
--- a/frontend/app/js/script.js
+++ b/frontend/app/js/script.js
@@ -29,10 +29,17 @@ $(function() {
     $("a[data-action='enlarge']",codeDiv).show();
   });
 
-  $('form input[type=submit], form button[type=submit]').on('click', function() {
-    var $this = $(this);
+  $('form').on('submit', function() {
+    var $this = $(this).find('button');
     window.setTimeout(function() { $this.attr('disabled', true); }, 1);
   });
+
+  $("form").submit(function() {
+    $(this).submit(function() {
+      return false;
+    });
+  });
+
 
   $('textarea').each(function () {
     var $this = $(this);

--- a/frontend/app/js/script.js
+++ b/frontend/app/js/script.js
@@ -30,7 +30,7 @@ $(function() {
   });
 
   $('form').on('submit', function() {
-    var $this = $(this).find('button');
+    var $this = $(this).find(':submit');
     window.setTimeout(function() { $this.attr('disabled', true); }, 1);
   });
 

--- a/lib/app/public/js/app.js
+++ b/lib/app/public/js/app.js
@@ -30181,7 +30181,7 @@ $(function() {
   });
 
   $('form').on('submit', function() {
-    var $this = $(this).find('button');
+    var $this = $(this).find(':submit');
     window.setTimeout(function() { $this.attr('disabled', true); }, 1);
   });
 

--- a/lib/app/public/js/app.js
+++ b/lib/app/public/js/app.js
@@ -30180,9 +30180,15 @@ $(function() {
     $("a[data-action='enlarge']",codeDiv).show();
   });
 
-  $('form input[type=submit], form button[type=submit]').on('click', function() {
-    var $this = $(this);
+  $('form').on('submit', function() {
+    var $this = $(this).find('button');
     window.setTimeout(function() { $this.attr('disabled', true); }, 1);
+  });
+
+  $("form").submit(function() {
+    $(this).submit(function() {
+      return false;
+    });
   });
 
   $('textarea').each(function () {


### PR DESCRIPTION
Fixes the issue where the submit button isn’t disabled when the user submits a nit using `cmd/ctrl + enter` the submit button will be disabled.

It also fixes the user being able to send `cmd/ctrl + enter` multiple times which would send multiple comments with the same body.

I only changed the Javascript under `lib/app/public` and not under `/frontend`. Should I add it there as well or is `/frontend` only for style development?

closes #2221 