### PR TITLE
Scrub LF from code before highlighting syntax

### DIFF
--- a/lib/exercism/syntax_highlighter.rb
+++ b/lib/exercism/syntax_highlighter.rb
@@ -14,6 +14,8 @@ module ExercismLib
 
     def initialize(code, track_id)
       language = normalize_language(track_id)
+      code     = normalize_newlines(code)
+
       @lexer = Rouge::Lexer.find_fancy(language, code) || Rouge::Lexers::PlainText
 
       # XXX HACK: Redcarpet strips hard tabs out of code blocks,
@@ -39,6 +41,10 @@ module ExercismLib
     def normalize_language(language)
       # HACK: Some languages have different names in Rouge
       ROUGE_LANG.fetch(language) { language }
+    end
+
+    def normalize_newlines(code)
+      code.gsub(/\r\n?/, "\n")
     end
   end
 end

--- a/test/app/helpers/syntax_test.rb
+++ b/test/app/helpers/syntax_test.rb
@@ -41,4 +41,20 @@ CODE
     output = helper.syntax("", "ecmascript")
     assert_match('<div class="highlight javascript">', output)
   end
+
+  def test_crlf_scrubbing
+    code = <<CODE
+#\r
+# Python Comment.\r
+#\r
+\r
+def foo(bar):\r
+    bar = bar.strip()\r
+\r
+\r
+CODE
+
+    output = helper.syntax(code, "python")
+    refute_match(/\r/, output)
+  end
 end


### PR DESCRIPTION
Windows LF characters are ignored by the highlighter, resulting in strange formatting in the browser.

Closes #2629.