### PR TITLE
Move team management tools to separate page

### DIFF
--- a/frontend/app/js/app.coffee
+++ b/frontend/app/js/app.coffee
@@ -12,11 +12,18 @@ $ ->
   unless $.cookie('feedback_guide_alert') == 'closed'
     $("#feedback_guide_alert").removeClass("hidden")
 
+  $('.manager_delete').on 'click', ->
+    username = $(@).data('username')
+    slug = $(@).data('team')
+
+    if confirm("Are you sure you want to remove #{username} as a team manager?")
+      dismissTeamManager(username, slug)
+
   $('.member_delete').on 'click', ->
     username = $(@).data('username')
     slug = $(@).data('team')
 
-    if confirm("Are you sure you want to remove #{username}?")
+    if confirm("Are you sure you want to remove #{username} as a member?")
       dismissTeamMember(username, slug)
 
   $('#destroy_team').on 'click', ->
@@ -33,17 +40,7 @@ $ ->
     emojify.setConfig(emoticons_enabled: false)
     emojify.run(document.getElementsByClassName("comments")[0])
 
-toggleTeamEdit = ->
-  members_box = $('#add_members')
-  delete_buttons = $('.member_delete')
-  if members_box.hasClass('hidden')
-    delete_buttons.removeClass('hidden')
-    members_box.slideDown()
-    members_box.removeClass('hidden')
-  else
-    members_box.slideUp ->
-      delete_buttons.addClass('hidden')
-      members_box.addClass('hidden')
+
 
 destroyTeam = (slug) ->
   href = "/teams/" + slug
@@ -60,6 +57,16 @@ dismissTeamMember = (username, slug) ->
   method_input = '<input name="_method" value="delete" type="hidden"/>'
 
   form.hide().append(method_input).appendTo('body')
