### PR TITLE
Adds link to cli on language page

### DIFF
--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -53,7 +53,7 @@
 
         <h3>Try It!</h3>
         <p>
-          If you've downloaded the command-line client and have <%= track.language %> installed
+          If you've downloaded the <a href='/cli'>command-line client</a> and have <%= track.language %> installed
           on your machine, then go ahead and fetch the first problem.
         </p>
         <%= syntax track.fetch_cmd, "plain" %>

--- a/test/acceptance/static_page_test.rb
+++ b/test/acceptance/static_page_test.rb
@@ -29,4 +29,12 @@ class StaticPageTest < AcceptanceTestCase
       assert_css 'a', text: 'Styleguide'
     end
   end
+
+  def test_language_page_contains_link_to_cli
+    user = create_user
+    with_login(user) do
+      visit '/languages/ruby'
+      assert_link 'command-line client'
+    end
+  end
 end


### PR DESCRIPTION
Adds a link to the cli on the language.  This way a user who has not installed the cli can easily find out how to as opposed to having to find link in footer or elsewhere