### PR TITLE
Add dailies migration, AR relations, tests

### DIFF
--- a/app/views/application/_nav.erb
+++ b/app/views/application/_nav.erb
@@ -23,7 +23,7 @@
   </ul>
 
   <ul class="nav navbar-nav navbar-right">
-    <% if current_user.show_five_suggestions? %>
+    <% if current_user.show_dailies? %>
       <%= erb :"application/nav/five_a_day" %>
     <% end %>
       <% if !current_user.guest? %>

--- a/app/views/application/nav/five_a_day.erb
+++ b/app/views/application/nav/five_a_day.erb
@@ -10,8 +10,8 @@
     <b class="caret"></b></a>
     <ul class="dropdown-menu" role="menu">
       <li class="dropdown-header">Give feedback on these submissions:</li>
-      <% current_user.five_a_day_exercises.each do |exercise| %>
-        <li><a role="menuitem" tabindex="-1" href="/exercises/<%= exercise["key"] %>"><%= nav_text(exercise["slug"]) %> in <%= Language.of(exercise["language"]) %> by <%= exercise["username"] %></a></li>
+      <% current_user.dailies.each do |daily| %>
+        <li><a role="menuitem" tabindex="-1" href="/exercises/<%= daily.key %>"><%= nav_text(daily.slug) %> in <%= Language.of(daily.language) %> by <%= daily.username %></a></li>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/application/nav/five_a_day.erb
+++ b/app/views/application/nav/five_a_day.erb
@@ -1,5 +1,5 @@
 <li class="dropdown">
-  <% total = current_user.count_existing_five_a_day.to_i || 0 %>
+  <% total = current_user.daily_count %>
   <% if total >= 5 %>
     <a class="dropdown-toggle" data-toggle="tooltip" data-placement="bottom" title="Good job!" style="font-size: 16pt">
       <i class="fa fa-check"></i>

--- a/app/views/application/nav/five_a_day.erb
+++ b/app/views/application/nav/five_a_day.erb
@@ -1,12 +1,11 @@
 <li class="dropdown">
-  <% total = current_user.daily_count %>
-  <% if total >= 5 %>
+  <% if current_user.daily_count >= Daily::LIMIT %>
     <a class="dropdown-toggle" data-toggle="tooltip" data-placement="bottom" title="Good job!" style="font-size: 16pt">
       <i class="fa fa-check"></i>
     </a>
   <% else %>
     <a class="dropdown-toggle" href="#" data-toggle="dropdown" style="font-size: 20pt; font-weight: bold">
-    <%= 5 - total %>
+    <%= Daily::LIMIT - current_user.daily_count %>
     <b class="caret"></b></a>
     <ul class="dropdown-menu" role="menu">
       <li class="dropdown-header">Give feedback on these submissions:</li>

--- a/db/migrate/201512072011_create_dailies.rb
+++ b/db/migrate/201512072011_create_dailies.rb
@@ -1,0 +1,53 @@
+class CreateDailies < ActiveRecord::Migration
+  def up
+  connection.execute (<<-SQL
+      CREATE OR REPLACE VIEW dailies AS
+        SELECT
+          acls.user_id,
+          ue. KEY,
+          u.username,
+          ue.slug,
+          ue.language,
+          COALESCE (COUNT(C . ID), 0) AS count
+        FROM
+          acls
+        INNER JOIN user_exercises ue ON ue.language = acls.language AND ue.slug = acls.slug
+        INNER JOIN submissions s ON ue.id = s.user_exercise_id
+        INNER JOIN users u ON u. ID = ue.user_id
+        LEFT JOIN comments C ON C .submission_id = s. ID
+        WHERE
+          ue. id NOT IN (
+            SELECT
+              submissions.user_exercise_id
+            FROM
+              comments
+            INNER JOIN submissions on submissions.id = comments.submission_id
+            WHERE
+              comments.user_id = acls.user_id
+            UNION
+            SELECT
+              submissions.user_exercise_id
+            FROM
+              likes
+            INNER JOIN submissions on submissions.id = likes.submission_id
+            WHERE
+              likes.user_id = acls.user_id
+            )
+        AND ue.archived = 'f'
+        AND ue.slug <> 'hello-world'
+        AND ue.user_id <> acls.user_id
+        GROUP BY
+          acls.user_id,
+          ue. KEY,
+          u.username,
+          ue.slug,
+          ue.language
+        ORDER BY COALESCE (COUNT(C . ID), 0)
+      SQL
+      )
+    end
+
+  def down
+    connection.execute "DROP VIEW IF EXISTS dailies;"
+  end
+end