+  form.submit()
+
+dismissTeamManager = (username, slug) ->
+  href = "/teams/#{slug}/managers"
+  form = $('<form method="post" action="' + href + '"></form>')
+  method_input = '<input name="_method" value="delete" type="hidden"/>'
+  username_input = '<input name="username" type="hidden" value="#{username}" />'
+
+  form.hide().append(method_input).appendTo('body')
+  form.hide().append(username_input).appendTo('body')
   form.submit()
 
 ((i, s, o, g, r, a, m) ->

--- a/lib/app/public/js/app.js
+++ b/lib/app/public/js/app.js
@@ -30398,7 +30398,7 @@ $(function() {
 });
 
 (function() {
-  var destroyTeam, dismissTeamMember, toggleTeamEdit;
+  var destroyTeam, dismissTeamManager, dismissTeamMember;
 
   angular.module('exercism', ['ui.bootstrap']);
 
@@ -30420,11 +30420,19 @@ $(function() {
     if ($.cookie('feedback_guide_alert') !== 'closed') {
       $("#feedback_guide_alert").removeClass("hidden");
     }
+    $('.manager_delete').on('click', function() {
+      var slug, username;
+      username = $(this).data('username');
+      slug = $(this).data('team');
+      if (confirm("Are you sure you want to remove " + username + " as a team manager?")) {
+        return dismissTeamManager(username, slug);
+      }
+    });
     $('.member_delete').on('click', function() {
       var slug, username;
       username = $(this).data('username');
       slug = $(this).data('team');
-      if (confirm("Are you sure you want to remove " + username + "?")) {
+      if (confirm("Are you sure you want to remove " + username + " as a member?")) {
         return dismissTeamMember(username, slug);
       }
     });
@@ -30447,22 +30455,6 @@ $(function() {
     }
   });
 
-  toggleTeamEdit = function() {
-    var delete_buttons, members_box;
-    members_box = $('#add_members');
-    delete_buttons = $('.member_delete');
-    if (members_box.hasClass('hidden')) {
-      delete_buttons.removeClass('hidden');
-      members_box.slideDown();
-      return members_box.removeClass('hidden');
-    } else {
-      return members_box.slideUp(function() {
-        delete_buttons.addClass('hidden');
-        return members_box.addClass('hidden');
-      });
-    }
-  };
-
   destroyTeam = function(slug) {
     var form, href, method_input;
     href = "/teams/" + slug;
@@ -30478,6 +30470,17 @@ $(function() {
     form = $('<form method="post" action="' + href + '"></form>');
     method_input = '<input name="_method" value="delete" type="hidden"/>';
     form.hide().append(method_input).appendTo('body');
+    return form.submit();
+  };
+
+  dismissTeamManager = function(username, slug) {
+    var form, href, method_input, username_input;
+    href = "/teams/" + slug + "/managers";
+    form = $('<form method="post" action="' + href + '"></form>');
+    method_input = '<input name="_method" value="delete" type="hidden"/>';
+    username_input = '<input name="username" type="hidden" value="#{username}" />';
+    form.hide().append(method_input).appendTo('body');
+    form.hide().append(username_input).appendTo('body');
     return form.submit();
   };
 

--- a/lib/app/views/teams/manage.erb
+++ b/lib/app/views/teams/manage.erb
@@ -1,0 +1,108 @@
+<div class="container">
+  <section class="page-header">
+    <h1>
+      Manage Team <%= h(team.name) %>
+      <a href="/teams/<%= team.slug %>" class="btn btn-default">Go back to team</a>
+    </h1>
+  </section>
+
+  <div id="team_settings">
+    <h3>Team Settings</h3>
+    <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}" %>" method="post">
+      <div class="row">
+        <div class="form-group col-sm-4">
+          <label for="team_slug">Slug (in URL)</label>
+          <div class="controls">
+            <input type="text" name="team[slug]" id="team_slug" placeholder="e.g. gocowboys" value="<%= team.slug %>" class="form-control" />
+          </div>
+        </div>
+
+        <div class="form-group col-sm-4">
+          <label for="team_name">Name (optional, defaults to slug)</label>
+          <div class="controls">
+            <input type="text" name="team[name]" id="team_name" placeholder="e.g. Go Cowboys" value="<%= team.name %>" class="form-control" />
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <button type="submit" class="btn btn-primary" style="margin-left: 15px">Update</button>
+      </div>
+    </form><br/>
+
+    <div id="danger_buttons" class="row">
+      <div class="col-md-2" style="margin: 0 10px 10px 0">
+        <form accept-charset="UTF-8" action="/teams/<%= team.slug %>" method="delete">
+          <button type="submit" class="btn btn-primary btn-danger">Delete Team</button>
+        </form>
+      </div>
+      <div class="col-md-2" style="margin: 0 10px 10px 0">
+        <% if team.managers.size > 1 %>
+          <form accept-charset="UTF-8" action="/teams/<%= team.slug %>/disown" method="post">
+            <button type="submit" class="btn btn-primary btn-danger">Resign as Manager</button>
+          </form>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+<hr>
+
+  <div id="managers">
+    <h3>Managers</h3>
+    <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}/managers" %>" method="post">
+      <div class="row">
+        <div class="form-group col-sm-4">
+          <label class="control-label" for="username">Username</label>
+          <div class="controls">
+            <input type="text" name="username" class="form-control" />
+          </div>
+        </div>
+      </div>
+      <button type="submit" class="btn btn-primary">Add manager</button>
+    </form>
+
+    <% if team.managers.count > 1 %>
+        <% (team.managers - [current_user]).each do |manager| %>
+          
+          <form accept-charset="UTF-8" action="/teams/<%= team.slug %>/managers" method="post">
+            <input type="hidden" name="_method" value="delete" />
+            <input type="hidden" name="username" value="<%= manager.username %>" />
+            <button type="submit" class="btn btn-xs btn-danger manager_delete" data-username="<%= manager.username %>" style="margin: 10px 10px 10px 0">Remove</button>
+            <%= gravatar_tag manager.avatar_url, size: 20 %>
+            <a href="/<%= manager.username %>"><%= manager.username %></a>
+          </form>
+        <% end %>
+    <% end %>
+  </div>
+
+<hr>
+
+  <div id="members">
+    <h3>Members</h3>
+    <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}/members" %>" method="post">
+      <div class="row">
+        <div class="control-group col-md-8">
+          <label  class="control-label" for="usernames">Usernames (comma-separated list)</label>
+          <div class="controls">
+            <textarea name="usernames" id="usernames" class="form-control" placeholder="e.g. kytrinyx, seeflanigan, rubysolo, theotherzach"></textarea>
+          </div>
+        </div>
+      </div>
+      <button type="submit" class="btn btn-primary" style="margin-top: 15px">Invite</button>
+    </form>
+
+    <br/>
+    
+    <div class="row">
+      <% members.each do |member| %>
+        <div class="col-sm-3">
+          <a href="#" data-username="<%= member.username %>" data-team="<%= team.slug %>"
+          class="btn btn-xs btn-danger member_delete" style="margin: 10px 10px 10px 0">X</a>
+          <%= gravatar_tag member.avatar_url, size: 20 %>
+          <a href="/<%= member.username %>"><%= member.username %></a>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/lib/app/views/teams/member_submissions.erb
+++ b/lib/app/views/teams/member_submissions.erb
@@ -1,5 +1,5 @@
 <div class="col-md-4" id="<%= member.username %>">
-  <h5>
+  <h5 class="well">
     <%= gravatar_tag member.avatar_url, size: 20 %>
     <a href="/<%= member.username %>"><%= member.username %></a>
     <% if team.managed_by?(current_user) %>

--- a/lib/app/views/teams/show.erb
+++ b/lib/app/views/teams/show.erb
@@ -1,79 +1,15 @@
 <div class="container">
   <section class="page-header">
-    <h1>Team <%= h(team.name) %></h1>
-  </section>
-  <% if team.managed_by?(current_user) %>
-    <a href="#" id="edit_team" class="btn btn-sm">Edit</a>
-    <a href="#" id="destroy_team" class="btn btn-sm btn-danger" data-team=<%= team.slug %>>Destroy</a>
-    <% if team.managers.size > 1 %>
-      <form accept-charset="UTF-8" action="/teams/<%= team.slug %>/disown" method="post">
-        <button type="submit" class="btn btn-primary btn-danger">Quit Managing</button>
-      </form>
-    <% end %>
-
-    <div class="hidden" id="add_members">
-      <br />
-      <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}" %>" method="post">
-        <input type="hidden" name="_method" value="put" />
-
-        <div class="form-group">
-          <label for="team_slug">Slug</label>
-          <div class="controls">
-            <input type="text" name="team[slug]" id="team_slug" placeholder="e.g. gocowboys" value="<%= team.slug %>" class="form-control">
-          </div>
-        </div>
-
-        <div class="form-group">
-          <label for="team_name">Name (optional; defaults to slug)</label>
-          <div class="controls">
-            <input type="text" name="team[name]" id="team_name" placeholder="e.g. Go Cowboys" value="<%= team.name %>" class="form-control">
-          </div>
-        </div>
-
-        <button type="submit" class="btn btn-primary">Update</button>
-      </form>
-
-      <h3>Managers</h3>
-      <% if team.managers.count > 1 %>
-        <ul>
-        <% (team.managers - [current_user]).each do |manager| %>
-        <li>
-          <%= manager.username %>
-          <form accept-charset="UTF-8" action="/teams/<%= team.slug %>/managers" method="post">
-            <input type="hidden" name="_method" value="delete" />
-            <input type="hidden" name="username" value="<%= manager.username %>" />
-            <button type="submit" class="btn btn-primary btn-danger">Remove</button>
-          </form>
-        </li>
-        <% end %>
-        </ul>
+    <h1>
+      Team <%= h(team.name) %>
+      <% if team.managed_by?(current_user) %>
+        <a href="/teams/<%= team.slug %>/manage" class="btn btn-default">Manage</a>
       <% end %>
-
-      <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}/managers" %>" method="post" class="form-inline">
-        <label  class="control-label" for="username">Username</label>
-        <input type="text" name="username" class="form-control" />
-        <button type="submit" class="btn btn-primary">Add manager</button>
-      </form>
-
-      <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}/members" %>" method="post">
-        <legend>Members</legend>
-
-        <div class="control-group">
-          <label  class="control-label" for="usernames">Usernames (comma-separated list)</label>
-          <div class="controls">
-            <textarea name="usernames" id="usernames" class="form-control" placeholder="e.g. kytrinyx, seeflanigan, rubysolo, theotherzach"></textarea>
-          </div>
-        </div>
-
-        <div class="control-group">
-          <div class="controls">
-            <button type="submit" class="btn btn-primary">Invite</button>
-          </div>
-        </div>
-      </form>
-    </div>
-  <% end %>
-
+    </h1>
+  </section>
+  
+  <h3><%= team.members.length %> members</h3>
+ 
   <% members.each_slice(3) do |row| %>
     <div class="row">
       <% row.each do |member| %>

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -61,7 +61,8 @@ class TeamsTest < Minitest::Test
       [:put, '/teams/abc/confirm'],
       [:post, '/teams/abc/managers'],
       [:delete, '/teams/abc/managers'],
-      [:post, '/teams/abc/disown']
+      [:post, '/teams/abc/disown'],
+      [:get, '/teams/:slug/manage']
     ].each do |verb, endpoint|
       send verb, endpoint
       assert_equal 302, last_response.status
