### PR TITLE
Add track mentor on user and data task for migration

### DIFF
--- a/db/migrate/201512292315_add_track_mentor_to_user.rb
+++ b/db/migrate/201512292315_add_track_mentor_to_user.rb
@@ -1,0 +1,5 @@
+class AddTrackMentorToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :track_mentor, :text
+  end
+end

--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -2,6 +2,7 @@ require 'digest/sha1'
 
 class User < ActiveRecord::Base
   serialize :mastery, Array
+  serialize :track_mentor, Array
 
   has_many :submissions
   has_many :notifications

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -192,5 +192,14 @@ namespace :data do
         end
       end
     end
+
+    desc "migrate info from mastery to track mentor"
+    task :track_mentor do
+      require 'bundler'
+      Bundler.require
+      require_relative '../exercism'
+
+      User.update_all("track_mentor=mastery")
+    end
   end
 end


### PR DESCRIPTION
Related to #2501 

Migrations for steps 1, 2 and 3:

>1. Create a migration that creates a new column on users called track_mentor that nothing references.
2. Create a data migration (lib/tasks/data.rake) to copy data from users.mastery to users.track_mentor
3. Deploy and run db migration and data migration.

@kytrinyx , let me know what you think and if these changes make sense for these first few steps.