### PR TITLE
Include a CSS class to show a background image for ECMAScript

### DIFF
--- a/lib/app/public/sass/base/components/main.scss
+++ b/lib/app/public/sass/base/components/main.scss
@@ -42,6 +42,10 @@ body {
   background-image: url('/img/javascript.png');
 }
 
+.ecmascript-icon {
+  background-image: url('/img/ecmascript.png');
+}
+
 .elixir-icon {
   background-image: url('/img/elixir.png');
 }


### PR DESCRIPTION
A class has been added to `lib/app/public/sass/base/components/main.scss`. The `lib/app/public/css/application.css` file should be regenerated to include new classes in SCSS files.

I don't know if it is done in the deployment process. If not, I haven't configured a development environment for this repo, so it would take me a while to configure it and generate the `application.css` file. If it's easy, like running some `rake` task, I could try.

Fixes #2596 