### PR TITLE
Fix delete_mastery_on_user migration

### DIFF
--- a/db/migrate/201512311928_delete_mastery_on_user.rb
+++ b/db/migrate/201512311928_delete_mastery_on_user.rb
@@ -1,11 +1,9 @@
 class DeleteMasteryOnUser < ActiveRecord::Migration
-  def change
-    def up
-      remove_column :users, :mastery
-    end
+  def up
+    remove_column :users, :mastery
+  end
 
-    def down
-      add_column :users, :mastery, :text
-    end
+  def down
+    add_column :users, :mastery, :text
   end
 end


### PR DESCRIPTION
Related to #2501 

@kytrinyx , I messed up and nested the up down inside of a change so when the migration occurs... it gets immediately reverted. I introduced this bug in pull #2695 

My bad... :disappointed: 

With this change `mastery` will deleted from user.

All tests pass locally but right now there's a bug in the seed data (https://github.com/exercism/seeds/issues/8) that probably should be fixed first. I'd like to see if fixing the seed data silences the pg error that I'm getting when running this migration.