### PR TITLE
Store solution paths relative to problem and not root

### DIFF
--- a/lib/exercism/iteration.rb
+++ b/lib/exercism/iteration.rb
@@ -1,17 +1,15 @@
 class Iteration
-  attr_reader :solution
+  attr_reader :solution, :paths
 
   def initialize(solution, track_id=nil, slug=nil)
     @track_id = track_id
     @slug = slug
-    @solution = {}
-    solution.each do |filename, contents|
-      @solution[filename] = contents.strip
-    end
-  end
+    @paths = solution.keys.map { |path| Code.new(path) }
 
-  def paths
-    @paths ||= solution.keys.map {|path| Code.new(path)}
+    @solution = {}
+    solution.each do |path, contents|
+      @solution[filename(path)] = contents.strip
+    end
   end
 
   def track_id
@@ -26,5 +24,9 @@ class Iteration
 
   def max_occurrences(ary)
     ary.group_by(&:itself).values.max_by(&:size).first
+  end
+
+  def filename(path)
+    Code.new(path).filename
   end
 end

--- a/lib/tasks/solution_path_cleanup.rake
+++ b/lib/tasks/solution_path_cleanup.rake
@@ -1,0 +1,21 @@
+task :environment do
+  require File.expand_path('../../app',
+                           File.dirname(__FILE__)) # your Sinatra app
+end
+
+namespace :db do
+  desc "Make all solution paths relative to the problem directory, not root"
+  task solution_path_cleanup: :environment do
+    Submission.find_each do |submission|
+      new_filename = Code.new(submission.filename)
+      begin
+        submission.update_attributes!(filename: new_filename)
+        print "."
+      rescue
+        STDERR.puts "\nError updating submission with Key: #{submission.key}\n"
+      end
+    end
+
+    puts "\n\nDone! #{Submission.all.count} submissions updated"
+  end
+end

--- a/test/exercism/iteration_test.rb
+++ b/test/exercism/iteration_test.rb
@@ -20,7 +20,7 @@ class IterationTest < Minitest::Test
   def test_multiple_files
     solution = {
       'ruby/one/file1.rb' => 'one = 1',
-      'ruby/one/file2.rb' => 'two = 2',
+      'ruby/one/some/subdirectory/file2.rb' => 'two = 2',
     }
     iteration = Iteration.new(solution)
     assert_equal 'ruby', iteration.track_id
@@ -48,7 +48,7 @@ class IterationTest < Minitest::Test
   def test_highest_frequency_wins
     solution = {
       'ruby/one/file1.rb' => 'one = 1',
-      'ruby/one/file2.rb' => 'two = 2',
+      'ruby/one/some/subdirectory/file2.rb' => 'two = 2',
       'who/knows/README.md' => 'stuff',
     }
     iteration = Iteration.new(solution)

--- a/test/exercism/iteration_test.rb
+++ b/test/exercism/iteration_test.rb
@@ -10,41 +10,56 @@ class IterationTest < Minitest::Test
     iteration = Iteration.new(solution)
     assert_equal 'ruby', iteration.track_id
     assert_equal 'one', iteration.slug
-    assert_equal solution, iteration.solution
+
+    expected_solution = {
+      'file.rb' => 'puts "ok"'
+    }
+    assert_equal expected_solution, iteration.solution
   end
 
   def test_multiple_files
-   solution = {
-     'ruby/one/file1.rb' => 'one = 1',
-     'ruby/one/file2.rb' => 'two = 2',
-   }
-   iteration = Iteration.new(solution)
-   assert_equal 'ruby', iteration.track_id
-   assert_equal 'one', iteration.slug
-   assert_equal solution, iteration.solution
+    solution = {
+      'ruby/one/file1.rb' => 'one = 1',
+      'ruby/one/file2.rb' => 'two = 2',
+    }
+    iteration = Iteration.new(solution)
+    assert_equal 'ruby', iteration.track_id
+    assert_equal 'one', iteration.slug
+
+    expected_solution = {
+      'file1.rb' => 'one = 1',
+      'file2.rb' => 'two = 2',
+    }
+    assert_equal expected_solution, iteration.solution
   end
 
   def test_dirty_files
-   solution = {
-     'ruby/one/file1.rb' => "\n\n\none = 1\ntwo = 2\n\n\n",
-     'ruby/one/file2.rb' => "\n\ntwo = 2\n\nthree = 3\n",
-   }
-   iteration = Iteration.new(solution)
-   assert_equal 'ruby', iteration.track_id
-   assert_equal 'one', iteration.slug
-   assert_equal "one = 1\ntwo = 2", iteration.solution['ruby/one/file1.rb']
-   assert_equal "two = 2\n\nthree = 3", iteration.solution['ruby/one/file2.rb']
+    solution = {
+      'ruby/one/file1.rb' => "\n\n\none = 1\ntwo = 2\n\n\n",
+      'ruby/one/file2.rb' => "\n\ntwo = 2\n\nthree = 3\n",
+    }
+    iteration = Iteration.new(solution)
+    assert_equal 'ruby', iteration.track_id
+    assert_equal 'one', iteration.slug
+    assert_equal "one = 1\ntwo = 2", iteration.solution['file1.rb']
+    assert_equal "two = 2\n\nthree = 3", iteration.solution['file2.rb']
   end
 
   def test_highest_frequency_wins
-   solution = {
-     'ruby/one/file1.rb' => 'one = 1',
-     'ruby/one/file2.rb' => 'two = 2',
-     'who/knows/README.md' => 'stuff',
-   }
-   iteration = Iteration.new(solution)
-   assert_equal 'ruby', iteration.track_id
-   assert_equal 'one', iteration.slug
-   assert_equal solution, iteration.solution
+    solution = {
+      'ruby/one/file1.rb' => 'one = 1',
+      'ruby/one/file2.rb' => 'two = 2',
+      'who/knows/README.md' => 'stuff',
+    }
+    iteration = Iteration.new(solution)
+    assert_equal 'ruby', iteration.track_id
+    assert_equal 'one', iteration.slug
+
+    expected_solution = {
+      'file1.rb' => 'one = 1',
+      'file2.rb' => 'two = 2',
+      'README.md' => 'stuff',
+    }
+    assert_equal expected_solution, iteration.solution
   end
 end

--- a/test/exercism/use_cases/attempt_test.rb
+++ b/test/exercism/use_cases/attempt_test.rb
@@ -45,7 +45,7 @@ class AttemptTest < Minitest::Test
     submission = Submission.first
     assert_equal 'python', submission.track_id
     assert_equal 'two', submission.slug
-    assert_equal python_two, submission.solution
+    assert_equal({'two.py' => 'CODE'}, submission.solution)
     assert_equal user, submission.user
   end
 
@@ -63,7 +63,7 @@ class AttemptTest < Minitest::Test
 
   def test_an_attempt_includes_the_code_and_filename_in_the_submissions_solution
     Attempt.new(user, Iteration.new('two/two.py' => 'CODE 123')).save
-    assert_equal({'two/two.py' => 'CODE 123'}, user.submissions.first.reload.solution)
+    assert_equal({'two.py' => 'CODE 123'}, user.submissions.first.reload.solution)
   end
 
   def test_previous_submission_after_first_attempt
@@ -119,4 +119,3 @@ class AttemptTest < Minitest::Test
     refute attempt.duplicate?
   end
 end
-


### PR DESCRIPTION
Fixes #2635 

Contains: 
* Fix to use filepath relative to the problem directory and not exercism root directory
* `rake` task to fix existing pathnames in the same way