### PR TITLE
Encourage people to contribute

### DIFF
--- a/lib/app/views/dashboard.erb
+++ b/lib/app/views/dashboard.erb
@@ -144,9 +144,9 @@
     </div>
 
     <div class="col-lg-6">
-      <h2>Improvements</h2>
-      <p>The dashboard could use a little love. What do you want to see here?</p> 
-      <p><a href="https://github.com/exercism/exercism.io/issues/1654">Submit your ideas or suggestions</a>.</p>
+      <h2>Want to help?</h2>
+      <p>The dashboard could use a little love. What do you want to see here? <a href="https://github.com/exercism/exercism.io/issues/1654">Submit your ideas or suggestions</a>.</p>
+      <p>Exercises in new languages are always welcome. See <a href="https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md" title="See how to contribute to the exercism problem sets in individual languages, as well as the exercism Problem API">the contribution guide</a> for details.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Adds a link to the dashboard to the x-api CONTRIBUTING guide. Also attempts to improve the copy a bit, not sure how successful it has been ;)

<img width="637" alt="screenshot 2015-11-13 21 05 13" src="https://cloud.githubusercontent.com/assets/6480/11156128/4e5d9f08-8a4a-11e5-81c9-ef77785745e5.png">

I took the liberty of not adding the link above "Improvements" despite the suggestion in the issue. I couldn't find a decent way of adding it there, and I figured asking people to help with ideas/suggestions and asking them to help with code/problems are pretty much in the same vein.

Fixes #2213