### PR TITLE
Fixes for bin/setup

### DIFF
--- a/lib/db/connection.rb
+++ b/lib/db/connection.rb
@@ -7,7 +7,8 @@ module DB
     def self.escape(string)
       # escape strings passed to SQL using PG::Connection instance method as per
       # http://deveiate.org/code/pg/PG/Connection.html#method-i-escape_string
-      PG::Connection.new.escape_string(string)
+      conn = PG::Connection.open(dbname: 'postgres')
+      conn.escape_string(string)
     end
 
     def self.establish


### PR DESCRIPTION
I reported the problem on [Issue 2163](https://github.com/exercism/exercism.io/issues/2163#issuecomment-162811803): When a database isn't specified, postgres will try to use a _username_ database. The `setup` script can't specify the database because it hasn't been created yet. 

PostgreSQL provides the `postgres` database [expressly for this bootstrapping purpose](http://stackoverflow.com/a/2411860/106906).

I also added error-checking for the call to `Open3#capture3`.