### PR TITLE
Only skipped new exercises.

### DIFF
--- a/lib/api/routes/iterations.rb
+++ b/lib/api/routes/iterations.rb
@@ -14,10 +14,16 @@ module ExercismAPI
           halt 401, {error: "Please double-check your exercism API key."}.to_json
         end
 
-        if UserExercise.new(user_id: current_user.id, language: language, slug: slug, iteration_count: 0, state: 'unstarted').save
+        exercise = UserExercise.where(user_id: current_user.id, language: language, slug: slug).first_or_initialize(iteration_count: 0, state: 'unstarted')
+        if exercise.new_record?
+          exercise.save!
+
           halt 204
         else
-          halt 400, {error: "Failed to skip '#{slug}' in '#{language}'."}.to_json
+          message = "Exercise '#{slug}' in '#{language}' has already been "
+          message += exercise.state == "unstarted" ? "skipped." : "started."
+
+          halt 400, {error: message}.to_json
         end
       end
 


### PR DESCRIPTION
While implementing https://github.com/exercism/cli/issues/73 I ran into this issue. Let me know if this is how we want to handle attempts to skipping invalid exercises. 

Skipping an already started or skipped exercises would cause an exception due to an unique index on the `UserExercise` fields. We only want to skip exercises that have not been attempted or skipped

