### PR TITLE
Minor refactor of site_title_helper

### DIFF
--- a/lib/app/helpers/site_title_helper.rb
+++ b/lib/app/helpers/site_title_helper.rb
@@ -1,10 +1,7 @@
 module Sinatra
   module SiteTitleHelper
-
     def title(value = nil)
-      @title = value if value
-      @title ? "#{@title}" : "exercism.io"
+      value || "exercism.io"
     end
-
   end
 end


### PR DESCRIPTION
The method seems to be returning the string "exercism.io" when no value was passed to it explicitly, and return the passed value itself when one is passed.