### PR TITLE
[FIXES #2716]decrements iteration count of submissions user_exercise

### DIFF
--- a/app/routes/submissions.rb
+++ b/app/routes/submissions.rb
@@ -62,6 +62,7 @@ module ExercismWeb
         end
 
         decrement_version(submission)
+        submission.user_exercise.decrement_iteration_count!
         submission.destroy
         Hack::UpdatesUserExercise.new(submission.user_id, submission.track_id, submission.slug).update
         redirect "/dashboard"

--- a/lib/exercism/user_exercise.rb
+++ b/lib/exercism/user_exercise.rb
@@ -66,6 +66,10 @@ class UserExercise < ActiveRecord::Base
     @comment_count ||= Hash(ActiveRecord::Base.connection.execute(comment_count_sql).to_a.first)["total"].to_i
   end
 
+  def decrement_iteration_count!
+    update_attributes(iteration_count: iteration_count - 1)
+  end
+
   private
 
   def comment_count_sql

--- a/test/app/submissions_test.rb
+++ b/test/app/submissions_test.rb
@@ -181,6 +181,13 @@ class SubmissionsTest < Minitest::Test
     assert_equal 2, Submission.find_by_key(sub3.key).version
   end
 
+  def test_delete_submission_decrements_user_exercise_iterations
+    exercise = UserExercise.create(user: bob, iteration_count: 1)
+    sub = Submission.create(user: bob, user_exercise: exercise)
+    delete "/submissions/#{sub.key}", {}, login(bob)
+    assert_equal 0, exercise.reload.iteration_count
+  end
+
   def test_redirects_to_dashboard_after_deleting
     data = {
       user: bob,

--- a/test/exercism/user_exercise_test.rb
+++ b/test/exercism/user_exercise_test.rb
@@ -41,5 +41,12 @@ class UserExerciseTest < Minitest::Test
     archived_ruby = UserExercise.create(user: alice, archived: true, language: 'ruby', iteration_count: 1)
     assert_equal UserExercise.current, [closure_1, closure_2, ruby_1, ruby_2]
   end
+
+  def test_decrement_iteration_count
+    alex = User.create(username: 'alex')
+    exercise = UserExercise.create(iteration_count: 2, user: alex)
+    exercise.decrement_iteration_count!
+    assert_equal exercise.iteration_count, 1
+  end
 end
 


### PR DESCRIPTION
fixes issue #2716
The issue is that the dashboard queries user_exercises using the 'current' scope.  This scope looks for user_exercises where iteration_count > 0.  However the submissions delete route wasn't decrementing the submission.user_exercise iteration_count so although the submission was deleted the user_exercise would still be returned in the query.

Only spec I'm having trouble with is the request spec, have it working in browser but can't seem to get submission.user_exercise to update in the spec.  Am I supposed to be using the Hack::UpdatesUserExercise as in the other tests in test/submission_test.rb