### PR TITLE
Added option to wake up hibernating submissions.

### DIFF
--- a/lib/app/routes/exercises.rb
+++ b/lib/app/routes/exercises.rb
@@ -134,6 +134,13 @@ module ExercismWeb
         redirect "/"
       end
 
+      post '/submissions/:key/wakeup' do |key|
+        submission = Submission.find_by_key(key)
+        submission.user_exercise.reopen!
+        flash[:success] = "#{submission.name} in #{submission.track_id} is now active."
+        redirect '/'
+      end
+
       delete '/submissions/:key' do |key|
         please_login
         submission = Submission.find_by_key(key)

--- a/lib/app/views/submissions/alerts.erb
+++ b/lib/app/views/submissions/alerts.erb
@@ -7,7 +7,7 @@
       </div>
     <% elsif submission.exercise_hibernating? %>
       <div class="alert alert-warning" role="alert">
-        This exercise is hibernating. To take the submission back out of hibernation either respond to the nitpicks, or submit a new version.
+        This exercise is hibernating. To wake from hibernation either respond to the nitpicks, submit a new version, or choose wake up from the "manage" dropdown.
       </div>
     <% end %>
   </div>

--- a/lib/app/views/submissions/user_actions.erb
+++ b/lib/app/views/submissions/user_actions.erb
@@ -40,6 +40,22 @@
         </li>
       <% end %>
 
+      <% if submission.user_exercise.state == "hibernating" %>
+        <li>
+          <form accept-charset="UTF-8" action="/submissions/<%= submission.key %>/wakeup" method="POST">
+            <button
+              type="submit"
+              name="wakeup"
+              class="btn btn-default"
+              data-toggle="tooltip"
+              data-placement="bottom"
+              title="Wake up from hibernation.">
+              Wake up
+            </button>
+          </form>
+        </li>
+      <% end %>
+
       <% unless current_user.nitpicker_on?(submission.problem) %>
         <li>
           <form accept-charset="UTF-8" action="/exercises/<%= submission.track_id %>/<%= submission.slug %>" method="POST">


### PR DESCRIPTION
After adding the hibernate option to a submission, the only way to
awaken was via comment or submitting a new new iteration.

Users can now select "wake up" from the manage dropdown to reset
exercise state back to 'pending'.

Also, not sure if this is exactly what was in mind.  If there is wording or anything you want me to change, just let me know, that's definitely not my strong suit. Thanks!