### PR TITLE
Fix rake db reset task

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -25,7 +25,6 @@ namespace :db do
 
   desc "set up your database"
   task :setup do
-    config = DB::Config.new
     sql = "CREATE USER #{config.username} PASSWORD '#{config.password}' " \
           'SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN'
     system 'psql', '-h', config.host, '-c', sql
@@ -33,21 +32,15 @@ namespace :db do
   end
 
   desc "drop and recreate your database"
-  task :reset do
-    config = DB::Config.new
-    system 'dropdb', '-h', config.host, config.database
-    system 'createdb', '-h', config.host, '-O', config.username, config.database
-  end
+  task reset: %i(drop create)
 
   desc "drop your databas"
   task :drop do
-    config = DB::Config.new
     system 'dropdb', '-h', config.host, config.database
   end
 
   desc "create your database"
   task :create do
-    config = DB::Config.new
     system 'createdb', '-h', config.host, '-O', config.username, config.database
   end
 
@@ -76,5 +69,9 @@ end
         f.puts text
       end
     end
+  end
+
+  def config
+    DB::Config.new
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -39,6 +39,18 @@ namespace :db do
     system 'createdb', '-h', config.host, '-O', config.username, config.database
   end
 
+  desc "drop your databas"
+  task :drop do
+    config = DB::Config.new
+    system 'dropdb', '-h', config.host, config.database
+  end
+
+  desc "create your database"
+  task :create do
+    config = DB::Config.new
+    system 'createdb', '-h', config.host, '-O', config.username, config.database
+  end
+
   desc 'set the database up from scratch'
   task from_scratch: %i(setup migrate seeds:fetch seed)
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -36,7 +36,7 @@ namespace :db do
   task :reset do
     config = DB::Config.new
     system 'dropdb', '-h', config.host, config.database
-    system 'createdb', '-h', config.host, '-O', config.user, config.database
+    system 'createdb', '-h', config.host, '-O', config.username, config.database
   end
 
   desc 'set the database up from scratch'


### PR DESCRIPTION
Just a little fix: I've noticed `db:reset` rake task had 'config.user` instead of correct `config.username` as an argument. Plus small clean up.

BTW Any reason why we are not using default database tasks from active record? 