### PR TITLE
fix new lines before and after code blocks in markdown, fix #2310

### DIFF
--- a/lib/exercism/converts_markdown_to_html.rb
+++ b/lib/exercism/converts_markdown_to_html.rb
@@ -16,6 +16,7 @@ class ConvertsMarkdownToHTML
   end
 
   def convert
+    preprocess_markdown
     convert_markdown_to_html
     sanitize_html
   end
@@ -28,5 +29,9 @@ class ConvertsMarkdownToHTML
 
   def convert_markdown_to_html
     @content = ExercismLib::Markdown.render(@content)
+  end
+
+  def preprocess_markdown
+    @content = @content.gsub(/^`{3}(.*?)`{3}$/im) { "\n#{$&}\n" }
   end
 end

--- a/test/exercism/markdown_test.rb
+++ b/test/exercism/markdown_test.rb
@@ -1,5 +1,6 @@
 require_relative '../test_helper'
 require 'exercism/markdown'
+require 'exercism/converts_markdown_to_html'
 
 class MarkdownTest < Minitest::Test
   def test_mention
@@ -30,5 +31,15 @@ class MarkdownTest < Minitest::Test
     markdown = "Foo\nBar"
     expected = "<p>Foo<br>\nBar</p>\n"
     assert_equal expected, ExercismLib::Markdown.render(markdown)
+  end
+
+  def test_no_newlines_before_and_after_code
+    markdown = "foo\n```ruby\nputs hi\n```\nbar"
+    assert_match "<div class=\"highlight", ConvertsMarkdownToHTML.convert(markdown)
+  end
+
+  def test_no_newlines_before_and_after_code_without_language
+    markdown = "foo\n```\nputs hi\n```\nbar"
+    assert_match "<div class=\"highlight", ConvertsMarkdownToHTML.convert(markdown)
   end
 end


### PR DESCRIPTION
This adds a preprocessing step to the Markdown parser that adds new lines before and after code blocks to fix #2310 