### PR TITLE
Add instructions to show user how to download their first exercise

### DIFF
--- a/lib/app/views/languages/languages.erb
+++ b/lib/app/views/languages/languages.erb
@@ -11,6 +11,10 @@
 							<%= docs.about %>
 						</p>
 				<% end %>
+        <% if !problems.empty? %>
+          <h2 class="header">Fetch your first exercise</h2>
+          <pre> exercism fetch <%= slug %> <%= problems.first.slug %></pre>
+        <% end %>
 				<h2 class="header">Available Exercises</h2>
 				<% problems.each do |problem| %>
 					<h5>

--- a/lib/app/views/onboarding/install_cli.erb
+++ b/lib/app/views/onboarding/install_cli.erb
@@ -37,9 +37,8 @@
           <p>The command can take an optional <code>--dir</code> argument, if you want to specify a particular directory. If nothing is specified, a directory will be created for you in your home directory.</p>
         <% end %>
 
-        <p>Fetch problems with this simple command:<br />
+        <p>Fetch your first problem by choosing a language from the languages tab above.</p>
 
-      <pre><code>  exercism fetch</code></pre>
       </div>
     </article>
   </section>


### PR DESCRIPTION
Issue #: #2604

This adds the instructions on each language page and removes the instruction shown in the onboarding flow which lets the user download the first problem for all languages.