### PR TITLE
Give some space for the new paragraph

### DIFF
--- a/lib/app/views/account/show.erb
+++ b/lib/app/views/account/show.erb
@@ -32,6 +32,7 @@
           <% end %>
         </ul>
       <% end %>
+      <p/>
       <p>Create a <a href="/teams">new team</a>.</p>
 
       <h2>Exercises</h2>


### PR DESCRIPTION
Right now, "Create a new team." occurs as:
![screen shot 2015-04-06 at 1 34 56 pm](https://cloud.githubusercontent.com/assets/3036093/7002059/e0861096-dc61-11e4-9d25-2a914f0a75fa.png)

I have added some space before it:
![screen shot 2015-04-06 at 1 35 14 pm](https://cloud.githubusercontent.com/assets/3036093/7002065/fdf44fe4-dc61-11e4-868f-c443e773fa41.png)

The <p/> tag seems fine for now. I tried with the <br/> tag but it was adding a bit more space than needed.