### PR TITLE
Fixes issue #2693 Order exercise by language

### DIFF
--- a/app/presenters/dashboard.rb
+++ b/app/presenters/dashboard.rb
@@ -7,7 +7,7 @@ module ExercismWeb
       end
 
       def current_exercises
-        user.exercises.current
+        user.exercises.current.order(:language)
       end
 
       def unsubmitted_exercises

--- a/test/app/presenters/dashboard_test.rb
+++ b/test/app/presenters/dashboard_test.rb
@@ -1,0 +1,19 @@
+require_relative '../../test_helper'
+require_relative '../../dashboard_helper'
+require_relative '../../../app/presenters/dashboard'
+
+class PresentersDashboardTest < Minitest::Test
+  include DBCleaner
+  def setup
+  end
+  
+  def test_current_exercises_order
+    user = User.create(username: 'Alex')
+    ruby_exercise_1 = UserExercise.create(user: user, iteration_count: 1, language: 'ruby')
+    javascript_exercise_1 = UserExercise.create(user: user, archived: false, iteration_count: 1, language: 'javascript')
+    javascript_exercise_2 = UserExercise.create(user: user, archived: false, iteration_count: 1, language: 'javascript')
+    ruby_exercise_2 = UserExercise.create(user: user, archived: false, iteration_count: 1, language: 'ruby')
+    dashboard = ExercismWeb::Presenters::Dashboard.new(user)
+    assert_equal dashboard.current_exercises.pluck(:language), ['javascript', 'javascript', 'ruby', 'ruby']
+  end
+end

--- a/test/dashboard_helper.rb
+++ b/test/dashboard_helper.rb
@@ -1,0 +1,2 @@
+require_relative './active_record_helper'
+require 'exercism'


### PR DESCRIPTION
This change updates the Dashboard#current_exercises method to order by language so that the dashboard displays user_exercises grouped by language track. This was addressed in issue 2693 https://github.com/exercism/exercism.io/issues/2693.

This also adds tests for the dashboard presenter.  Was thinking we might also want to order by another attribute such as last_iteration_at, but as for now this should fix the current issue.  First PR of the new year :), so hopefully you agree with the fix.