### PR TITLE
Refactor tests to use track_mentor over mastery and drop mastery from user

### DIFF
--- a/db/migrate/201512311928_delete_mastery_on_user.rb
+++ b/db/migrate/201512311928_delete_mastery_on_user.rb
@@ -1,0 +1,11 @@
+class DeleteMasteryOnUser < ActiveRecord::Migration
+  def change
+    def up
+      remove_column :users, :mastery
+    end
+
+    def down
+      add_column :users, :mastery, :text
+    end
+  end
+end

--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -1,7 +1,6 @@
 require 'digest/sha1'
 
 class User < ActiveRecord::Base
-  serialize :mastery, Array
   serialize :track_mentor, Array
 
   has_many :submissions

--- a/test/app/helpers/submission_test.rb
+++ b/test/app/helpers/submission_test.rb
@@ -39,7 +39,7 @@ class AppHelpersSubmissionTest < Minitest::Test
   end
 
   def test_like_submission_button_for_nitpicker
-    @fred.mastery << 'ruby'
+    @fred.track_mentor << 'ruby'
     @submission.problem.track_id = 'ruby'
     expected = %Q{
       <form accept-charset="UTF-8" action="/submissions/#{@submission.key}/like" method="POST" class="submission-like-button">
@@ -51,7 +51,7 @@ class AppHelpersSubmissionTest < Minitest::Test
   end
 
   def test_like_submission_button_for_someone_who_has_liked
-    @fred.mastery << 'ruby'
+    @fred.track_mentor << 'ruby'
     @submission.problem.track_id = 'ruby'
     @submission.liked_by << @fred
     expected = %Q{

--- a/test/app/submissions_test.rb
+++ b/test/app/submissions_test.rb
@@ -22,7 +22,7 @@ class SubmissionsTest < Minitest::Test
     {
       username: 'bob',
       github_id: 2,
-      mastery: ['ruby'],
+      track_mentor: ['ruby'],
       email: "bob@example.com"
     }
   end

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -22,7 +22,7 @@ class TeamsTest < Minitest::Test
     {
       username: 'bob',
       github_id: 2,
-      mastery: ['ruby'],
+      track_mentor: ['ruby'],
       email: "bob@example.com"
     }
   end
@@ -31,7 +31,7 @@ class TeamsTest < Minitest::Test
     {
       username: 'charlie',
       github_id: 3,
-      mastery: ['ruby'],
+      track_mentor: ['ruby'],
       email: "charlie@example.com"
     }
   end

--- a/test/exercism/inbox_test.rb
+++ b/test/exercism/inbox_test.rb
@@ -34,7 +34,7 @@ class InboxTrackTest < Minitest::Test
     # In Go she can see only what she has submitted (Leap and Hamming, but not Clock).
     # Her own exercises appear in the inbox.
     # We won't bother with Bob's views and ACLs, since we're not testing his inbox.
-    alice = User.create(username: 'alice', avatar_url: 'alice.jpg', mastery: ['elixir'])
+    alice = User.create(username: 'alice', avatar_url: 'alice.jpg', track_mentor: ['elixir'])
     bob = User.create(username: 'bob', avatar_url: 'bob.jpg')
 
     [

--- a/test/exercism/user_track_test.rb
+++ b/test/exercism/user_track_test.rb
@@ -18,7 +18,7 @@ class UserTrackTest < Minitest::Test
     # the total count or in the unread count.
     # Her own exercises appear in the inbox, and are included in the counts.
     # We won't bother with Bob's views and ACLs, since we're not testing his inbox.
-    alice = User.create(username: 'alice', mastery: ['elixir'])
+    alice = User.create(username: 'alice', track_mentor: ['elixir'])
     bob = User.create(username: 'bob')
 
     [
@@ -96,4 +96,3 @@ class UserTrackTest < Minitest::Test
     assert_equal 1, p3.unread
   end
 end
-


### PR DESCRIPTION
Related to #2501 

Code changes and migration for steps 4, 5 and 6:
>4) Change the codebase to reference the users.track_mentor column instead of mastery.
5) Create a migration to drop the mastery field.
6) Deploy and run the db migration

@kytrinyx , could you take a look at this? I also refactored a task in `lib/tasks/data.rake` called `migrate mentor acls` to reference `track_mentor` instead of `mastery`. I'm guessing this is the task to open up access to track members?

Happy new year!! Time to go watch fireworks :tada: