### PR TITLE
adding database.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tmp
 db/seeds.sql
 db/schema.sql
 db/migrations.sql
+config/database.yml
 
 # JavaScript
 node_modules


### PR DESCRIPTION
Since database.example.yml exists, prevent users from committing database.yml.