### PR TITLE
[Fixes #2693] - orders current_exercises by language, id

### DIFF
--- a/app/views/user/show.erb
+++ b/app/views/user/show.erb
@@ -14,7 +14,7 @@
 
       <h3>Exercises</h3>
       <% if profile.has_current_exercises? %>
-        <%= erb :"user/_exercises_table", locals: { profile: profile, exercises: profile.exercises } %>
+        <%= erb :"user/_exercises_table", locals: { profile: profile, exercises: profile.exercises.current } %>
       <% else %>
         <p>No current exercises.</p>
       <% end %>

--- a/lib/exercism/user_exercise.rb
+++ b/lib/exercism/user_exercise.rb
@@ -15,7 +15,7 @@ class UserExercise < ActiveRecord::Base
       where('views.user_id': user.id).
       where('views.last_viewed_at > ?', 30.days.ago).order('views.last_viewed_at DESC')
   }
-  scope :current, ->{ where(archived: false).where.not(iteration_count: 0).order('last_activity_at DESC') }
+  scope :current, ->{ where(archived: false).where.not(iteration_count: 0).order('language, id ASC') }
   scope :archived, ->{ where(archived: true).where('iteration_count > 0') }
   scope :for, lambda { |problem| where(language: problem.track_id, slug: problem.slug) }
   scope :randomized, ->{ order('RANDOM()') }

--- a/test/exercism/user_exercise_test.rb
+++ b/test/exercism/user_exercise_test.rb
@@ -31,5 +31,15 @@ class UserExerciseTest < Minitest::Test
     exercise.reload
     assert_equal 12, exercise.nit_count
   end
+
+  def test_current
+    alice = User.create(username: 'alice')
+    closure_1 = UserExercise.create(user: alice, archived: false, language: 'closure', iteration_count: 1)
+    ruby_1 = UserExercise.create(user: alice, archived: false, language: 'ruby', iteration_count: 1)
+    closure_2 = UserExercise.create(user: alice, archived: false, language: 'closure', iteration_count: 1)
+    ruby_2 = UserExercise.create(user: alice, archived: false, language: 'ruby', iteration_count: 1)
+    archived_ruby = UserExercise.create(user: alice, archived: true, language: 'ruby', iteration_count: 1)
+    assert_equal UserExercise.current, [closure_1, closure_2, ruby_1, ruby_2]
+  end
 end
 


### PR DESCRIPTION


This PR fixes https://github.com/exercism/exercism.io/issues/2693 by updating the named scope UserExercise#current to order by language and id ascending.  It also adds the corresponding test.

It also updates user/show.erb to use the current scope to maintain consistency and make this view much more readable as well.