--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -41,6 +41,7 @@ require 'exercism/user_track'
 require 'exercism/view'
 require 'exercism/language_track'
 require 'exercism/user_lookup'
+require 'exercism/daily'
 
 
 require 'db/connection'

--- a/lib/exercism/daily.rb
+++ b/lib/exercism/daily.rb
@@ -1,0 +1,3 @@
+class Daily < ActiveRecord::Base
+  belongs_to :user
+end

--- a/lib/exercism/daily.rb
+++ b/lib/exercism/daily.rb
@@ -1,3 +1,4 @@
 class Daily < ActiveRecord::Base
   belongs_to :user
+  LIMIT = 5
 end

--- a/lib/exercism/five_a_day_count.rb
+++ b/lib/exercism/five_a_day_count.rb
@@ -1,3 +1,7 @@
 class FiveADayCount < ActiveRecord::Base
   belongs_to :user
+
+  def self.today
+    find_by_day(Date.today)
+  end
 end

--- a/lib/exercism/guest.rb
+++ b/lib/exercism/guest.rb
@@ -26,7 +26,7 @@ class Guest
     false
   end
 
-  def show_five_suggestions?
+  def show_dailies?
     false
   end
 end

--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -116,7 +116,7 @@ class User < ActiveRecord::Base
     end
   end
 
-  def show_five_suggestions?
+  def show_dailies?
     onboarded? && dailies_available?
   end
 

--- a/test/exercism/daily_test.rb
+++ b/test/exercism/daily_test.rb
@@ -3,21 +3,26 @@ require_relative '../integration_helper'
 class DailyTest < Minitest::Test
   include DBCleaner
 
-  def test_returns_exercises_for_authorized_language_and_slug
-    fred = User.create(username: 'fred')
-    sarah = User.create(username: 'sarah')
+  def fred
+    @fred ||= User.create(username: 'fred')
+  end
+
+  def sarah
+    @sarah ||= User.create(username: 'sarah')
+  end
+
+  def test_only_returns_exercises_for_authorized_language_and_slug
     ACL.authorize(fred, Problem.new('ruby', 'bob'))
 
     ex1 = create_exercise_with_submission(sarah, 'ruby', 'bob')
     Like.create!(submission: ex1.submissions.first, user: sarah)
     Comment.create!(submission: ex1.submissions.first, user: sarah, body: "I hope that when I die, people say about me, 'Boy, that guy sure owed me a lot of money.'")
+    create_exercise_with_submission(sarah, 'ruby', 'leap')
 
     assert_equal [ex1.key], fred.dailies.map(&:key)
   end
 
   def test_orders_dailies_by_comment_count
-    fred = User.create(username: 'fred')
-    sarah = User.create(username: 'sarah')
     jaclyn = User.create(username: 'jaclyn')
     ACL.authorize(fred, Problem.new('ruby', 'bob'))
 
@@ -32,7 +37,6 @@ class DailyTest < Minitest::Test
   end
 
   def test_does_not_return_archived_exercises