@@ -322,12 +323,12 @@ class TeamsTest < Minitest::Test
 
     post '/teams/dragon/managers', {username: bob.username}, login(alice)
     assert_response_status(302)
-    assert_equal "http://example.org/teams/dragon", last_response.location
+    assert_equal "http://example.org/teams/dragon/manage", last_response.location
     assert_equal [alice.id, bob.id].sort, team.reload.managers.map(&:id).sort
 
     post '/teams/dragon/managers', {username: 'no-such-user'}, login(alice)
     assert_response_status(302)
-    assert_equal "http://example.org/teams/dragon", last_response.location
+    assert_equal "http://example.org/teams/dragon/manage", last_response.location
     assert_equal [alice.id, bob.id].sort, team.reload.managers.map(&:id).sort
   end
 
@@ -338,12 +339,12 @@ class TeamsTest < Minitest::Test
 
     delete '/teams/salamander/managers', {username: bob.username}, login(alice)
     assert_response_status 302
-    assert_equal "http://example.org/teams/salamander", last_response.location
+    assert_equal "http://example.org/teams/salamander/manage", last_response.location
     assert_equal [alice.id], team.reload.managers.map(&:id)
 
     delete '/teams/salamander/managers', {username: 'no-such-user'}, login(alice)
     assert_response_status 302
-    assert_equal "http://example.org/teams/salamander", last_response.location
+    assert_equal "http://example.org/teams/salamander/manage", last_response.location
     assert_equal [alice.id], team.reload.managers.map(&:id)
   end
 
@@ -364,7 +365,7 @@ class TeamsTest < Minitest::Test
 
     post '/teams/condor/disown', {}, login(alice)
     assert_response_status 302
-    assert_equal "http://example.org/teams/condor", last_response.location
+    assert_equal "http://example.org/teams/condor/manage", last_response.location
     assert_equal [alice.id], team.reload.managers.map(&:id)
   end
 end


### PR DESCRIPTION
- Update look of management tools
- Link to user/manager profiles to make sure you are acting on the correct person
- Delete button for users is text X rather than font-awesome as it was slowing page load and 'Delete' or 'Remove' text could be cumbersome for many users.
- Add `/teams/:slug/manage` route
- Update teams tests to match new route
- Update existing routes to stay on manage page when managing

Addresses #2491 