### PR TITLE
adding sortable js/css library to sort exercises tables

### DIFF
--- a/frontend/vendor/js/sortable.js
+++ b/frontend/vendor/js/sortable.js
@@ -1,0 +1,152 @@
+/*!
+ * Sortable.js v0.6
+ * https://github.com/HubSpot/sortable
+ *
+ * Copyright 2013 Adam Schwartz
+ * Released under the MIT license
+ */
+(function() {
+  var SELECTOR, clickEvent, numberRegExp, sortable, touchDevice, trimRegExp;
+
+  SELECTOR = 'table[data-sortable]';
+
+  numberRegExp = /^-?[£$¤]?[\d,.]+%?$/;
+
+  trimRegExp = /^\s+|\s+$/g;
+
+  touchDevice = 'ontouchstart' in document.documentElement;
+
+  clickEvent = touchDevice ? 'touchstart' : 'click';
+
+  sortable = {
+    init: function() {
+      var table, tables, _i, _len, _results;
+      tables = document.querySelectorAll(SELECTOR);
+      _results = [];
+      for (_i = 0, _len = tables.length; _i < _len; _i++) {
+        table = tables[_i];
+        _results.push(sortable.initTable(table));
+      }
+      return _results;
+    },
+    initTable: function(table) {
+      var i, th, ths, _i, _len;
+      if (table.tHead.rows.length !== 1) {
+        return;
+      }
+      if (table.getAttribute('data-sortable-initialized') === 'true') {
+        return;
+      }
+      table.setAttribute('data-sortable-initialized', 'true');
+      ths = table.querySelectorAll('th');
+      for (i = _i = 0, _len = ths.length; _i < _len; i = ++_i) {
+        th = ths[i];
+        if (th.getAttribute('data-sortable') !== 'false') {
+          sortable.setupClickableTH(table, th, i);
+        }
+      }
+      return table;
+    },
+    setupClickableTH: function(table, th, i) {
+      var type;
+      type = sortable.getColumnType(table, i);
+      return th.addEventListener(clickEvent, function(e) {
+        var newSortedDirection, row, rowArray, rowArrayObject, sorted, sortedDirection, tBody, ths, _i, _j, _k, _len, _len1, _len2, _ref, _results;
+        sorted = this.getAttribute('data-sorted') === 'true';
+        sortedDirection = this.getAttribute('data-sorted-direction');
+        if (sorted) {
+          newSortedDirection = sortedDirection === 'ascending' ? 'descending' : 'ascending';
+        } else {
+          newSortedDirection = type.defaultSortDirection;
+        }
+        ths = this.parentNode.querySelectorAll('th');
+        for (_i = 0, _len = ths.length; _i < _len; _i++) {
+          th = ths[_i];
+          th.setAttribute('data-sorted', 'false');
+          th.removeAttribute('data-sorted-direction');
+        }
+        this.setAttribute('data-sorted', 'true');
+        this.setAttribute('data-sorted-direction', newSortedDirection);
+        tBody = table.tBodies[0];
+        rowArray = [];
+        _ref = tBody.rows;
+        for (_j = 0, _len1 = _ref.length; _j < _len1; _j++) {
+          row = _ref[_j];
+          rowArray.push([sortable.getNodeValue(row.cells[i]), row]);
+        }
+        if (sorted) {
+          rowArray.reverse();
+        } else {
+          rowArray.sort(type.compare);
+        }
+        _results = [];
+        for (_k = 0, _len2 = rowArray.length; _k < _len2; _k++) {
+          rowArrayObject = rowArray[_k];
+          _results.push(tBody.appendChild(rowArrayObject[1]));
+        }
+        return _results;
+      });
+    },
+    getColumnType: function(table, i) {
+      var row, text, _i, _len, _ref;
+      _ref = table.tBodies[0].rows;
+      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+        row = _ref[_i];
+        text = sortable.getNodeValue(row.cells[i]);
+        if (text !== '' && text.match(numberRegExp)) {
+          return sortable.types.numeric;
+        }
+      }
+      return sortable.types.alpha;
+    },
+    getNodeValue: function(node) {
+      if (!node) {
+        return '';
+      }
+      if (node.getAttribute('data-value') !== null) {
+        return node.getAttribute('data-value');
+      }
+      if (typeof node.innerText !== 'undefined') {
+        return node.innerText.replace(trimRegExp, '');
+      }
+      return node.textContent.replace(trimRegExp, '');
+    },
+    types: {
+      numeric: {
+        defaultSortDirection: 'descending',
+        compare: function(a, b) {
+          var aa, bb;
+          aa = parseFloat(a[0].replace(/[^0-9.-]/g, ''));
+          bb = parseFloat(b[0].replace(/[^0-9.-]/g, ''));
+          if (isNaN(aa)) {
+            aa = 0;
+          }
+          if (isNaN(bb)) {
+            bb = 0;
+          }
+          return bb - aa;
+        }
+      },
+      alpha: {
+        defaultSortDirection: 'ascending',
+        compare: function(a, b) {
+          var aa, bb;
+          aa = a[0].toLowerCase();
+          bb = b[0].toLowerCase();
+          if (aa === bb) {
+            return 0;
+          }
+          if (aa < bb) {
+            return -1;
+          }
+          return 1;
+        }
+      }
+    }
+  };
+
+  setTimeout(sortable.init, 0);
+
+  window.Sortable = sortable;
+
+}).call(this);

