### PR TITLE
Move env handling from DB::Connection to DB::Config

### DIFF
--- a/lib/db/config.rb
+++ b/lib/db/config.rb
@@ -1,5 +1,5 @@
-require 'yaml'
 require 'erb'
+require 'yaml'
 
 module DB
   class Config
@@ -10,13 +10,11 @@ module DB
     class UnconfiguredEnvironment < StandardError; end
 
     attr_reader :file, :environment
-    def initialize(environment, file=default_database_config)
+
+    def initialize(environment = default_environment,
+                   file = default_database_config)
       @environment = environment
       @file = file
-    end
-
-    def default_database_config
-      relative_to_root('config', 'database.yml')
     end
 
     def options
@@ -30,13 +28,18 @@ module DB
       result
     end
 
+    private
+
+    def default_database_config
+      relative_to_root('config', 'database.yml')
+    end
+
+    def default_environment
+      ENV.fetch('RACK_ENV') { 'development' }
+    end
+
     def yaml
-      if ENV['RACK_ENV'] == 'production'
-        ERB.new(File.read(file)).result binding
-      else
-        File.read(file)
-      end
+      ERB.new(File.read(file)).result(binding)
     end
   end
-
 end

--- a/lib/db/connection.rb
+++ b/lib/db/connection.rb
@@ -1,10 +1,8 @@
 require 'active_record'
-require 'db/config'
-# require 'pg'
+require_relative 'config'
 
 module DB
   class Connection
-
     def self.establish
       new.establish
     end
@@ -14,12 +12,8 @@ module DB
       self
     end
 
-    def environment
-      ENV.fetch('RACK_ENV') { 'development' }
-    end
-
     def config
-      @config ||= DB::Config.new(environment).options
+      @config ||= DB::Config.new.options
     end
   end
 end

--- a/test/db/config_test.rb
+++ b/test/db/config_test.rb
@@ -15,6 +15,25 @@ class DB::ConfigTest < Minitest::Test
     assert_equal 'exercism_development', DB::Config.new('development').options['database']
   end
 
+  def test_defaults_to_the_current_environment
+    assert_equal 'test', DB::Config.new.environment
+  end
+
+  def test_uses_environment_from_RACK_ENV
+    original_rack_env = ENV.delete('RACK_ENV')
+    ENV['RACK_ENV'] = 'custom'
+    assert_equal 'custom', DB::Config.new.environment
+  ensure
+    ENV['RACK_ENV'] = original_rack_env if original_rack_env
+  end
+
+  def test_defaults_to_development_if_RACK_ENV_unset
+    original_rack_env = ENV.delete('RACK_ENV')
+    assert_equal 'development', DB::Config.new.environment
+  ensure
+    ENV['RACK_ENV'] = original_rack_env if original_rack_env
+  end
+
   def test_override_file
     file = relative_to_root('test', 'fixtures', 'database.yml')
     assert_equal file, DB::Config.new('env', file).file


### PR DESCRIPTION
This moves environment handling from `DB::Connection` to `DB::Config` as per https://github.com/exercism/exercism.io/pull/2246#issuecomment-84512331 (and cleans both a bit along the way).