### PR TITLE
Working db setup tasks

### DIFF
--- a/lib/db/connection.rb
+++ b/lib/db/connection.rb
@@ -11,10 +11,11 @@ module DB
 
     def establish
       ActiveRecord::Base.establish_connection(config)
+      self
     end
 
     def environment
-      ENV.fetch('RACK_ENV') { 'development'}
+      ENV.fetch('RACK_ENV') { 'development' }
     end
 
     def config

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -2,7 +2,7 @@ namespace :db do
   require 'bundler'
   Bundler.require
   require_relative '../db/connection'
-  DB::Connection.establish
+  conn = DB::Connection.establish
 
   desc "migrate your database"
   task :migrate do
@@ -24,8 +24,12 @@ namespace :db do
 
   desc "set up your database"
   task :setup do
-    `createuser -s exercism`
-    `createdb -O exercism exercism_development`
+    db, host, user, pass = conn.config.values_at('database', 'host',
+                                                 'username', 'password')
+    sql = "CREATE USER #{user} PASSWORD '#{pass}' " \
+          'SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN'
+    system 'psql', '-h', host, '-c', sql
+    system 'createdb', '-h', host, '-O', user, db
   end
 
   desc "drop and recreate your database"

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -34,8 +34,9 @@ namespace :db do
 
   desc "drop and recreate your database"
   task :reset do
-    `dropdb exercism_development`
-    `createdb -O exercism exercism_development`
+    db, host, user = conn.config.values_at('database', 'host', 'username')
+    system 'dropdb', '-h', host, db
+    system 'createdb', '-h', host, '-O', user, db
   end
 
   namespace :generate do

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -22,8 +22,13 @@ namespace :db do
     require 'bundler'
     Bundler.require
     require 'exercism'
+    require_relative '../db/connection'
 
-    %x{psql -U exercism -d exercism_development -f db/seeds.sql}
+    config = DB::Connection.new.config
+    db, host, user, pass = config.values_at('database', 'host',
+                                            'username', 'password')
+    system({ 'PGPASSWORD' => pass },
+           'psql', '-h', host, '-U', user, '-d', db, '-f', 'db/seeds.sql')
 
     # Trigger generation of html body
     Comment.find_each { |comment| comment.save }


### PR DESCRIPTION
This makes the `db:setup`, `db:reset` and `db:seed` tasks actually work and use the values from `config/database.yml`.

This uses the host everywhere, so it works in default PostgreSQL configurations (which require peer identification on socket connections and only allow user/pass auth when connecting over the network). This also creates the PostgreSQL user with a password and then uses that password where needed.

This also uses `Kernel#system` – rather than <code>Kernel#`</code> – as the former does proper shell escaping.

I don’t like how the config values are obtained here (and that `DB::Connection.establish` violates CQRS), but getting the config from an existing `DB::Connection` was simpler than instantiating a `DB::Config` with the right environment. In the long run I think it should be `DB::Config` that knows the environment (and defaults to `development`), not `DB::Connection` (which should just instantiate a new `DB::Config`). I can prepare such a PR if needed. :)