### PR TITLE
Link to my submission

### DIFF
--- a/lib/app/helpers/submissions_helper.rb
+++ b/lib/app/helpers/submissions_helper.rb
@@ -62,5 +62,9 @@ module Sinatra
         submission.save!
       end
     end
+
+    def their_submission_to(user, submission)
+      submission.participant_submissions(current_user).find { |s| s.user == user }
+    end
   end
 end

--- a/lib/app/views/submissions/nit.erb
+++ b/lib/app/views/submissions/nit.erb
@@ -1,7 +1,7 @@
 <div class="comment <%= "comment-submitter" if nit.nitpicker == submission.user %>">
   <div class="comment-author">
-    <a href="/<%= nit.user.username %>">
-      <img src="<%= nit.user.avatar_url %>" class="img-responsive img-rounded" />
+    <a href="/<%= nit.nitpicker.username %>">
+      <img src="<%= nit.nitpicker.avatar_url %>" class="img-responsive img-rounded" />
     </a>
   </div>
   <div class="comment-body">
@@ -11,10 +11,24 @@
         <a href="/submissions/<%= submission.key %>/nits/<%= nit.id %>/edit" class="pull-right btn btn-default btn-xs edit-text">
           <i class="fa fa-pencil"></i> Edit
         </a>
+
+      <% elsif submission.user != nit.nitpicker %>
+        <% if their_submission = their_submission_to(nit.nitpicker, submission) %>
+          <a
+            href="/submissions/<%= their_submission.key %>"
+            class="pull-right btn btn-default btn-xs"
+            data-toggle="tooltip"
+            data-placement="bottom"
+            title="<%= nit.nitpicker.username %>'s submission for this exercise"
+            target="_blank">
+            <i class="fa fa-rocket"></i>
+          </a>
+        <% end %>
       <% end %>
 
-      <%= profile_link(nit.user) %>
+      <%= profile_link(nit.nitpicker) %>
       commented <%= ago(nit.created_at) %>
+      
     </div>
   </div>
 </div>

--- a/lib/app/views/submissions/toolbar.erb
+++ b/lib/app/views/submissions/toolbar.erb
@@ -13,6 +13,19 @@
         target="_blank">
         <i class="fa fa-twitter"></i>
       </a>
+    <% else %>
+      <% if my_submission = their_submission_to(current_user, submission) %>
+        <a
+          href="/submissions/<%= my_submission.key %>"
+          class="btn btn-default"
+          data-toggle="tooltip"
+          data-placement="bottom"
+          title="My submission for this exercise"
+          target="_blank">
+          <i class="fa fa-rocket"></i>
+        </a>
+      <% end %>
+
     <% end %>
     <a
       href="<%= language_path_for_slug(submission.problem.track_id, submission.problem.slug) %>"

--- a/lib/exercism/submission.rb
+++ b/lib/exercism/submission.rb
@@ -214,6 +214,15 @@ class Submission < ActiveRecord::Base
     @related ||= Submission.related(self)
   end
 
+  def participant_submissions(current_user = nil)
+    @participant_submissions ||= begin
+      user_ids = [*comments.map(&:user), current_user].compact.map(&:id)
+      self.class.reversed
+        .where(user_id: user_ids, language: track_id, slug: slug)
+        .where.not(state: 'superseded')
+    end
+  end
+
   private
 
   # Experiment: Cache the iteration number so that we can display it


### PR DESCRIPTION
I have a suggestion that I think will increase the incentive to nitpick: **provide a link to a nitpicker's submission below their comment.** This way, people are more likely to nitpick their nitpicker's code!

This also adds a link to a user's own submission for a problem they are viewing. I find myself often wanting to review my own code after looking at someone's implementation but it's too many clicks away.

I added tests for Submission#participant_submissions. That method avoids N queries when there are N comments. Please check that it will correctly return the latest submission for each user. I used `where.not(state: 'superseded')` for that condition.

### Link to my submission:
![my_submission](https://cloud.githubusercontent.com/assets/1919681/6766254/142ac868-cfd5-11e4-86b8-aca7e4c79f03.png)

### Link to nitpicker's submission:
![their_submission](https://cloud.githubusercontent.com/assets/1919681/6766257/249636d8-cfd5-11e4-9c44-57e89428fde5.png)



