### PR TITLE
DB setup fixes

### DIFF
--- a/lib/db/config.rb
+++ b/lib/db/config.rb
@@ -17,8 +17,8 @@ module DB
       @file = file
     end
 
-    %i(database host password username).each do |field|
-      define_method(field) { options[field.to_s] }
+    %i(database host password username port).each do |field|
+      define_method(field) { options[field.to_s].to_s }
     end
 
     def options

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -26,7 +26,8 @@ namespace :db do
 
     config = DB::Config.new
     system({ 'PGPASSWORD' => config.password },
-           'psql', '-h', config.host, '-U', config.username,
+           'psql', '-h', config.host, '-p', config.port,
+                   '-U', config.username,
                    '-d', config.database, '-f', 'db/seeds.sql')
 
     # Trigger generation of html body


### PR DESCRIPTION
* The `system` method does not convert its args to Strings, but YAML loads the port as a Fixnum from the file. So we need to explicitly convert all db config values to strings before returning them.
* When importing seed data, we also need to use the configured port