### PR TITLE
Fixed todo start-here link in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Behind the scenes we also have:
 
 ### Contributing
 
-We curate issues that we think are good for starting out into [exercism/todo](https://github.com/exercism/todo/issues/label://github.com/exercism/todo/labels/start-here).
+We curate issues that we think are good for starting out into [exercism/todo](https://github.com/exercism/todo/labels/start-here).
 
 If you want to work on the exercism.io website codebase, then continue reading this guide.
 


### PR DESCRIPTION
Hey :wave: 

I was going through the contributing document and found that the link for the curated issues was broken.

This PR fixes the link preserving the pre-selection of the start-here label.

Hope this is ok.

Thanks,
.FxN