### PR TITLE
Fixed path to Compass config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ required to be running for the server to run though.
 
 For CSS we are using Sass (with `.scss`). Feel free to use [Bootstrap 3](http://getbootstrap.com) components and mixins. Or if you want to use even more mixins you can use [Compass](http://compass-style.org/reference/compass/). Structurewise we try to separate components, mixins and layouts. Where layouts should be a single page (using an HTML id as a selector) and components should be reusable partials, which can look different by layout.
 
-You can find the Compass config in `lib/app/config.rb`.
+You can find the Compass configuration in `config.rb` in the project's root directory.
 
 ### Styleguide
 


### PR DESCRIPTION
Not terribly important, but probably would be nice to have correct path in the README. Re: #2292