### PR TITLE
Don't display beta banner on mobile

### DIFF
--- a/lib/app/public/sass/base/components/beta_banner.scss
+++ b/lib/app/public/sass/base/components/beta_banner.scss
@@ -39,4 +39,7 @@
       border-color: rgba(255, 255, 255, 0.7);
     }
   }
+  @media (max-device-width: 480px) {
+    display:none;
+  }
 }


### PR DESCRIPTION
I find it hard to write a quick comment on my phone because the beta banner is hidding the nitpick form. I suggest hiding the banner on mobile.

![Beta banner hiding the nitpick form](https://cloud.githubusercontent.com/assets/1919681/6685796/9a928dce-cc73-11e4-8f03-b5aadccd85f0.png)
