### PR TITLE
Tidy up the accounts page and add an API key header

### DIFF
--- a/app/views/account/show.erb
+++ b/app/views/account/show.erb
@@ -3,17 +3,16 @@
     <h1>Account Settings</h1>
   </section>
   <article>
-    <p>View or reset your Exercism API key <a href="/account/key">here<a>.</p>
-
+    <h3>API Key</h3>
+    <p>View or reset your Exercism API key <a href="/account/key">here</a>.</p>
     <hr>
 
-    <h2>Avatar</h2>
-      <p>You can update your <%= gravatar_tag current_user.avatar_url %> avatar on
+    <h3>Avatar</h3>
+    <p>You can update your <%= gravatar_tag current_user.avatar_url %> avatar on
       <a href="https://github.com/settings/profile">GitHub</a>.</p>
-
     <hr>
 
-    <h2>Teams</h2>
+    <h3>Teams</h3>
     <% if profile.has_teams? %>
       <ul class="nav nav-stacked nav-bordered" style="max-width: 400px">
         <% profile.teams.each do |team| %>


### PR DESCRIPTION
The [accounts page](http://exercism.io/account) has an extra `<a>` tag [here](https://github.com/exercism/exercism.io/blob/master/app/views/account/show.erb#L6) which messes up the next Avatar section. This PR fixes it, adds an API Key header and makes the page look like this:

![exercism](https://cloud.githubusercontent.com/assets/980783/12372844/e99d237c-bc8a-11e5-896c-159afc721323.jpg)
