### PR TITLE
Track fetched but unsubmitted exercises

### DIFF
--- a/db/migrate/201509141447_add_fetched_at_to_exercises.rb
+++ b/db/migrate/201509141447_add_fetched_at_to_exercises.rb
@@ -1,0 +1,5 @@
+class AddFetchedAtToExercises < ActiveRecord::Migration
+  def change
+    add_column :user_exercises, :fetched_at, :timestamp
+  end
+end

--- a/lib/api/routes/exercises.rb
+++ b/lib/api/routes/exercises.rb
@@ -13,9 +13,7 @@ module ExercismAPI
         end
 
         begin
-          result = Homework.new(current_user).all.to_json
-          LifecycleEvent.track('fetched', current_user.id)
-          result
+          Homework.new(current_user).all.to_json
         rescue Exception => e
           Bugsnag.notify(e)
           halt 500, {error: "Something went wrong, and it's not clear what it was. The error has been sent to our tracker. If you want to get involved, post an issue to GitHub so we can figure it out! https://github.com/exercism/exercism.io/issues"}.to_json

--- a/lib/app/presenters/dashboard.rb
+++ b/lib/app/presenters/dashboard.rb
@@ -15,7 +15,11 @@ module ExercismWeb
       end
 
       def current_exercises
-        @current_exercises ||= user.exercises.where(archived: false).order('last_activity_at DESC')
+        user.exercises.current
+      end
+
+      def unsubmitted_exercises
+        user.exercises.unsubmitted
       end
 
       def trending

--- a/lib/app/views/dashboard.erb
+++ b/lib/app/views/dashboard.erb
@@ -43,6 +43,31 @@
           <% else %>
             <p>You are not currently working on any exercises.</p>
           <% end %>
+          <% if dashboard.unsubmitted_exercises.present? %>
+            <p>You've fetched these problems. Now solve them!</p>
+            <ul class="nav nav-stacked" id="menu-current" role="menu">
+              <% dashboard.unsubmitted_exercises.limit(5).each do |exercise| %>
+                <li class="looks-list-item">
+                  <a role="menuitem"
+                     tabindex="-1"
+                     href=<%= "/exercises/#{exercise.language}/#{exercise.slug}/readme" %>>
+                    <table width="100%">
+                      <tr>
+                        <td width="60%">
+                          <%= "#{exercise.problem.name} (#{exercise.problem.language})" %>
+                        </td>
+                      </tr>
+                    </table>
+                  </a>
+                </li>
+              <% end %>
+              <% if dashboard.unsubmitted_exercises.size > 5 %>
+                <p>You have <%= dashboard.unsubmitted_exercises.size %> unsubmitted problems.</p>
+              <% end %>
+            </ul>
+          <% else %>
+            <p>You do not have any unsubmitted problems.</p>
+          <% end %>
         </div>
     </div>
 

--- a/lib/exercism/user_exercise.rb
+++ b/lib/exercism/user_exercise.rb
@@ -15,11 +15,11 @@ class UserExercise < ActiveRecord::Base
       where('views.user_id': user.id).
       where('views.last_viewed_at > ?', 30.days.ago).order('views.last_viewed_at DESC')
   }
-
+  scope :current, ->{ where(archived: false).where.not(iteration_count: 0).order('last_activity_at DESC') }
   scope :archived, ->{ where(archived: true).where('iteration_count > 0') }
   scope :for, lambda { |problem| where(language: problem.track_id, slug: problem.slug) }
   scope :randomized, ->{ order('RANDOM()') }
-
+  scope :unsubmitted, ->{ where(archived: false, iteration_count: 0).where.not(fetched_at: nil) }
   scope :by_activity, ->{ order('last_activity_at DESC') }
 
   before_create do

--- a/test/api/iterations_test.rb
+++ b/test/api/iterations_test.rb
@@ -94,4 +94,92 @@ class IterationsApiTest < Minitest::Test
     assert_equal 401, last_response.status
     assert last_response.body.include?(expected_message)
   end
