### PR TITLE
Add Procfile_Vagrant and update CONTRIBUTOR.md to reflect the changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ db/seeds.sql
 db/schema.sql
 db/migrations.sql
 config/database.yml
+Procfile_Vagrant
 
 # JavaScript
 node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,9 +165,11 @@ from their perspective.
 ### Running The Application In A Vagrant Environment
 _The following assumes your Vagrantfile is configured to forward port 3000 to 3030, adjust the port number to suit your environment_
 
-* Install Shotgun gem (this will be necessary to run on 0.0.0.0 loopback required in this instance by Vagrant): 'gem install shotgun'
-* Start the server with: `shotgun -o 0.0.0.0 -p 3000`
-* Sometimes you need to: `bundle exec shotgun -o 0.0.0.0 -p 3000`
+If you are using a different port than 3000 to forward outside of your Vagrant environment you will need to go into `Procfile_Vagrant` and adjust the port number that applies to your needs.
+
+* Copy the Vagrant Procfile example `cp Procfile_Vagrant.example Procfile_Vagrant`
+* Start the server with: `foreman s -f Procfile_Vagrant` (the `-f` explicitly states which Procfile to use and we don't want to use the original Procfile in our vagrant environments)
+* Sometimes you need to: `bundle exec foreman s -f Procfile_Vagrant`
 * Then you can access the local server at [localhost:3030](http://localhost:3030).
 * You can log in as a test user using the `assume` dropdown menu on the top right of the page without creating any new user for the app.
 

--- a/Procfile_Vagrant.example
+++ b/Procfile_Vagrant.example
@@ -1,0 +1,1 @@
+web: rackup -s puma -p 3000 -o 0.0.0.0


### PR DESCRIPTION
Figured out a more appropriate and efficient way of getting the server running in a Vagrant environment. While Foreman doesn't support explicitly stating a host loopback address, puma does. In the changes I have added a Procfile for Vagrant that reflects the needs of Vagrant. Instead of running `foreman s -p 4567` people with a Vagrant environment will need to run `foremans s -f Procfile_Vagrant` and if they need to adjust their port they can edit the Vagrant Procfile. 

The other question is should I add a `Procfile_Vagrant.example` file and then gitignore `Procfile_Vagrant` in the case of people changing port numbers and then submitting a pull request which would result in a change in the files. It seems like a better approach. 