### PR TITLE
Added repository url for language page

### DIFF
--- a/lib/app/presenters.rb
+++ b/lib/app/presenters.rb
@@ -6,7 +6,7 @@ module ExercismWeb
       Tracks: 'tracks',
       Setup: 'setup',
       Dashboard: 'dashboard',
-      Progress: 'progress',
+      Progress: 'progress'
     }.each do |name, file|
       autoload name, Exercism.relative_to_root('lib', 'app', 'presenters', file)
     end

--- a/lib/app/presenters/tracks.rb
+++ b/lib/app/presenters/tracks.rb
@@ -25,6 +25,10 @@ module ExercismWeb
         tracks.find {|track| track.id == id}
       end
 
+      def self.repo_url(id)
+        find(id)["repository"]
+      end
+
       def self.active
         @@active ||= tracks.select(&:active?)
       end

--- a/lib/app/routes/languages.rb
+++ b/lib/app/routes/languages.rb
@@ -21,8 +21,9 @@ module ExercismWeb
 
         problems = Presenters::Special::Problems.new(track_id).track_problems
         docs = Presenters::Docs.new(track_id)
+        repo_url = ExercismWeb::Presenters::Tracks.repo_url(track_id)
 
-        erb :"languages/languages", locals: { problems: problems, docs: docs, language: language, slug: track_id }
+        erb :"languages/languages", locals: { problems: problems, docs: docs, language: language, slug: track_id, repo_url: repo_url }
       end
     end
   end

--- a/lib/app/views/languages/_getting_started.erb
+++ b/lib/app/views/languages/_getting_started.erb
@@ -2,6 +2,5 @@
   <div class="article-contents">
     <h2 class="header">Getting Started</h2>
     <p>Need help getting started? You can find install documentation and resources for <%= language %> <a href="http://help.exercism.io/getting-started-with-<%= slug %>.html">here</a>.</p>
-    <p>Also here is the repository with the all the problems <a href=<%= repo_url %>>repository</a>.</p>
   </div>
 </article>

--- a/lib/app/views/languages/_getting_started.erb
+++ b/lib/app/views/languages/_getting_started.erb
@@ -2,5 +2,6 @@
   <div class="article-contents">
     <h2 class="header">Getting Started</h2>
     <p>Need help getting started? You can find install documentation and resources for <%= language %> <a href="http://help.exercism.io/getting-started-with-<%= slug %>.html">here</a>.</p>
+    <p>Also here is the repository with the all the problems <a href=<%= repo_url %>>repository</a>.</p>
   </div>
 </article>

--- a/lib/app/views/languages/_having_issues.erb
+++ b/lib/app/views/languages/_having_issues.erb
@@ -1,0 +1,6 @@
+<article class="article-block">
+  <div class="article-contents">
+    <h2 class="header">Having Issues?</h2>
+    <p>If you find typos or inconsistencies in any of the problems, or if anything is unclear, post a new issue in the <a href=<%= repo_url %>>repository</a> for this track.</p>
+  </div>
+</article>

--- a/lib/app/views/languages/languages.erb
+++ b/lib/app/views/languages/languages.erb
@@ -1,7 +1,7 @@
 <div class="container getting-started">
   <%= erb :"languages/_header", locals: { language: language } %>
   <%= erb :"languages/_fetch_problem", locals: { problem: problems.first, slug: slug } %>
-  <%= erb :"languages/_getting_started", locals: { language: language, slug: slug } %>
+  <%= erb :"languages/_getting_started", locals: { language: language, slug: slug, repo_url: repo_url } %>
   <article class="article-block">
     <div class="article-contents">
       <%= erb :"languages/_docs", locals: { docs: docs } %>

--- a/lib/app/views/languages/languages.erb
+++ b/lib/app/views/languages/languages.erb
@@ -1,7 +1,8 @@
 <div class="container getting-started">
   <%= erb :"languages/_header", locals: { language: language } %>
   <%= erb :"languages/_fetch_problem", locals: { problem: problems.first, slug: slug } %>
-  <%= erb :"languages/_getting_started", locals: { language: language, slug: slug, repo_url: repo_url } %>
+  <%= erb :"languages/_getting_started", locals: { language: language, slug: slug } %>
+  <%= erb :"languages/_having_issues", locals: { repo_url: repo_url } %>
   <article class="article-block">
     <div class="article-contents">
       <%= erb :"languages/_docs", locals: { docs: docs } %>

--- a/test/app/presenters/tracks_test.rb
+++ b/test/app/presenters/tracks_test.rb
@@ -3,14 +3,24 @@ require_relative '../../tracks_helper'
 require 'app/presenters/tracks'
 
 class PresentersTracksTest < Minitest::Test
+  def setup
+    @tracks = ExercismWeb::Presenters::Tracks
+  end
+
   def test_stuff
-    tracks = ExercismWeb::Presenters::Tracks
     active = ["Clojure", "CoffeeScript", "C++", "C#", "Elixir", "Erlang", "F#", "Go", "Haskell", "Java", "JavaScript", "Common Lisp", "Lua", "Objective-C", "OCaml", "Perl 5", "PL/SQL", "Python", "Ruby", "Scala", "Swift"]
     upcoming = ["Groovy", "Nimrod", "Perl 6", "PHP", "Rust", "VB.NET"]
     planned = ["Assembly", "Bash", "C", "D", "ECMAScript", "Windows PowerShell", "Mathematical Proofs", "R", "Standard ML"]
 
-    assert_equal active, tracks.active.map(&:language)
-    assert_equal upcoming, tracks.upcoming.map(&:language)
-    assert_equal planned, tracks.planned.map(&:language)
+    assert_equal active, @tracks.active.map(&:language)
+    assert_equal upcoming, @tracks.upcoming.map(&:language)
+    assert_equal planned, @tracks.planned.map(&:language)
+  end
+
+  def test_repository
+    languages = @tracks.load_tracks.map { |track| track.slug}
+    languages.each do |l|
+      assert_equal "https://github.com/exercism/x#{l}", @tracks.repo_url(l)
+    end
   end
 end


### PR DESCRIPTION
Issue: #2620 

@kytrinyx I added the repo url to language page, I added the link in the `_getting_started` partial that way both `_languages` and `_first_problem` will display the link.

At first I thought of wrapping the logic of fetching the repository url in a new `Presenter` like `Presenters::Repo`, but that would imply an extra request, so I placed in the inside the `Presenters::Tracks`, if you prefer to have it own presenter I don't mind change it back.

Last thing I didn't know if you wanted any kind of text so I placed the first thing it came to my head.

Waiting on your feedback