### PR TITLE
persist url to everlasting exercises link, that way the username can change

### DIFF
--- a/lib/app/routes/exercises.rb
+++ b/lib/app/routes/exercises.rb
@@ -16,6 +16,21 @@ module ExercismWeb
         erb :"nitpick/index", locals: locals
       end
 
+      get '/exercises/:key' do |key|
+        exercise = UserExercise.find_by_key(key)
+        if exercise.nil?
+          flash[:notice] = "Couldn't find that exercise."
+          redirect '/'
+        end
+
+        if exercise.submissions.empty?
+          # We have orphan exercises at the moment.
+          flash[:notice] = "That submission no longer exists."
+          redirect '/'
+        end
+        redirect "/submissions/%s" % exercise.submissions.last.key
+      end
+
       get '/submissions/:key' do |key|
         submission = Submission.includes(:user, comments: :user).find_by_key(key)
         unless submission

--- a/lib/exercism/use_cases/hibernation.rb
+++ b/lib/exercism/use_cases/hibernation.rb
@@ -51,7 +51,7 @@ class Hibernation
     attributes = {
       user_id: submission.user_id,
       read: false,
-      url: ['', submission.user.username, submission.user_exercise.key].join('/'),
+      url: "/exercises/#{submission.user_exercise.key}",
       link_text: "View submission.",
       text: "Your exercise #{submission.slug} in #{submission.track_id} has gone into hibernation."
     }
@@ -78,4 +78,3 @@ class Hibernation
     comment.user == submission.user
   end
 end
-

--- a/lib/tasks/alerts.rake
+++ b/lib/tasks/alerts.rake
@@ -1,0 +1,20 @@
+namespace :alerts do
+  namespace :hibernation do
+    desc "convert hibernation links"
+    task :convert_links do
+      require 'bundler'
+      Bundler.require
+      require 'exercism'
+      require './lib/exercism/use_cases/hibernation'
+
+      alerts = Alert.where("text LIKE '%has gone into hibernation.'").
+                     where("url not like '/exercises/%'")
+      alerts.find_each do |alert|
+        exercise_key = alert.url.split("/").last
+        alert.url = "/exercises/#{exercise_key}"
+        alert.save
+      end
+
+    end
+  end
+end

--- a/test/app/exercises_test.rb
+++ b/test/app/exercises_test.rb
@@ -9,6 +9,17 @@ class AppExercisesTest < Minitest::Test
     ExercismWeb::App
   end
 
+  def test_excercises_by_key
+    alice = User.create(username: 'alice', github_id: 1)
+    exercise = UserExercise.create(user: alice, language: 'go', slug: 'one', state: 'done')
+    submission = Submission.create(user: alice, language: 'go', slug: 'bob', user_exercise: exercise)
+
+    get "/exercises/#{exercise.key}", {}, login(alice)
+    assert_equal 302, last_response.status
+    location = "http://example.org/submissions/#{submission.key}"
+    assert_equal location, last_response.location, "Wrong redirect for GET exercises"
+  end
+
   def test_unlock_nitpicking
     alice = User.create(username: 'alice', github_id: 1)
     Submission.create(user: alice, language: 'ruby', slug: 'bob')


### PR DESCRIPTION
@kytrinyx this is a slightly different implementation that the one described in the issue https://github.com/exercism/exercism.io/issues/2359 but I think it will suit the system for the time being (Since you mentioned rebuilding the Alerts/etc)

The rake task `rake alerts:hibernation:convert_links` should only need to be run once, but is idempotent either way.

The old route is still in there, since there are probably other places that might be using it.  Let me know what you think.