### PR TITLE
Fix read more link in Feedback Guide alert

### DIFF
--- a/lib/app/views/submissions/feedback_guide.erb
+++ b/lib/app/views/submissions/feedback_guide.erb
@@ -1,4 +1,4 @@
-<div class="alert alert-info hidden" id="feedback_guide_alert" data-dismiss="alert">
+<div class="alert alert-info hidden" id="feedback_guide_alert">
   <button type="button" class="close" data-dismiss="alert">
     <span aria-hidden="true">&times;</span>
     <span class="sr-only">Close</span>


### PR DESCRIPTION
Because the entire alert had a data-dismiss tag it didn't receive the link click for the Read more link.

This fixes #2298.