### PR TITLE
Fix #2423 via a working db:setup and escape strings passed to raw SQL

### DIFF
--- a/lib/db/connection.rb
+++ b/lib/db/connection.rb
@@ -1,8 +1,15 @@
 require 'active_record'
+require 'pg'
 require_relative 'config'
 
 module DB
   class Connection
+    def self.escape(string)
+      # escape strings passed to SQL using PG::Connection instance method as per
+      # http://deveiate.org/code/pg/PG/Connection.html#method-i-escape_string
+      PG::Connection.new.escape_string(string)
+    end
+
     def self.establish
       new.establish
     end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -26,12 +26,14 @@ namespace :db do
 
   desc "set up your database"
   task :setup do
+    user = DB::Connection.escape(config.username)
+    pass = DB::Connection.escape(config.password)
     # Only create user if it doesn't already exist
-    sql = "SELECT 'user exists' FROM pg_user WHERE usename = '#{config.username}'"
+    sql = "SELECT 'user exists' FROM pg_user WHERE usename = '#{user}'"
     out, _, status = Open3.capture3('psql', '-t', '-h', config.host,
                                     '-p', config.port, '-c', sql)
     if status.success? and not out.include?('user exists')
-      sql = "CREATE USER #{config.username} PASSWORD '#{config.password}' " \
+      sql = "CREATE USER #{user} PASSWORD '#{pass}' " \
             'SUPERUSER CREATEDB CREATEROLE INHERIT LOGIN'
       system 'psql', '-h', config.host, '-p', config.port, '-c', sql
     end


### PR DESCRIPTION
This is a fix for #2423 that’s an alternative to #2434 – `DB::Connection.establish` is harmless until Active Record tries to actually use it, so this simply switches the user existence check to a raw `psql` call.

This also escapes the username and password strings passed to raw SQL.