### PR TITLE
Remove the link for "Welcome new users" for onboarded users.

### DIFF
--- a/lib/app/views/application/_nav.erb
+++ b/lib/app/views/application/_nav.erb
@@ -1,7 +1,9 @@
 <div id="navbar" class="navbar-collapse collapse">
   <ul class="nav navbar-nav">
     <li><a href="http://help.exercism.io">Help</a></li>
-    <li><a href="/getting-started">Welcome new users</a></li>
+    <% unless current_user.onboarded? %>
+      <li><a href="/getting-started">Welcome new users</a></li>
+    <% end %>
     <li class="dropdown">
       <a class="dropdown-toggle" id="drop-current" href="#" data-toggle="dropdown">Languages<b class="caret"></b></a>
     <ul class="dropdown-menu" id="menu-current" role="menu" area-labelledby="drop-current">


### PR DESCRIPTION
The link [Welcome new users](http://exercism.io/getting-started) in the navbar seems unnecessary for users who have been using exercism for a considerable amount of time now. So I think we can remove it for `onboarded users`.
Makes navbar cleaner.