### PR TITLE
Disallow skipping non existent problems

### DIFF
--- a/test/api/iterations_test.rb
+++ b/test/api/iterations_test.rb
@@ -121,4 +121,15 @@ class ItertaionsApiTest < Minitest::Test
     assert_equal 404, last_response.status
     assert last_response.body.include?(expected_message)
   end
+
+  def test_skip_problem_as_guest
+    Xapi.stub(:exists?, true) do
+      post '/iterations/ruby/one/skip', { key: 'invalid-api-key' }
+    end
+
+    expected_message = "Please double-check your exercism API key."
+
+    assert_equal 401, last_response.status
+    assert last_response.body.include?(expected_message)
+  end
 end


### PR DESCRIPTION
This should solve #2239. System now checks if the issue exists before allowing the user to skip it. It returns 404 and error message if the issue doesn't exist.

I also noticed missing test case for when guest user is trying to skip the issue, so I added it and I moved things around a bit for better readability (introduced some variables, split longer lines etc.).

Ideally I would continue and refactor `api/iterations_test.rb` and maybe `iterations.rb` itself. Any thoughts on this?