### PR TITLE
Ensure Trending#for uses UTC date comparison

### DIFF
--- a/lib/exercism/trending.rb
+++ b/lib/exercism/trending.rb
@@ -9,7 +9,8 @@ module Trending
 
   # TODO: select exercises, not submissions
   def self.for(user, timeframe)
-    ts = Time.now-timeframe
+    ts = Time.now.utc-timeframe
+
     sql = <<-SQL
       SELECT
         s.key AS uuid,


### PR DESCRIPTION
Before looking at https://github.com/exercism/exercism.io/issues/2631 I was trying to get all tests to pass and I got a single failure:

```
$ RACK_ENV=test CI=1 bundle exec ruby test/exercism/trending_test.rb 
Run options: --seed 1136

# Running:

F

Fabulous run in 0.083306s, 12.0039 runs/s, 12.0039 assertions/s.

  1) Failure:
TrendingTest#test_trending_only_returns_recent_activity [test/exercism/trending_test.rb:24]:
--- expected
+++ actual
@@ -1 +1 @@
-["b57f5e6f0d1c49bb9f747beacd30362e", "ce2318e4ae5d40538f25649e6f0f98fd"]
+[]


1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
ben@bang:~/sauce/exercism.io$ 

``` 

And it appears to be due to `Trending#for` comparing against local time instead of UTC. I am guessing I get this error because I am at GMT +1300. 

Also tried setting `created_at` values on the like and comments, but that did not work.

Is this reasonable?

Build [still passing in CI](https://travis-ci.org/ben-biddington/exercism.io).