### PR TITLE
Show all test files for exercises, add tab bar

### DIFF
--- a/lib/app/presenters/assignment.rb
+++ b/lib/app/presenters/assignment.rb
@@ -1,0 +1,56 @@
+require 'exercism/problem'
+
+module ExercismWeb
+  module Presenters
+    class Assignment
+      Testfile = Struct.new(:filename, :content) do
+        def self.collection_from_json(hash)
+          hash.collect do |filename, content|
+            new(filename, content)
+          end
+        end
+
+        def extension
+          File.extname(filename)[1..-1]
+        end
+
+        def testfile?
+          filename =~ /test/i ||
+            filename =~ /\.t$/ ||
+            filename =~ /ut_.*#\.plsql\Z/
+        end
+      end
+
+      def self.from_json_data(data)
+        assignment, * = data.fetch('assignments')
+        track = assignment.fetch('track')
+        slug = assignment.fetch('slug')
+        raw_files = assignment.fetch('files')
+
+        new(track, slug, raw_files)
+      end
+
+      def initialize(track, slug, raw_files)
+        @track = track
+        @slug = slug
+        @raw_files = raw_files
+      end
+
+      def files
+        @files ||= Testfile.collection_from_json(@raw_files)
+      end
+
+      def testfiles
+        files.select(&:testfile?)
+      end
+
+      def problem
+        Problem.new(@track, @slug)
+      end
+
+      def to_locals
+        {problem: problem, testfiles: testfiles}
+      end
+    end
+  end
+end

--- a/lib/app/presenters/assignment.rb
+++ b/lib/app/presenters/assignment.rb
@@ -19,6 +19,10 @@ module ExercismWeb
             filename =~ /\.t$/ ||
             filename =~ /ut_.*#\.plsql\Z/
         end
+
+        def readme_file?
+          filename == 'README.md'
+        end
       end
 
       def self.from_json_data(data)
@@ -44,12 +48,21 @@ module ExercismWeb
         files.select(&:testfile?)
       end
 
+      def readme_file
+        files.find(&:readme_file?) ||
+          Testfile.new('README.md', 'This exercise has no readme.')
+      end
+
       def problem
         Problem.new(@track, @slug)
       end
 
       def to_locals
-        {problem: problem, testfiles: testfiles}
+        {
+          problem: problem,
+          testfiles: testfiles,
+          readme_file: readme_file
+        }
       end
     end
   end

--- a/lib/app/routes/metadata.rb
+++ b/lib/app/routes/metadata.rb
@@ -1,3 +1,5 @@
+require 'app/presenters/assignment'
+
 module ExercismWeb
   module Routes
     class Metadata < Core
@@ -8,11 +10,9 @@ module ExercismWeb
           flash[:notice] = data['error']
           redirect '/'
         end
