### PR TITLE
Add Twitter link to footer

### DIFF
--- a/lib/app/views/application/footer/social.erb
+++ b/lib/app/views/application/footer/social.erb
@@ -6,6 +6,12 @@
     </a>
   </li>
   <li>
+    <a href="https://twitter.com/exercism_io">
+      <i class="fa fa-twitter fa-lg"></i>
+      Twitter
+    </a>
+  </li>
+  <li>
     <a href="https://tinyletter.com/exercism">
       <i class="fa fa-envelope"></i>
       Newsletter


### PR DESCRIPTION
Seems like this is missing from the footer, but maybe there's a reason it was left off.