### PR TITLE
Issue #2410 - Mark exercises as complete

### DIFF
--- a/lib/app/views/onboarding/have_a_conversation.erb
+++ b/lib/app/views/onboarding/have_a_conversation.erb
@@ -25,6 +25,8 @@
         <p>There's no rule for when you should archive a problem. You're done when you feel done. That might be that you're sick of the problem, or that you just don't feel like talking about it anymore, or that it's been hashed and rehashed, and there really isn't anything left to say about it. Or any other reason that you can think of.</p>
 
         <p>When you're ready to move on, select <em>Archive Exercise</em> in the "Manage" dropdown, and your solution will no longer appear in the list of exercises that are waiting for feedback.</p>
+
+        <p>If you feel like you have completed the exercise and do not want any further feedback on it, you can archive the exercise. To do this simply choose the 'Archive Exercise' option from the 'Manage' menu on the exercise page. If ever you want to do more work and want to reactivate the exercise for feedback, choose the 'Reactivate Exercise' option from that same menu. </p>
       </div>
     </article>
   </section>


### PR DESCRIPTION
This is my first time contributing to an open source project so I hope I'm doing it right!

Anyway, this is my fix for <a href="https://github.com/exercism/exercism.io/issues/2410">Issue #2410</a> where someone was having trouble marking their exercise as complete. I know that you've now moved on to archiving exercises instead so I've just added a paragraph to the 'have a conversation' page explaining how to do this. 

I hope this is the correct place for such an explanation. My first thought was to add a step to the onboarding process explaining how to archive exercises instead but since this is my first time contributing I went the simpler route. Let me know if this is not okay!