### PR TITLE
Update puma for openSSL fixes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'newrelic_rpm', '~>3.8' # used both in production and development
 gem 'petroglyph'
 gem 'pg'
 gem 'pry', require: false
-gem 'puma'
+gem 'puma', '~> 2.15.0'
 gem 'rack-flash3', require: 'rack-flash'
 gem 'rake'
 gem 'redcarpet', '~> 3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,8 +111,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    puma (2.11.2)
-      rack (>= 1.1, < 2.0)
+    puma (2.15.3)
     rack (1.6.4)
     rack-flash3 (1.0.5)
       rack
@@ -211,7 +210,7 @@ DEPENDENCIES
   petroglyph
   pg
   pry
-  puma
+  puma (~> 2.15.0)
   rack-flash3
   rack-test
   rake
@@ -227,3 +226,6 @@ DEPENDENCIES
   timecop
   will_paginate
   will_paginate-bootstrap
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Puma now allows installation with optional SSL if it is not found in cases like El Capitan.