### PR TITLE
Change to sort exercises by updated_at instead of created_at

### DIFF
--- a/app/views/user/_exercises_table.erb
+++ b/app/views/user/_exercises_table.erb
@@ -9,7 +9,7 @@
     </tr>
   </thead>
   <tbody>
-  <% exercises.order(created_at: :desc).each do |exercise| %>
+  <% exercises.order(updated_at: :desc).each do |exercise| %>
     <tr>
       <td>
         <% if profile.can_access?(exercise) %>


### PR DESCRIPTION
The default sort column on the user show page is by "latest iteration."
The iteration date was displaying correctly, but the sorting was by
exercise creation_date, which coincides with the first submitted
iteration.

Addresses issue #2638