### PR TITLE
Only show exercises with iterations on the team member submissions page

### DIFF
--- a/lib/app/views/teams/member_submissions.erb
+++ b/lib/app/views/teams/member_submissions.erb
@@ -5,7 +5,7 @@
   </h5>
   <% if exercises.any? %>
     <ul>
-      <% exercises.by_activity.limit(5).each do |exercise| %>
+      <% exercises.current.limit(5).each do |exercise| %>
         <li>
         <% if current_user.can_access?(exercise) %>
           <a href="/exercises/<%= exercise.key %>">

--- a/test/acceptance/account_test.rb
+++ b/test/acceptance/account_test.rb
@@ -36,4 +36,36 @@ class AccountTest < AcceptanceTestCase
       assert_content 'two_username'
     end
   end
+
+  def test_team_shows_current_exercises
+    team = Team.by(@user).defined_with({ slug: 'some-team', name: 'Some Name'})
+    team.save!
+
+    membership = TeamMembership.create!(user: @user, team: team)
+    membership.confirm!
+
+    UserExercise.create!(
+      user: @user,
+      last_iteration_at: 5.days.ago,
+      archived: false,
+      iteration_count: 1,
+      language: 'ruby',
+      slug: 'leap',
+      submissions: [Submission.create!(user: @user, language: 'ruby', slug: 'leap', created_at: 22.days.ago, version: 1)]
+    )
+    UserExercise.create!(
+      user: @user,
+      archived: false,
+      iteration_count: 0,
+      language: 'ruby',
+      slug: 'clock',
+    )
+
+    with_login(@user) do
+      visit "/teams/some-team"
+
+      assert_content 'Leap'
+      assert_no_content 'Clock'
+    end
+  end
 end


### PR DESCRIPTION
If i fetch an exercise it shows up under my name on my team page even if I'm not intending to complete it. If I `exercism fetch` it fetches an exercise from every available track so to my team members it looks like I'm doing "Hello World" in several languages.

In addition to this being slightly misleading there is an extra weirdness if one of my team members who HAS completed that exercise clicks on it. They end up at the home page with a flash message "That submission no longer exists."

I changed the view to use the `current` scope instead of `by_activity` so it only shows exercises with 1 or more iteration. I also added a test to ensure this but I'm not sure how correct my test is for the domain. Let me know if this needs tweaked.

If this doesn't seem like the right solution I'd be happy to help consider other options.

By the way I really appreciated all of the documentation for getting my local install set up.