### PR TITLE
Better rake db tasks and setup instructions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,17 +34,16 @@ gem 'font-awesome-sass'
 gem 'kss'
 
 group :test, :development do
-  # gem 'ruby-prof', '~> 0.14'
-  gem 'database_cleaner', require: false
   gem 'approvals', require: false
-  gem 'rack-test', require: false
-  gem 'mocha', require: false
-  gem 'simplecov', require: false
   gem 'coveralls', require: false
+  gem 'database_cleaner', require: false
   gem 'foreman', require: false
+  gem 'mailcatcher', require: false
+  gem 'mocha', require: false
+  gem 'rack-test', require: false
+  gem 'simplecov', require: false
   gem 'sqlite3'
   gem 'timecop', require: false
-  # gem 'debugger'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,11 +55,13 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
+    daemons (1.1.9)
     database_cleaner (1.3.0)
     docile (1.1.5)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
     dotenv-deployment (0.0.2)
+    eventmachine (1.0.5)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.6)
@@ -80,6 +82,14 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    mailcatcher (0.6.1)
+      activesupport (>= 4.0.0, < 5)
+      eventmachine (~> 1.0.0, <= 1.0.5)
+      mail (~> 2.3)
+      sinatra (~> 1.2)
+      skinny (~> 0.2.3)
+      sqlite3 (~> 1.3)
+      thin (~> 1.5.0)
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (2.4.3)
@@ -149,10 +159,17 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (~> 1.3)
+    skinny (0.2.3)
+      eventmachine (~> 1.0.0)
+      thin (~> 1.5.0)
     slop (3.6.0)
     sqlite3 (1.3.9)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
+    thin (1.5.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 0.12.6)
+      rack (>= 1.0.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -185,6 +202,7 @@ DEPENDENCIES
   kss
   launchy
   loofah
+  mailcatcher
   minitest-capybara
   mocha
   newrelic_rpm (~> 3.8)

--- a/README.md
+++ b/README.md
@@ -208,10 +208,9 @@ user.submissions
 
 ## Testing
 
-1. Create a test database: `createdb -O exercism exercism_test`
-2. Prepare the test environment: `RACK_ENV=test rake db:migrate`
-3. Make sure MailCatcher is running: `mailcatcher`
-4. Run the test suite: `rake` or `rake test`
+1. Create and migrate a test database: `RACK_ENV=test rake db:setup db:migrate`
+1. Make sure MailCatcher is running: `mailcatcher`
+1. Run the test suite: `rake` or `rake test`
 
 To run a single test suite, you can do so with:
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ You don't need to fill in the EXERCISES_API value unless you're going to be work
 Next, make sure all the application dependencies are installed:
 
 * Install gems with: `bundle install`
-* Install MailCatcher with: `gem install mailcatcher`
 
 ### Data
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ Next, make sure all the application dependencies are installed:
 Finally, set up the database. This means both creating the underlying database, and migrating so that it
 has all the correct tables. Also run a script to add fake data, so there are things to click on and look at while working on the app.
 
+* Do all of it in one go: `rake db:from_scratch`
+
+Alternatively (or to debug if the above blows up), do it one-by-one:
+
 * Create the PostgreSQL database: `rake db:setup`
 * Run the database migrations: `rake db:migrate`
 * Fetch the seed data: `rake db:seeds:fetch`

--- a/lib/db/config.rb
+++ b/lib/db/config.rb
@@ -17,6 +17,10 @@ module DB
       @file = file
     end
 
+    %i(database host password username).each do |field|
+      define_method(field) { options[field.to_s] }
+    end
+
     def options
       result = YAML.load(yaml)[environment]
 

--- a/lib/db/connection.rb
+++ b/lib/db/connection.rb
@@ -9,7 +9,6 @@ module DB
 
     def establish
       ActiveRecord::Base.establish_connection(config)
-      self
     end
 
     def config

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,8 +1,9 @@
 namespace :db do
   require 'bundler'
   Bundler.require
+  require_relative '../db/config'
   require_relative '../db/connection'
-  conn = DB::Connection.establish
+  DB::Connection.establish
 
   desc "migrate your database"
   task :migrate do
@@ -24,19 +25,18 @@ namespace :db do
 
   desc "set up your database"
   task :setup do
-    db, host, user, pass = conn.config.values_at('database', 'host',
-                                                 'username', 'password')
-    sql = "CREATE USER #{user} PASSWORD '#{pass}' " \
+    config = DB::Config.new
+    sql = "CREATE USER #{config.username} PASSWORD '#{config.password}' " \
           'SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN'
-    system 'psql', '-h', host, '-c', sql
-    system 'createdb', '-h', host, '-O', user, db
+    system 'psql', '-h', config.host, '-c', sql
+    system 'createdb', '-h', config.host, '-O', config.username, config.database
   end
 
   desc "drop and recreate your database"
   task :reset do
-    db, host, user = conn.config.values_at('database', 'host', 'username')
-    system 'dropdb', '-h', host, db
-    system 'createdb', '-h', host, '-O', user, db
+    config = DB::Config.new
+    system 'dropdb', '-h', config.host, config.database
+    system 'createdb', '-h', config.host, '-O', config.user, config.database
   end
 
   namespace :generate do

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -39,6 +39,9 @@ namespace :db do
     system 'createdb', '-h', config.host, '-O', config.user, config.database
   end
 
+  desc 'set the database up from scratch'
+  task from_scratch: %i(setup migrate seeds:fetch seed)
+
   namespace :generate do
     desc "generate migration"
     task :migration do

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -22,13 +22,12 @@ namespace :db do
     require 'bundler'
     Bundler.require
     require 'exercism'
-    require_relative '../db/connection'
+    require_relative '../db/config'
 
-    config = DB::Connection.new.config
-    db, host, user, pass = config.values_at('database', 'host',
-                                            'username', 'password')
-    system({ 'PGPASSWORD' => pass },
-           'psql', '-h', host, '-U', user, '-d', db, '-f', 'db/seeds.sql')
+    config = DB::Config.new
+    system({ 'PGPASSWORD' => config.password },
+           'psql', '-h', config.host, '-U', config.username,
+                   '-d', config.database, '-f', 'db/seeds.sql')
 
     # Trigger generation of html body
     Comment.find_each { |comment| comment.save }

--- a/test/db/config_test.rb
+++ b/test/db/config_test.rb
@@ -57,4 +57,20 @@ class DB::ConfigTest < Minitest::Test
       config.options
     end
   end
+
+  def test_exposes_database
+    assert_equal 'exercism_test', DB::Config.new.database
+  end
+
+  def test_exposes_host
+    assert_equal 'localhost', DB::Config.new.host
+  end
+
+  def test_exposes_password
+    assert_equal 'apples', DB::Config.new.password
+  end
+
+  def test_exposes_username
+    assert_equal 'exercism', DB::Config.new.username
+  end
 end


### PR DESCRIPTION
This makes the `rake db` tasks a bit better:

* exposes `DB::Config#database`, `#host`, `#password` and `#username` (and uses them in tasks),
* adds `rake db:from_scratch` that sets up the development database in one go.

This also installs the mailcatcher gem in development and adjusts the README accordingly.