### PR TITLE
Align the PR help section inside tab and add links to filenames

### DIFF
--- a/app/views/site/cli.erb
+++ b/app/views/site/cli.erb
@@ -40,11 +40,11 @@
         </div>
       <% end %>
 
+      <h2>Want to add more help topics?</h2>
+      <p>Submit a pull request or open an issue with suggestions! The code for this documentation is in <a href="https://github.com/exercism/exercism.io">the exercism.io repository</a> on GitHub.</p>
+      <p>(Check out the <code><a href="https://github.com/exercism/exercism.io/blob/master/x/docs/cli.rb">./x/docs/cli.rb</a></code> and <code><a href="https://github.com/exercism/exercism.io/blob/master/app/views/site/cli.erb">./app/views/site/cli.erb</a></code> files.)</p>
     </div>
 
-    <h2>Want to add more help topics?</h2>
-    <p>Submit a pull request or open an issue with suggestions! The code for this documentation is in <a href="https://github.com/exercism/exercism.io">the exercism.io repository</a> on GitHub.</p>
-    <p>(Check out the <code>./x/docs/cli.rb</code> and <code>./app/views/site/cli.erb</code> files.)</p>
   </div>
 
 </div>


### PR DESCRIPTION
Currently the PR Help section on the [cli page](http://exercism.io/cli) is not aligned with the tab.
![align-exericism](https://cloud.githubusercontent.com/assets/980783/12078054/e8e604f2-b227-11e5-95d6-0fab71e33f11.jpg)

This PR aligns it with the tab and also adds direct github links to the two filenames `./x/docs/cli.rb` and `./app/views/site/cli.erb`.