### PR TITLE
Quick fix wrong JS included

### DIFF
--- a/lib/app/views/application/_footer.erb
+++ b/lib/app/views/application/_footer.erb
@@ -26,5 +26,5 @@
 
 <div id="list-notifications"></div>
 
-<!-- <script src="/js/app.js"></script> -->
-<script src="/js/bundle.js"></script>
+ <script src="/js/app.js"></script> 
+<!--<script src="/js/bundle.js"></script>-->


### PR DESCRIPTION
ooops, I accidentally pushed the version with old front end scripts commented out and new included. It's suppose to be the other way around for now.