### PR TITLE
Hide accepted invitation notification

### DIFF
--- a/db/migrate/201504251623_add_inviter_id_to_team_memberships.rb
+++ b/db/migrate/201504251623_add_inviter_id_to_team_memberships.rb
@@ -1,0 +1,5 @@
+class AddInviterIdToTeamMemberships < ActiveRecord::Migration
+  def change
+    add_column :team_memberships, :inviter_id, :integer
+  end
+end

--- a/lib/app/helpers/notification_count.rb
+++ b/lib/app/helpers/notification_count.rb
@@ -3,7 +3,12 @@ module ExercismWeb
     module NotificationCount
       def notification_count
         sql = "SELECT COUNT(note.id) AS tally FROM notifications note INNER JOIN submissions sub ON note.item_id=sub.id WHERE note.item_type='Submission' AND note.user_id=#{current_user.id} AND note.read='f'"
-        ActiveRecord::Base.connection.execute(sql).to_a.first["tally"].to_i + current_user.alerts.count
+
+        notifications_count = ActiveRecord::Base.connection.execute(sql).to_a.first["tally"].to_i
+        alert_count = current_user.alerts.count
+        unconfirmed_memberships_count = current_user.unconfirmed_team_memberships.count
+
+        notifications_count + alert_count + unconfirmed_memberships_count
       end
     end
   end

--- a/lib/app/presenters/inbox.rb
+++ b/lib/app/presenters/inbox.rb
@@ -7,7 +7,7 @@ module ExercismWeb
       end
 
       def count
-        alerts.count + notifications.count
+        alerts.count + notifications.count + unconfirmed_team_memberships.count
       end
 
       def has_stuff?
@@ -22,12 +22,20 @@ module ExercismWeb
         alerts.count > 0
       end
 
+      def has_unconfirmed_team_memberships?
+        unconfirmed_team_memberships.count > 0
+      end
+
       def alerts
         user.alerts
       end
 
       def notifications
         user.notifications.on_submissions.unread.recent
+      end
+
+      def unconfirmed_team_memberships
+        user.unconfirmed_team_memberships
       end
     end
   end

--- a/lib/app/views/notifications/index.erb
+++ b/lib/app/views/notifications/index.erb
@@ -21,6 +21,29 @@
 
       <p class="well">Are you looking for a discussion you recently viewed? There's a <a href="/looks">list of these</a> available.</p>
 
+      <% if inbox.has_unconfirmed_team_memberships? %>
+        <ul style="list-style-type: none; margin: 0;">
+          <% inbox.unconfirmed_team_memberships.each do |team_membership| %>
+          <li class="alert-row">
+            <span class="fa fa-bell-o alert-icon"></span>
+            <% if team_membership.inviter.present? %>
+            <a href="<%= team_membership.inviter.username %>"><%= team_membership.inviter.username.capitalize %></a> would like you to join the team <%= team_membership.team.name %>.
+            <% else %>
+            You are invited to join the team <%= team_membership.team.name %>.
+            <% end %>
+            <form action="<%= "/teams/#{team_membership.team.slug}/confirm" %>" method="post" class="inline">
+              <input type="hidden" name="_method" value="put"/>
+              <input type="submit" name="update" value="Accept invitation" class="btn btn-xs btn-success"/>
+            </form>
+            <form action="<%= "/teams/#{team_membership.team.slug}/leave" %>" method="post" class="inline">
+              <input type="hidden" name="_method" value="put" />
+              <input type="submit" name="update" value="Decline" class="btn btn-xs btn-danger"/>
+            </form>
+          </li>
+          <% end %>
+        </ul>
+      <% end %>
+
       <% if inbox.has_alerts? %>
         <ul style="list-style-type: none; margin: 0;">
           <% inbox.alerts.each do |alert| %>

--- a/lib/exercism/team_membership.rb
+++ b/lib/exercism/team_membership.rb
@@ -1,6 +1,7 @@
 class TeamMembership < ActiveRecord::Base
   belongs_to :team
   belongs_to :user
+  belongs_to :inviter, class_name: 'User', foreign_key: :inviter_id
 
   validates :user, uniqueness: { scope: :team }
   scope :confirmed, ->{ where(confirmed: true) }

--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -12,9 +12,10 @@ class User < ActiveRecord::Base
 
   has_many :management_contracts, class_name: "TeamManager"
   has_many :managed_teams, through: :management_contracts, source: :team
