### PR TITLE
Changes user progress to only show tracks submitted to

### DIFF
--- a/lib/exercism/user_progression.rb
+++ b/lib/exercism/user_progression.rb
@@ -3,7 +3,7 @@ class UserProgression
 
   def self.user_progress(user)
     track_complete_exercises = Hash.new 0
-    user.exercises.each{|exe| track_complete_exercises[exe.problem.language] += 1}
+    user.exercises.where('iteration_count > 0').each{|exe| track_complete_exercises[exe.problem.language] += 1}
     tracks = track_count
     track_complete_exercises.each{|k, v| track_complete_exercises[k] = [v, tracks[k]]}
     track_complete_exercises

--- a/test/acceptance/profile_test.rb
+++ b/test/acceptance/profile_test.rb
@@ -20,8 +20,9 @@ class ProfileTest < AcceptanceTestCase
   def test_profile_shows_progress
     @f= './test/fixtures/xapi_v3_tracks.json'
     X::Xapi.stub(:get, [200, File.read(@f)]) do
-      UserExercise.create(user: @user, language: 'Fake')
+      UserExercise.create(user: @user, language: 'Fake', iteration_count: 1)
       with_login(@user) do
+        visit '/'
         click_on 'Profile'
 
         assert_content "Progress:"

--- a/test/exercism/user_progression_test.rb
+++ b/test/exercism/user_progression_test.rb
@@ -14,7 +14,7 @@ class UserProgressionTest < Minitest::Test
   def test_user_progress_for_100_percent
     X::Xapi.stub(:get, [200, File.read(@f)]) do
       expected = {'Animal'=>[1, 1]}
-      UserExercise.create(user: @user, language: 'Animal')
+      UserExercise.create(user: @user, language: 'Animal', iteration_count: 1)
       actual = UserProgression.user_progress(@user)
       assert_equal actual, expected
     end
@@ -23,11 +23,21 @@ class UserProgressionTest < Minitest::Test
   def test_user_progress_for_1_out_of_4
     X::Xapi.stub(:get, [200, File.read(@f)]) do
       expected = {'Fake'=>[1, 4]}
+      UserExercise.create(user: @user, language: 'Fake', iteration_count: 1)
+      actual = UserProgression.user_progress(@user)
+      assert_equal actual, expected
+    end
+  end
+
+  def test_user_progress_ignores_exercises_without_iterations
+    X::Xapi.stub(:get, [200, File.read(@f)]) do
+      expected = {}
       UserExercise.create(user: @user, language: 'Fake')
       actual = UserProgression.user_progress(@user)
       assert_equal actual, expected
     end
   end
+
 
   def test_user_progress_for_0_percent
     X::Xapi.stub(:get, [200, File.read(@f)]) do


### PR DESCRIPTION
I was confused by the data model in my previous pr. I didn't realize that there could be exercises without iterations. 