--- a/lib/app/public/sass/application.scss
+++ b/lib/app/public/sass/application.scss
@@ -4,6 +4,7 @@
 @import 'layouts/import';
 
 @import 'vendor/jquery.atwho';
+@import 'vendor/sortable';
 
 .nit-links.nav-pills {
   margin-top: $line-height-computed;

--- a/lib/app/public/sass/vendor/sortable.sass
+++ b/lib/app/public/sass/vendor/sortable.sass
@@ -1,0 +1,48 @@
+table[data-sortable]
+    border-collapse: collapse
+    border-spacing: 0
+
+    th
+        vertical-align: bottom
+        font-weight: bold
+
+    th, td
+        text-align: left
+        padding: 10px
+
+    th:not([data-sortable="false"])
+        -webkit-user-select: none
+        -moz-user-select: none
+        -ms-user-select: none
+        -o-user-select: none
+        user-select: none
+        -webkit-tap-highlight-color: rgba(0, 0, 0, 0)
+        -webkit-touch-callout: none
+        cursor: pointer
+
+    th
+
+        &:after
+            content: ""
+            visibility: hidden
+            display: inline-block
+            vertical-align: inherit
+            height: 0
+            width: 0
+            border-width: 5px
+            border-style: solid
+            border-color: transparent
+            margin-right: 1px
+            margin-left: 10px
+            float: right
+
+        &[data-sorted="true"]:after
+            visibility: visible
+
+        &[data-sorted-direction="descending"]:after
+            border-top-color: black
+            margin-top: 8px
+
+        &[data-sorted-direction="ascending"]:after
+            border-bottom-color: black
+            margin-top: 8px - 5px

--- a/lib/app/views/account/show.erb
+++ b/lib/app/views/account/show.erb
@@ -3,13 +3,13 @@
     <h1>Account</h1>
   </section>
   <article>
-    <div class="col-md-8">
-      <ul class="nav nav-pills nav-stacked col-md-4">
+    <div class="col-md-12">
+      <ul class="nav nav-pills nav-stacked col-md-3">
         <li class="active"><a href="#teams_tab" data-toggle="pill">Teams</a></li>
         <li><a href="#exercises_tab" data-toggle="pill">Exercises</a></li>
         <li><a href="#settings_tab" data-toggle="pill">Settings</a></li>
       </ul>
-      <div class="tab-content col-md-8">
+      <div class="tab-content col-md-9">
         <div class="tab-pane active" id="teams_tab">
           <h2>Teams</h2>
           <% if profile.has_teams? %>

--- a/lib/app/views/user/_exercises_table.erb
+++ b/lib/app/views/user/_exercises_table.erb
@@ -1,21 +1,21 @@
-<table class="table table-bordered table-striped">
+<table class="table table-bordered table-striped" data-sortable>
   <thead>
     <tr>
       <th>Exercise</th>
       <th>Language</th>
       <th>Iteration</th>
       <th>Nits</th>
-      <th>Date Submitted</th>
+      <th data-sorted="true" data-sorted-direction="descending">Date Submitted</th>
     </tr>
   </thead>
   <tbody>
-  <% exercises.each do |submission| %>
+  <% exercises.order(created_at: :desc).each do |submission| %>
     <tr>
       <td><%= profile.submission_link(submission) %></td>
       <td><%= submission.problem.language %></td>
       <td><%= submission.version %></td>
       <td><%= submission.nit_count %></td>
-      <td><%= submission.created_at.strftime("%m-%d-%Y") %></td>
+      <td data-value="<%= submission.created_at.to_i %>"><%= submission.created_at.strftime("%m-%d-%Y") %></td>
     </tr>
   <% end %>
   </tbody>

--- a/lib/app/views/user/show.erb
+++ b/lib/app/views/user/show.erb
@@ -3,7 +3,7 @@
     <h1><%= profile.username %></h1>
   </section>
   <div class="row">
-    <div class="col-md-8">
+    <div class="col-md-12">
       <p>GitHub Profile: <%= profile.github_link %></p>
       <h3>Exercises</h3>
       <h4>Current</h4>


### PR DESCRIPTION
Adds a JS sorter for the `_exercises_table.erb` partial as described in https://github.com/exercism/exercism.io/issues/2354.  The table is sorted by 'Date Submitted' descending by default.  All columns are allowed to be sorted.

I have left the compiled JS/CSS/SCSS out of this PR, let me know if you would like me to include those.

![screen shot 2015-05-03 at 10 13 35 pm](https://cloud.githubusercontent.com/assets/5061812/7449090/10b900bc-f1e2-11e4-8a76-937d7bee9671.png)