-    fred = User.create(username: 'fred')
     ACL.authorize(fred, Problem.new('ruby', 'bob'))
     UserExercise.create!(
         user: fred,
@@ -47,7 +51,6 @@ class DailyTest < Minitest::Test
   end
 
   def test_does_not_return_hello_world_slug
-    fred = User.create(username: 'fred')
     ACL.authorize(fred, Problem.new('ruby', 'hello-world'))
     UserExercise.create!(
         user: fred,
@@ -62,8 +65,6 @@ class DailyTest < Minitest::Test
   end
 
   def test_does_not_return_liked_user_exercises
-    fred = User.create(username: 'fred')
-    sarah = User.create(username: 'sarah')
     ACL.authorize(fred, Problem.new('ruby', 'bob'))
 
     ex1 = create_exercise_with_submission(sarah, 'ruby', 'bob')
@@ -73,8 +74,6 @@ class DailyTest < Minitest::Test
   end
 
   def test_does_not_return_commented_user_exercises
-    fred = User.create(username: 'fred')
-    sarah = User.create(username: 'sarah')
     ACL.authorize(fred, Problem.new('ruby', 'bob'))
 
     ex1 = create_exercise_with_submission(sarah, 'ruby', 'bob')

--- a/test/exercism/daily_test.rb
+++ b/test/exercism/daily_test.rb
@@ -1,0 +1,99 @@
+require_relative '../integration_helper'
+
+class DailyTest < Minitest::Test
+  include DBCleaner
+
+  def test_returns_exercises_for_authorized_language_and_slug
+    fred = User.create(username: 'fred')
+    sarah = User.create(username: 'sarah')
+    ACL.authorize(fred, Problem.new('ruby', 'bob'))
+
+    ex1 = create_exercise_with_submission(sarah, 'ruby', 'bob')
+    Like.create!(submission: ex1.submissions.first, user: sarah)
+    Comment.create!(submission: ex1.submissions.first, user: sarah, body: "I hope that when I die, people say about me, 'Boy, that guy sure owed me a lot of money.'")
+
+    assert_equal [ex1.key], fred.dailies.map(&:key)
+  end
+
+  def test_orders_dailies_by_comment_count
+    fred = User.create(username: 'fred')
+    sarah = User.create(username: 'sarah')
+    jaclyn = User.create(username: 'jaclyn')
+    ACL.authorize(fred, Problem.new('ruby', 'bob'))
+
+    ex1 = create_exercise_with_submission(sarah, 'ruby', 'bob')
+    Like.create!(submission: ex1.submissions.first, user: sarah)
+    Comment.create!(submission: ex1.submissions.first, user: sarah, body: "I hope that when I die, people say about me, 'Boy, that guy sure owed me a lot of money.'")
+
+    ex2 = create_exercise_with_submission(jaclyn, 'ruby', 'bob')
+    Like.create!(submission: ex1.submissions.first, user: sarah)
+
+    assert_equal [ex2.key, ex1.key], fred.dailies.map(&:key)
+  end
+
+  def test_does_not_return_archived_exercises
+    fred = User.create(username: 'fred')
+    ACL.authorize(fred, Problem.new('ruby', 'bob'))
+    UserExercise.create!(
+        user: fred,
+        last_iteration_at: 3.days.ago,
+        archived: true,
+        iteration_count: 1,
+        language: 'ruby',
+        slug: 'bob',
+        submissions: [Submission.create!(user: fred, language: 'ruby', slug: 'bob', created_at: 22.days.ago, version: 1)]
+    )
+    assert_equal([], Daily.all)
+  end
+
+  def test_does_not_return_hello_world_slug
+    fred = User.create(username: 'fred')
+    ACL.authorize(fred, Problem.new('ruby', 'hello-world'))
+    UserExercise.create!(
+        user: fred,
+        last_iteration_at: 3.days.ago,
+        archived: true,
+        iteration_count: 1,
+        language: 'ruby',
+        slug: 'hello-world',
+        submissions: [Submission.create!(user: fred, language: 'ruby', slug: 'bob', created_at: 22.days.ago, version: 1)]
+    )
+    assert_equal([], Daily.all)
+  end
+
+  def test_does_not_return_liked_user_exercises
+    fred = User.create(username: 'fred')
+    sarah = User.create(username: 'sarah')
+    ACL.authorize(fred, Problem.new('ruby', 'bob'))
+
+    ex1 = create_exercise_with_submission(sarah, 'ruby', 'bob')
+    Like.create!(submission: ex1.submissions.first, user: fred)
+
+    assert_equal [], fred.dailies
+  end
+
+  def test_does_not_return_commented_user_exercises
+    fred = User.create(username: 'fred')
+    sarah = User.create(username: 'sarah')
+    ACL.authorize(fred, Problem.new('ruby', 'bob'))
+
+    ex1 = create_exercise_with_submission(sarah, 'ruby', 'bob')
+    Comment.create!(submission: ex1.submissions.first, user: fred, body: "I hope that when I die, people say about me, 'Boy, that guy sure owed me a lot of money.'")
+
+    assert_equal [], fred.dailies
+  end
+
+  private
+
+  def create_exercise_with_submission(user, language, slug)
+    UserExercise.create!(
+        user: user,
+        last_iteration_at: 3.days.ago,
+        archived: false,
+        iteration_count: 1,
+        language: language,
+        slug: slug,
+        submissions: [Submission.create!(user: user, language: language, slug: slug, created_at: 22.days.ago, version: 1)]
+    )
+  end
+end

--- a/test/exercism/five_a_day_count_test.rb
+++ b/test/exercism/five_a_day_count_test.rb
@@ -1,0 +1,11 @@
+require_relative '../integration_helper'
+
+class FiveADayCountTest < Minitest::Test
+  include DBCleaner
+
+  def test_today_scope_with_user_records
+    fred = User.create(username: 'fred')
+    five = FiveADayCount.create(user: fred, total: 2, day: Date.today)
+    assert_equal(five, FiveADayCount.today)
+  end
+end

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -119,49 +119,50 @@ class UserTest < Minitest::Test
     assert_equal 1, FiveADayCount.count
   end
 
-  def test_five_a_day_exercises_comments
+  def test_dailies
     fred = User.create(username: 'fred')
     sarah = User.create(username: 'sarah')
     jaclyn = User.create(username: 'jaclyn')
     ACL.authorize(fred, Problem.new('ruby', 'bob'))
     ACL.authorize(fred, Problem.new('ruby', 'leap'))
 
-    ex1 = UserExercise.create!(
-        user: sarah,
-        last_iteration_at: 5.days.ago,
-        archived: false,
-        iteration_count: 1,
-        language: 'ruby',
-        slug: 'bob',
-        submissions: [Submission.create!(user: sarah, language: 'ruby', slug: 'bob', created_at: 22.days.ago, version: 1)]
-    )
+    ex1 = create_exercise_with_submission(sarah, 'ruby', 'bob')
     Comment.create!(submission: ex1.submissions.first, user: sarah, body: 'I like to comment')
 
-    UserExercise.create!(
-        user: jaclyn,
-        last_iteration_at: 5.days.ago,
-        archived: false,
-        iteration_count: 1,
-        language: 'ruby',
-        slug: 'bob',
-        submissions: [Submission.create!(user: jaclyn, language: 'ruby', slug: 'bob', created_at: 22.days.ago, version: 1)]
-    )
+    create_exercise_with_submission(jaclyn, 'ruby', 'bob')
 
-    ex3 = UserExercise.create!(
-        user: jaclyn,
-        last_iteration_at: 3.days.ago,
-        archived: false,
-        iteration_count: 1,
-        language: 'ruby',
-        slug: 'leap',
-        submissions: [Submission.create!(user: jaclyn, language: 'ruby', slug: 'bob', created_at: 22.days.ago, version: 1)]
-    )
+    ex3 = create_exercise_with_submission(jaclyn, 'ruby', 'leap')
     Comment.create!(submission: ex3.submissions.first, user: fred, body: 'nice')
 
-    assert_equal 2, fred.five_a_day_exercises.size
+    assert_equal 2, fred.dailies.size
+  end
+
+  def test_dailies_will_subtract_five_a_day_count
+    fred = User.create(username: 'fred')
+    ACL.authorize(fred, Problem.new('ruby', 'bob'))
+    ['billy' ,'rich', 'jaclyn', 'maddy', 'sarah'].each do |name|
+      create_exercise_with_submission(User.create(username: name), 'ruby', 'bob')
+    end
+
+    assert_equal 5, fred.dailies.size
+    fred.increment_five_a_day
+    fred.reload
+    assert_equal 4, fred.dailies.size
   end
 
   private
+
+  def create_exercise_with_submission(user, language, slug)
+    UserExercise.create!(
+        user: user,
+        last_iteration_at: 3.days.ago,
+        archived: false,
+        iteration_count: 1,
+        language: language,
+        slug: slug,
+        submissions: [Submission.create!(user: user, language: language, slug: slug, created_at: 22.days.ago, version: 1)]
+    )
+  end
 
   def create_submission(problem, attributes={})
     submission = Submission.on(problem)

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -150,6 +150,33 @@ class UserTest < Minitest::Test
     assert_equal 4, fred.dailies.size
   end
 
+  def test_user_daily_count
+    fred = User.create(username: 'fred')
+
+    fred.increment_five_a_day
+    assert_equal 1, fred.daily_count
+  end
+
+  def test_user_daily_count_returns_0_if_no_daily
+    fred = User.create(username: 'fred')
+
+    assert_equal 0, fred.daily_count
+  end
+
+  def test_dailies_available_when_less_than_5
+    fred = User.create(username: 'fred')
+
+    fred.increment_five_a_day
+    assert_equal true, fred.dailies_available?
+  end
+
+  def test_dailies_available_when_5
+    fred = User.create(username: 'fred')
+
+    5.times { fred.increment_five_a_day }
+    assert_equal false, fred.dailies_available?
+  end
+
   private
 
   def create_exercise_with_submission(user, language, slug)


### PR DESCRIPTION
This is based on
https://github.com/exercism/exercism.io/issues/2572#issuecomment-166112676

This does some small refactoring of the Five A Day feature.  It moves the SQL for the Five A Day into a view called dailies and places a Daily model on top of it,  this allows for true AR relations/queries, (i.e user.dailies).

In addition when a user likes a submission it will be removed from their suggestions, but not count toward their daily count.

@kytrinyx Please take a look and let me know what you think, and if I missed anything!