+
+  def test_fetch_problem
+    Xapi.stub(:exists?, true) do
+      post '/iterations/ruby/one/fetch', { key: @alice.key }
+    end
+
+    exercise = @alice.exercises.first
+    fetched_events_count = @alice.lifecycle_events.where(key: 'fetched').size
+
+    assert_equal 'ruby', exercise.language
+    assert_equal 'one', exercise.slug
+    assert_in_delta Time.now.utc.to_f, exercise.fetched_at.to_f, 1.0
+    assert_equal 0, exercise.iteration_count
+    assert_equal 1, fetched_events_count
+    assert_equal 204, last_response.status
+  end
+
+  def test_fetch_non_existent_problem
+    Xapi.stub(:exists?, false) do
+      post '/iterations/ruby/not-found/fetch', { key: @alice.key }
+    end
+
+    message = "Exercise 'not-found' in language 'ruby' doesn't exist. " \
+              'Maybe you mispelled it?'
+    expected_body = { error: message }.to_json
+
+    assert_equal 404, last_response.status
+    assert_equal expected_body, last_response.body
+  end
+
+  def test_fetch_problem_as_guest
+    Xapi.stub(:exists?, true) do
+      post '/iterations/ruby/one/fetch', { key: 'invalid-api-key' }
+    end
+
+    message = 'Please double-check your exercism API key.'
+    expected_body = { error: message }.to_json
+
+    assert_equal 401, last_response.status
+    assert_equal expected_body, last_response.body
+  end
+
+  def test_fetch_non_existent_problem_as_guest
+    Xapi.stub(:exists?, false) do
+      post '/iterations/ruby/not-found/fetch', { key: 'invalid-api-key' }
+    end
+
+    assert_equal 401, last_response.status
+  end
+
+  def test_fetch_problem_when_user_has_exercise
+    @alice.exercises.create language: 'ruby', slug: 'one'
+    Xapi.stub(:exists?, true) do
+      post '/iterations/ruby/one/fetch', { key: @alice.key }
+    end
+
+    exercise_count = @alice.exercises.count
+    exercise = @alice.exercises.first
+
+    assert_equal 1, exercise_count
+    assert_equal 204, last_response.status # does not raise PG::UniqueViolation
+
+    assert_in_delta Time.now.utc.to_f, exercise.fetched_at.to_f, 1.0
+    assert_equal 0, exercise.iteration_count
+  end
+
+  def test_fetch_problem_after_user_has_already_fetched
+    a_time_long_ago = Time.utc 2010
+    @alice.exercises.create language: 'ruby',
+                            slug: 'one',
+                            fetched_at: a_time_long_ago
+    Xapi.stub(:exists?, true) do
+      post '/iterations/ruby/one/fetch', { key: @alice.key }
+    end
+
+    exercise = @alice.exercises.first
+    assert_equal a_time_long_ago, exercise.fetched_at
+  end
+
+  def test_fetch_problem_when_user_has_iterations
+    @alice.exercises.create language: 'ruby', slug: 'one', iteration_count: 3
+    Xapi.stub(:exists?, true) do
+      post '/iterations/ruby/one/fetch', { key: @alice.key }
+    end
+
+    exercise = @alice.exercises.first
+    assert_equal 3, exercise.iteration_count
+  end
 end


### PR DESCRIPTION
This enables Exercism.io to store and retrieve a list of exercises that the user has fetched but not submitted. In order for this feature to work, x-api must be modified to post a fetch for a new exercise in addition to getting the user's existing exercises.

One caveat: the fetch LifecycleEvent has been moved from `GET /exercises` to the new `POST /exercises/:language/:slug/fetch` route. Until x-api uses this route, the fetch events won't be created. If this is critical, then this change should not be deployed without the corresponding change to x-api.

Changes:
* Migrate `user_exercises` to add `fetched_at` timestamp
* Add route to register exercise as fetched
* Create 'fetch' LifecycleEvent in fetch route instead of in `GET /exercises`
* Exclude skipped and unsubmitted exercises from dashboard's current exercises
* Add unsubmitted exercises to dashboard