### PR TITLE
Adding API endpoint for `exercism status $language` CLI command

### DIFF
--- a/lib/api.rb
+++ b/lib/api.rb
@@ -21,5 +21,6 @@ module ExercismAPI
     use Routes::Comments
     use Routes::Users
     use Routes::Legacy
+    use Routes::Tracks
   end
 end

--- a/lib/api/routes.rb
+++ b/lib/api/routes.rb
@@ -9,6 +9,7 @@ module ExercismAPI
       Comments: 'comments',
       Users: 'users',
       Legacy: 'legacy',
+      Tracks: 'tracks',
     }.each do |name, file|
       autoload name, Exercism.relative_to_root('lib', 'api', 'routes', file)
     end

--- a/lib/api/routes/tracks.rb
+++ b/lib/api/routes/tracks.rb
@@ -1,0 +1,16 @@
+module ExercismAPI
+  module Routes
+    class Tracks < Core
+      get '/tracks/:id/status' do |id|
+        require_key
+
+        begin
+          Homework.new(User.find_by(key: params[:key])).status(id).to_json
+        rescue Exception => e
+          Bugsnag.notify(e, nil, request)
+          halt 500, {error: "Something went wrong, and it's not clear what it was. The error has been sent to our tracker. If you want to get involved, post an issue to GitHub so we can figure it out! https://github.com/exercism/exercism.io/issues"}.to_json
+        end
+      end
+    end
+  end
+end

--- a/lib/exercism/homework.rb
+++ b/lib/exercism/homework.rb
@@ -15,6 +15,27 @@ class Homework
     extract(sql)
   end
 
+  def status(language)
+    exercises = user.exercises.where(language: language)
+
+    skipped = exercises.where.not(skipped_at: nil).pluck(:slug)
+    fetched = exercises.where.not(fetched_at: nil).pluck(:slug)
+    recent = exercises.where.not(last_iteration_at: nil)
+             .order(:last_iteration_at).last
+
+    recent = Struct.new(:slug, :last_iteration_at).new("", "") if recent.nil?
+
+    {
+      track_id: language,
+      recent: {
+        problem: recent.slug,
+        submitted_at: recent.last_iteration_at
+      },
+      skipped: skipped,
+      fetched: fetched
+    }
+  end
+
   private
 
   def extract(sql)

--- a/test/exercism/homework_test.rb
+++ b/test/exercism/homework_test.rb
@@ -1,0 +1,39 @@
+require_relative '../test_helper'
+require_relative '../active_record_helper'
+require_relative '../../lib/exercism'
+require_relative '../../lib/exercism/homework'
+
+class HomeworkTest < Minitest::Test
+  include DBCleaner
+
+  def test_status
+    alice = User.create(username: 'alice')
+    homework = Homework.new(alice)
+    now = Time.now.utc
+    attributes = { user: alice, language: 'ruby' }
+
+    UserExercise.create(attributes.merge(slug: 'leap', skipped_at: now))
+    UserExercise.create(attributes.merge(slug: 'clock', fetched_at: now))
+    UserExercise.create(attributes.merge(slug: 'gigasecond', last_iteration_at: now))
+
+    assert_equal homework.status('ruby').to_json, {
+      track_id: 'ruby',
+      recent: {
+        problem: 'gigasecond',
+        submitted_at: now
+      },
+      skipped: ['leap'],
+      fetched: ['clock']
+    }.to_json
+
+    assert_equal homework.status('go').to_json, {
+      track_id: 'go',
+      recent: {
+        problem: '',
+        submitted_at: ''
+      },
+      skipped: [],
+      fetched: []
+    }.to_json
+  end
+end


### PR DESCRIPTION
This adds a very rough, but working, implementation of the endpoint that goes with the new CLI command `exercism status $language`. I wanted to submit this now it its very rough form before I start to refactor to make sure this is generally on the right path and that the logic is in the right place. I also need to write tests for this endpoint, but since I haven't use MiniTest before, that will have to come a little later.