### PR TITLE
Update language in onboarding to reflect new exercises menu

### DIFF
--- a/lib/app/views/onboarding/pay_it_forward.erb
+++ b/lib/app/views/onboarding/pay_it_forward.erb
@@ -5,8 +5,9 @@
       <div class="article-contents">
         <h2>More Conversations</h2>
 
-        <p>Now that you've completed an exercise, you will see that a "Nitpick" menu has appeared. This lets you see exercises that other people are working on. Look at their code and think about what you see there. Is anything more complicated than it needs to be? Is there something that is unclear or confusing? Ask questions, wonder out loud.</p>
-
+        <p>If you've submitted <code>Hello World</code> as your first exercise, complete the next exercise in the sequence to unlock the ability to comment on code.</p>
+        <p>Once you've unlocked commenting, you will see that an "Exercises" menu has appeared. This lets you see exercises that other people are working on. Look at their code and think about what you see there. Is anything more complicated than it needs to be? Is there something that is unclear or confusing? Ask questions, wonder out loud.</p>
+        <p>We will suggest five different exercises for you to comment on every day. You don't have to comment on them, but getting in the habit of giving feedback frequently will help you think critically about your own code while you write it.</p>
       </div>
     </article>
   </section>


### PR DESCRIPTION
The language in "Pay It Forward" was outdated and confusing since it directed new users to a "Nitpick" menu which no longer exists.