### PR TITLE
Ignore the vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ db/seeds.sql
 db/schema.sql
 db/migrations.sql
 Procfile_Vagrant
+vendor
 
 # JavaScript
 node_modules


### PR DESCRIPTION
After running `bin/setup`, a wild `vendor` directory appears 👻It stays there, in `git status`, red, all the time. It looks like we can safely ignore it.