### PR TITLE
Center new element count in exercises inbox

### DIFF
--- a/public/sass/base/components/inbox.scss
+++ b/public/sass/base/components/inbox.scss
@@ -9,8 +9,8 @@ nav.inbox {
     }
     .badge {
       position: absolute;
-      top: 0;
-      left: 0;
+      top: 10px;
+      left: 5px;
     }
   }
 }


### PR DESCRIPTION
The counter is given a little more space and it does not appear in the upper left corner of the exercises list.

Before:

![not-centered-counter](https://cloud.githubusercontent.com/assets/612688/12055432/90cd91c4-af2d-11e5-9160-e8adfc8a387c.png)

After:

![centered-counter](https://cloud.githubusercontent.com/assets/612688/12055437/9c8aff7e-af2d-11e5-9117-1f27e323a757.png)
