### PR TITLE
Avoid showing pop up when deleting nitpick 

### DIFF
--- a/app/views/submissions/edit_nit.erb
+++ b/app/views/submissions/edit_nit.erb
@@ -13,7 +13,5 @@
       <input type="hidden" name="_method" value="delete">
         <button type="submit" class="btn btn-danger" name="delete">Delete</button>
     </form>
-
-
   </section>
 </div>

--- a/frontend/app/js/script.js
+++ b/frontend/app/js/script.js
@@ -45,7 +45,7 @@ $(function() {
     var $this = $(this);
     var question_text = "You have unsaved changes on this page";
     var was_submitted = false;
-    $this.parents("form").on('submit',function(){
+    $this.parents("form").on('submit',function(e){
       was_submitted = true;
     });
     window.onbeforeunload = function (e) {
@@ -61,6 +61,10 @@ $(function() {
         return question_text;
       }
     };
+  });
+  // Remove the window.onberofereload when deleting comments
+  $("button[type='submit'][name='delete']").on('click', function(e){
+    window.onbeforeunload = null;
   });
 
   // cmd + return submits nitpicks on mac ctrl + return submits on windows

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30350,7 +30350,7 @@ $(function() {
     var $this = $(this);
     var question_text = "You have unsaved changes on this page";
     var was_submitted = false;
-    $this.parents("form").on('submit',function(){
+    $this.parents("form").on('submit',function(e){
       was_submitted = true;
     });
     window.onbeforeunload = function (e) {
@@ -30366,6 +30366,10 @@ $(function() {
         return question_text;
       }
     };
+  });
+  // Remove the window.onberofereload when deleting comments
+  $("button[type='submit'][name='delete']").on('click', function(e){
+    window.onbeforeunload = null;
   });
 
   // cmd + return submits nitpicks on mac ctrl + return submits on windows


### PR DESCRIPTION
Issue: #2418 
By place the delete button inside the same form as the edit form, the javascript will change the flag `was_submitted` [js_file](https://github.com/exercism/exercism.io/blob/master/frontend/app/js/script.js#L44) to true disabling the pop up form happening.

What do you think abut this @kytrinyx and @trayo although if you try to refresh it will show a different pop up. 