### PR TITLE
Remove redundant rake db:migrate call within rake db:from_scratch

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -59,7 +59,7 @@ namespace :db do
   end
 
   desc 'set the database up from scratch'
-  task from_scratch: %i(setup migrate seeds:fetch seed)
+  task from_scratch: %i(setup seeds:fetch seed)
 
   namespace :generate do
     desc "generate migration"


### PR DESCRIPTION
This removes the redundant `rake db:migrate` call within the `rake db:from_scratch` call. `rake db:from_scratch` calls the `rake db:seed` command which calls `rake db:migrate`.

This also fixes the failing `rake db:from_scratch` command (#2606) because the `rake db:migrate` call before running `rake db:seed` doesn't close the connection until the process is ended. As to why that is the case, I have no idea.