### PR TITLE
fix exercise order on track page

### DIFF
--- a/lib/app/presenters/problems.rb
+++ b/lib/app/presenters/problems.rb
@@ -22,7 +22,7 @@ module ExercismWeb
         end
 
         def fetch_all_problems
-          status, body = Xapi.get("problems")
+          status, body = Xapi.get("/tracks/#{track_id}/problems")
           if status != 200
             raise "something fishy in x-api: (#{status}) - #{body}"
           end
@@ -33,13 +33,11 @@ module ExercismWeb
           @track_problems = []
           all_problems.each do |problem|
             slug = problem["slug"]
-            if problem["track_ids"].include?(track_id)
-              @track_problems << {
-                :slug => slug,
-                :blurb => problem["blurb"],
-                :name => slug.split('-').map(&:capitalize).join(' ')
-                }
-            end
+            @track_problems << {
+              :slug => slug,
+              :blurb => problem["blurb"],
+              :name => slug.split('-').map(&:capitalize).join(' ')
+            }
           end
           @track_problems.map {|problem| Problem.new(problem)}
         end

--- a/test/app/presenters/problems_test.rb
+++ b/test/app/presenters/problems_test.rb
@@ -38,12 +38,4 @@ class PresentersProblemsTest < Minitest::Test
       assert_includes problems.track_problems.to_s, "Write a program that implements a binary search algorithm."
     end
   end
-
-  def test_does_not_return_problems_not_in_specific_track
-    Xapi.stub(:get, [200, all_problems_json]) do
-      get '/languages/ruby'
-      problems = ExercismWeb::Presenters::Special::Problems.new('ruby')
-      refute_includes problems.track_problems.to_s, "Compute the result for a game of Hex / Polygon"
-    end
-  end
 end


### PR DESCRIPTION
This PR fixes issue https://github.com/exercism/exercism.io/issues/2577 (List exercises on language page in the track order), by using the new `/tracks/:id/problems` endpoint in the API... that just got deployed!  :-)  It also removes a test that is no longer applicable; it was testing that the _site_ filtered out the problems from other tracks, and that is now done on the _API_ side.

BTW, a big chunk of the change is merely indentation; to ignore such changes, use https://github.com/exercism/exercism.io/pull/2586/files?w=1 . 