### PR TITLE
Add hibernate option to submission menu

### DIFF
--- a/lib/app/routes/exercises.rb
+++ b/lib/app/routes/exercises.rb
@@ -119,6 +119,19 @@ module ExercismWeb
         redirect "/submissions/#{submission.key}"
       end
 
+      post '/submissions/:key/hibernate' do |key|
+        please_login("You have to be logged in to do that")
+        submission = Submission.find_by_key(key)
+        unless current_user.owns?(submission)
+          flash[:notice] = "Only the submitter may hibernate this exercise."
+          redirect "/submissions/#{key}"
+        end
+        submission.state = "hibernating"
+        submission.save
+        flash[:success] = "#{submission.name} in #{submission.track_id} is now hibernating."
+        redirect "/"
+      end
+
       delete '/submissions/:key' do |key|
         please_login
         submission = Submission.find_by_key(key)

--- a/lib/app/routes/exercises.rb
+++ b/lib/app/routes/exercises.rb
@@ -107,6 +107,7 @@ module ExercismWeb
         end
 
         submission = Submission.where(user_id: current_user.id, language: selected_submission.track_id, slug: selected_submission.slug, state: 'done').first
+
         if submission.nil?
           flash[:notice] = "No such submission"
           redirect "/"
@@ -121,13 +122,14 @@ module ExercismWeb
 
       post '/submissions/:key/hibernate' do |key|
         please_login("You have to be logged in to do that")
-        submission = Submission.find_by_key(key)
+        submission = Submission.find_by_key(key).participant_submissions.last
         unless current_user.owns?(submission)
           flash[:notice] = "Only the submitter may hibernate this exercise."
           redirect "/submissions/#{key}"
         end
         submission.state = "hibernating"
         submission.save
+        Hack::UpdatesUserExercise.new(submission.user_id, submission.track_id, submission.slug).update
         flash[:success] = "#{submission.name} in #{submission.track_id} is now hibernating."
         redirect "/"
       end

--- a/lib/app/views/submissions/user_actions.erb
+++ b/lib/app/views/submissions/user_actions.erb
@@ -24,7 +24,7 @@
         <% end %>
       </li>
 
-      <% unless submission.state == "hibernating" %>
+      <% unless submission.state == "hibernating" || submission.state == "done" %>
         <li>
           <form accept-charset="UTF-8" action="/submissions/<%= submission.key %>/hibernate" method="POST">
             <button

--- a/lib/app/views/submissions/user_actions.erb
+++ b/lib/app/views/submissions/user_actions.erb
@@ -24,6 +24,22 @@
         <% end %>
       </li>
 
+      <% unless submission.state == "hibernating" %>
+        <li>
+          <form accept-charset="UTF-8" action="/submissions/<%= submission.key %>/hibernate" method="POST">
+            <button
+              type="submit"
+              name="hibernate"
+              class="btn btn-default"
+              data-toggle="tooltip"
+              data-placement="bottom"
+              title="I'd like a break from this for a while.">
+              Hibernate
+            </button>
+          </form>
+        </li>
+      <% end %>
+
       <% unless current_user.nitpicker_on?(submission.problem) %>
         <li>
           <form accept-charset="UTF-8" action="/exercises/<%= submission.track_id %>/<%= submission.slug %>" method="POST">

--- a/lib/app/views/submissions/user_actions.erb
+++ b/lib/app/views/submissions/user_actions.erb
@@ -24,7 +24,7 @@
         <% end %>
       </li>
 
-      <% unless submission.state == "hibernating" || submission.state == "done" %>
+      <% unless submission.user_exercise.state == "hibernating" || submission.state == "done" %>
         <li>
           <form accept-charset="UTF-8" action="/submissions/<%= submission.key %>/hibernate" method="POST">
             <button


### PR DESCRIPTION
Fixes #2415, Allows users to put submissions into hibernation.

This PR, addresses hibernating the exercise, to re-open the process is still the same (comment, or submit new iteration).  

Not sure if it makes sense to add a "un-hibernate" <--- (insert hibernate antonym here) to the message dropdown for hibernated submissions?  If so, just let me know.