-        data = data["assignments"].first
-        problem = Problem.new(data['track'], data['slug'])
-        text = data["files"].find {|filename, _|
-          filename =~ /test/i || filename =~ /\.t$/ || filename =~ /ut_.*#\.plsql\Z/}.last
-        erb :"exercises/test_suite", locals: {problem: problem, text: text}
+
+        locals = Presenters::Assignment.from_json_data(data).to_locals
+        erb :"exercises/test_suite", locals: locals
       end
 
       get '/exercises/:track_id/:slug/readme' do |track_id, slug|

--- a/lib/app/routes/metadata.rb
+++ b/lib/app/routes/metadata.rb
@@ -22,10 +22,9 @@ module ExercismWeb
           flash[:notice] = data['error']
           redirect '/'
         end
-        data = data["assignments"].first
-        problem = Problem.new(data['track'], data['slug'])
-        text = data["files"].find {|key, _| key == "README.md"}.last
-        erb :"exercises/readme", locals: {problem: problem, text: text}
+
+        locals = Presenters::Assignment.from_json_data(data).to_locals
+        erb :"exercises/readme", locals: locals
       end
     end
   end

--- a/lib/app/views/exercises/readme.erb
+++ b/lib/app/views/exercises/readme.erb
@@ -14,5 +14,5 @@
       </li>
     </ul>
   </nav>
-  <%= md(text) %>
+  <%= md(readme_file.content) %>
 </div>

--- a/lib/app/views/exercises/readme.erb
+++ b/lib/app/views/exercises/readme.erb
@@ -1,9 +1,18 @@
 <div class="container">
   <section class="page-header">
-  <h1>
-    README:
-    <small><%= problem.name %> in <%= problem.language %></small>
-  </h1>
+    <h1>
+      <%= problem.name %> in <%= problem.language %>
+    </h1>
   </section>
+  <nav role="navigation">
+    <ul class="nav nav-tabs">
+      <li role="presentation" class="active">
+        <a href="readme">Readme</a>
+      </li>
+      <li role="presentation">
+        <a href="../<%= problem.name.downcase %>"> Test Suite</a>
+      </li>
+    </ul>
+  </nav>
   <%= md(text) %>
 </div>

--- a/lib/app/views/exercises/test_suite.erb
+++ b/lib/app/views/exercises/test_suite.erb
@@ -1,9 +1,19 @@
 <div class="container">
   <section class="page-header">
-    <h1>Test Suite:
-      <small><%= problem.name %> in <%= problem.language %></small>
+    <h1>
+      <%= problem.name %> in <%= problem.language %>
     </h1>
   </section>
+  <nav role="navigation">
+    <ul class="nav nav-tabs">
+      <li role="presentation">
+        <a href="<%= problem.name.downcase %>/readme">Readme</a>
+      </li>
+      <li role="presentation" class="active">
+        <a href="<%= problem.name.downcase %>">Test Suite</a>
+      </li>
+    </ul>
+  </nav>
   <% testfiles.each do |f| %>
     <div>
       <h4><%= f.filename %></h4>

--- a/lib/app/views/exercises/test_suite.erb
+++ b/lib/app/views/exercises/test_suite.erb
@@ -4,5 +4,10 @@
       <small><%= problem.name %> in <%= problem.language %></small>
     </h1>
   </section>
-  <%= md(text, problem.track_id) %>
+  <% testfiles.each do |f| %>
+    <div>
+      <h4><%= f.filename %></h4>
+      <%= md(f.content, f.extension) %>
+    </div>
+  <% end %>
 </div>

--- a/test/app/metadata_test.rb
+++ b/test/app/metadata_test.rb
@@ -1,0 +1,21 @@
+require_relative '../app_helper'
+
+class MetadataTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    ExercismWeb::App
+  end
+
+  def assignments_multiple_files_json
+    File.read("./test/fixtures/assignments_multiple_files.json")
+  end
+
+  def test_metadata
+    Xapi.stub(:get, [200, assignments_multiple_files_json]) do
+      get '/exercises/go/leap'
+      assert_includes last_response.body, 'file1_content'
+      assert_includes last_response.body, 'file2_content'
+    end
+  end
+end

--- a/test/app/presenters/assignment_test.rb
+++ b/test/app/presenters/assignment_test.rb
@@ -43,4 +43,16 @@ class PresentersAssignmentTest < Minitest::Test
     assert_equal 'po', pipa.extension
     assert_equal '2', pipa.content
   end
+
+  def test_find_readme
+    assert_equal 'readme_content', assignment.readme_file.content
+  end
+
+  def test_fallback_readme
+    files = { 'no' => 'readme' }
+    assignment = ewpa.new('track', 'slug', files)
+
+    assert_equal 'This exercise has no readme.',
+                 assignment.readme_file.content
+  end
 end

--- a/test/app/presenters/assignment_test.rb
+++ b/test/app/presenters/assignment_test.rb
@@ -1,0 +1,46 @@
+require_relative '../../test_helper'
+require 'exercism/named'
+require 'json'
+require 'app/presenters/assignment'
+
+class PresentersAssignmentTest < Minitest::Test
+  def assignments_multiple_files
+    JSON.parse File.read("./test/fixtures/assignments_multiple_files.json")
+  end
+
+  def ewpa
+    ExercismWeb::Presenters::Assignment
+  end
+
+  def assignment
+    ewpa.from_json_data(assignments_multiple_files)
+  end
+
+  def test_build_from_json_data
+    assert_instance_of ewpa, assignment
+  end
+
+  def test_select_testfiles
+    testfile1, testfile2, *tail = assignment.testfiles
+
+    assert_equal 'file1_test.name', testfile1.filename
+    assert_equal 'file2_test.name', testfile2.filename
+
+    assert_empty tail
+  end
+
+  def test_locals
+    locals = assignment.to_locals
+
+    refute_empty locals.values
+  end
+
+  def test_testfiles_class
+    data = { 'foo.bar.baz' => '1', 'pi.pa.po' => '2' }
+    _foobar, pipa = ewpa::Testfile.collection_from_json(data)
+
+    assert_equal 'pi.pa.po', pipa.filename
+    assert_equal 'po', pipa.extension
+    assert_equal '2', pipa.content
+  end
+end

--- a/test/fixtures/assignments_multiple_files.json
+++ b/test/fixtures/assignments_multiple_files.json
@@ -1,0 +1,18 @@
+{
+  "assignments": [
+    {
+      "track_id": "go",
+      "id": "leap",
+      "track": "go",
+      "slug": "leap",
+      "files": {
+        "file1_test.name": "file1_content",
+        "file2_test.name": "file2_content",
+        "file3.name": "file3_content",
+        "README.md": "readme_content",
+        "Readme2.md": "readme2_content"
+      },
+      "fresh": false
+    }
+  ]
+}


### PR DESCRIPTION
Hi, I finally got around to finish my ROSSConf Vienna issue.

This PR
- adds an assignment presenter
- extracts all parsing logic from the metadata route (test files and readme)
- modifies test files view to show all test files
- adds tests
- adds Bootstrap tab bar to test files view and readme view to easily toggle between them

It fixes #2273 (and https://github.com/exercism/rossconf/issues/19 if it is still active)