### PR TITLE
Assemble readme and test suite URIs from slug

### DIFF
--- a/lib/app/views/exercises/readme.erb
+++ b/lib/app/views/exercises/readme.erb
@@ -10,7 +10,7 @@
         <a href="readme">Readme</a>
       </li>
       <li role="presentation">
-        <a href="../<%= problem.name.downcase %>"> Test Suite</a>
+        <a href="../<%= problem.slug %>"> Test Suite</a>
       </li>
     </ul>
   </nav>

--- a/lib/app/views/exercises/test_suite.erb
+++ b/lib/app/views/exercises/test_suite.erb
@@ -7,10 +7,10 @@
   <nav role="navigation">
     <ul class="nav nav-tabs">
       <li role="presentation">
-        <a href="<%= problem.name.downcase %>/readme">Readme</a>
+        <a href="<%= problem.slug %>/readme">Readme</a>
       </li>
       <li role="presentation" class="active">
-        <a href="<%= problem.name.downcase %>">Test Suite</a>
+        <a href="<%= problem.slug %>">Test Suite</a>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
The readme and test suite URIs in the exercise page were being derived
from the problem name, so that for problems with multiple-word names
("Phone Number", "Nth Prime", ...), the URI was being assembled
incorrectly, causing an uncaught server error like this:

URI::InvalidURIError at /exercises/ruby/phone%20number
bad URI(is not URI?): /assignments/ruby/phone number

The fix is simply to use the `problem.slug` instead of the
`problem.name.downcase`.

Tests for this change produced noisy Xapi network output, so they
are not included in this commit. Two different testing strategies
are recorded in this Gist:
https://gist.github.com/amar47shah/0e73a5176fbba67fb398