### PR TITLE
Made collapsable toggles easier to select on exercises list

### DIFF
--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -97,10 +97,12 @@
 
         <% track.problems.each do |problem| %>
           <h5>
-            <%= problem.name %>
-            <b class="caret fuchsia" data-toggle="collapse" data-target="#<%= problem.slug %>" aria-expanded="false" aria-controls="<%= problem.slug %>">
-              &nbsp;
-            </b>
+            <button class="btn btn-default" data-toggle="collapse" data-target="#<%= problem.slug %>" aria-expanded="false" aria-controls="<%= problem.slug %>">
+              <%= problem.name %>
+              <b class="caret fuchsia">
+                &nbsp;
+              </b>
+            </button>
           </h5>
 
           <div class="collapse" id="<%= problem.slug %>">


### PR DESCRIPTION
I noticed when going through the exercises list it was sometimes difficult to select the caret to expand the section.  Added a button within the header to make expanding a section easy.