### PR TITLE
Use Rack::Session::Cookie instead of enable :sessions

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -17,8 +17,7 @@ require_relative './app/routes'
 module ExercismWeb
   class App < Sinatra::Base
     configure do
-      enable :sessions
-      set :session_secret, ENV.fetch('SESSION_SECRET') { "Need to know only." }
+      use Rack::Session::Cookie, :secret => ENV.fetch('SESSION_SECRET') { "Need to know only." }
     end
 
     if settings.development?


### PR DESCRIPTION
When switching into device mode in Chrome, the session keys were being cleared. But using Rack::Session::Cookie instead of enable :sessions seems to fix this.

Resolves: #2492