### PR TITLE
Add syntax highlight for exercism fetch command in language tracks

### DIFF
--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -115,7 +115,7 @@
             </p>
 
             <h6>Fetch it!</h6>
-            <%= md track.fetch_cmd(problem) %>
+            <%= syntax track.fetch_cmd(problem), 'shell' %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
Will look like this:

![exercism](https://cloud.githubusercontent.com/assets/980783/12275821/3a46321e-b998-11e5-9ece-4f37bbcb0670.jpg)