-  has_many :team_memberships, ->{ where confirmed: true }, class_name: "TeamMembership"
+  has_many :team_memberships, ->{ where confirmed: true }, class_name: "TeamMembership", dependent: :destroy
   has_many :teams, through: :team_memberships
-  has_many :unconfirmed_team_memberships, ->{ where confirmed: false }, class_name: "TeamMembership"
+  has_many :inviters, through: :team_memberships, class_name: "User", foreign_key: :inviter_id
+  has_many :unconfirmed_team_memberships, ->{ where confirmed: false }, class_name: "TeamMembership", dependent: :destroy
   has_many :unconfirmed_teams, through: :unconfirmed_team_memberships, source: :team
 
   before_save do

--- a/test/acceptance/team_test.rb
+++ b/test/acceptance/team_test.rb
@@ -5,10 +5,8 @@ class TeamAcceptanceTest < AcceptanceTestCase
     creating_user = create_user(username: 'creating_user')
     joining_user = create_user(username: 'joining_user', github_id: 123)
 
-    Team.by(creating_user).defined_with(slug: 'some-team',
-                                        name: 'Some Name',
-                                        usernames: 'joining_user')
-        .save!
+    attributes = { slug: 'some-team', name: 'Some Name', usernames: 'joining_user' }
+    Team.by(creating_user).defined_with(attributes, creating_user).save!
 
     with_login(joining_user) do
       click_on 'Account'

--- a/test/exercism/cohort_test.rb
+++ b/test/exercism/cohort_test.rb
@@ -13,9 +13,9 @@ class CohortTest < Minitest::Test
     Submission.create(language: 'ruby', slug: 'cake', code: 'CODE', user: charlie)
     Submission.create(language: 'ruby', slug: 'cake', code: 'CODE', user: dave, state: 'done')
 
-    team1 = Team.by(alice).defined_with(slug: 'team1', users: [bob, charlie])
+    team1 = Team.by(alice).defined_with(slug: 'team1', users: [bob, charlie], inviter: alice)
     team1.save
-    team2 = Team.by(alice).defined_with(slug: 'team2', users: [bob, dave, eve])
+    team2 = Team.by(alice).defined_with(slug: 'team2', users: [bob, dave, eve], inviter: alice)
     team2.save
 
     team1.confirm(bob.username)

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -156,18 +156,38 @@ class UserTest < Minitest::Test
   end
 
   def test_find_user_by_case_insensitive_username
-    %w{alice bob}.each do |name| User.create username: name end
+    %w{alice bob}.each do |name| User.create(username: name) end
     assert_equal 'alice', User.find_by_username('ALICE').username
   end
 
   def test_find_a_bunch_of_users_by_case_insensitive_username
-    %w{alice bob fred}.each do |name| User.create username: name end
+    %w{alice bob fred}.each do |name| User.create(username: name) end
     assert_equal ['alice', 'bob'], User.find_in_usernames(['ALICE', 'BOB']).map(&:username)
   end
 
   def test_create_users_unless_present
-    User.create username: 'alice'
+    User.create(username: 'alice')
     assert_equal ['alice', 'bob'], User.find_or_create_in_usernames(['alice', 'bob']).map(&:username).sort
+  end
+
+  def test_delete_team_memberships_with_user
+    alice = User.create(username: 'alice')
+    bob = User.create(username: 'bob')
+
+    team = Team.by(alice).defined_with({ slug: 'team a', usernames: bob.username }, alice)
+    other_team = Team.by(alice).defined_with({ slug: 'team b', usernames: bob.username }, alice)
+
+    team.save
+    other_team.save
+    TeamMembership.where(user: bob).first.confirm!
+
+    assert TeamMembership.exists?(team: team, user: bob, inviter: alice), 'Confirmed TeamMembership for bob was created.'
+    assert TeamMembership.exists?(team: other_team, user: bob, inviter: alice), 'Unconfirmed TeamMembership for charlie was created.'
+
+    bob.destroy
+
+    refute TeamMembership.exists?(team: team, user: bob, inviter: alice), 'Confirmed TeamMembership was deleted.'
+    refute TeamMembership.exists?(team: other_team, user: bob, inviter: alice), 'Unconfirmed TeamMembership was deleted.'
   end
 
   private


### PR DESCRIPTION
Proposal for https://github.com/exercism/exercism.io/issues/2340

* Refactor TeamMembership to store the inviter's id
* Remove use of Alerts for invitation notifications and creates notification message from unconfirmed team memberships
* Destroy dependent TeamMemberships if Team or User is deleted
* Add inline accept/decline buttons after notification