### PR TITLE
README: better prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For working on the backend you'll need both Ruby and PostgreSQL. Frontend develo
 To install Ruby, check out [RVM](https://rvm.io), [rbenv](https://github.com/sstephenson/rbenv) or [ruby-install](https://github.com/postmodern/ruby-install).
 
 PostgreSQL can be installed with [Homebrew](http://brew.sh) on Mac OS X: `brew install postgresql`  
-If you're on a Linux system with apt-get then run: `apt-get install postgresql-9.2`
+If you're on a Linux system with apt-get then run: `apt-get install postgresql postgresql-contrib`
 
 Install Node.js and npm on Mac OS X with Homebrew:  `brew install node`  
 On other systems see the [Node.js docs](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ running locally.
 
 For working on the backend you'll need both Ruby and PostgreSQL. Frontend development uses Node.js.
 
-To install Ruby, check out [RVM](https://rvm.io), [rbenv](https://github.com/sstephenson/rbenv) or [chruby](https://github.com/postmodern/chruby).
+To install Ruby, check out [RVM](https://rvm.io), [rbenv](https://github.com/sstephenson/rbenv) or [ruby-install](https://github.com/postmodern/ruby-install).
 
 PostgreSQL can be installed with [Homebrew](http://brew.sh) on Mac OS X: `brew install postgresql`  
 If you're on a Linux system with apt-get then run: `apt-get install postgresql-9.2`


### PR DESCRIPTION
Three minor changes to the README’s [Prerequisites section](https://github.com/exercism/exercism.io#prerequisites):

* chruby is for Ruby switching, but for installing is ruby-install,
* the postgresql package always depends on the latest version,
* the postgresql-contrib package is needed for the citext extension.