### PR TITLE
Update about.erb for problems -> tracks rename

### DIFF
--- a/app/views/site/about.erb
+++ b/app/views/site/about.erb
@@ -17,7 +17,7 @@
         People have asked for <%= planned_languages %>, and we hope to eventually add them as well.
         </p>
         <p>
-        If you want to help make this happen more quickly, join us on <a href="https://github.com/exercism/x-api/tree/master/problems">GitHub</a>.
+        If you want to help make this happen more quickly, join us on <a href="https://github.com/exercism/x-api/tree/master/tracks">GitHub</a>.
         </p>
       </div>
     </article>


### PR DESCRIPTION
The `problems` directory in `x-api` has been renamed to `tracks`, breaking the link on the website.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exercism/exercism.io/2652)
<!-- Reviewable:end -->
