### PR TITLE
Rough draft - UI for track mentor

### DIFF
--- a/app/presenters/profile.rb
+++ b/app/presenters/profile.rb
@@ -51,6 +51,14 @@ module ExercismWeb
         @track_ids ||= archived_exercises.pluck('language').uniq
       end
 
+      def is_track_mentor?
+        user.track_mentor.any?
+      end
+
+      def mentored_tracks
+        user.track_mentor
+      end
+
       attr_reader :user, :current_user
     end
   end

--- a/app/routes/account.rb
+++ b/app/routes/account.rb
@@ -34,6 +34,30 @@ module ExercismWeb
         current_user.reset_key
         redirect "/account"
       end
+
+      post '/account/track-mentor/invite' do
+        please_login
+
+        begin
+          user_to_invite = ::User.find_by_username(params[:user_to_invite])
+          track = params[:track]
+
+          user_to_invite.present? or raise "couldn't find user for #{user_to_invite.username}"
+          track.present? or raise "track cannot be blank"
+          !(user_to_invite == current_user) or raise "you cannot invite yourself"
+          current_user.track_mentor.include?(track) or raise "you must be mentor for #{track} first"
+          !user_to_invite.track_mentor.include?(track) or raise "#{user_to_invite.username} is already a mentor for #{track}"
+
+          user_to_invite.track_mentor << track
+          user_to_invite.save!
+
+          flash[:notice] = "Successfully invited #{user_to_invite.username} to mentor #{track.capitalize}"
+          redirect "/account"
+        rescue StandardError => se
+          flash[:notice] = "Error while inviting: #{se}"
+          redirect "/account"
+        end
+      end
     end
   end
 end

--- a/app/views/account/_track_mentor_invite.erb
+++ b/app/views/account/_track_mentor_invite.erb
@@ -1,0 +1,17 @@
+<div>
+  <form class="form-inline" action="/account/track-mentor/invite" method="POST">
+    <div class="form-group">
+      Username:
+      <input type="text" name="user_to_invite" required>
+    </div>
+    <div class="form-group">
+      Track:
+      <select class="form-control" name="track" required>
+        <% profile.mentored_tracks.each do |track| %>
+          <option value="<%= track %>"><%= track.capitalize %></option>
+        <% end %>
+      </select>
+    </div>
+    <button type="submit" name="invite" class="btn btn-default">Send Invite</button>
+  </form>
+</div>

--- a/app/views/account/show.erb
+++ b/app/views/account/show.erb
@@ -5,11 +5,13 @@
   <article>
     <h3>API Key</h3>
     <p>View or reset your Exercism API key <a href="/account/key">here</a>.</p>
+
     <hr>
 
     <h3>Avatar</h3>
     <p>You can update your <%= gravatar_tag current_user.avatar_url %> avatar on
-      <a href="https://github.com/settings/profile">GitHub</a>.</p>
+    <a href="https://github.com/settings/profile">GitHub</a>.</p>
+
     <hr>
 
     <h3>Teams</h3>
@@ -42,7 +44,26 @@
     <% end %>
     <p/><br/>
     <a href="/teams" class="btn btn-primary">Create a new team</a>
-  </div>
+
+    <hr>
+
+    <h3>Track Mentor</h3>
+    <% if profile.is_track_mentor? %>
+    <div>
+      <h4>Mentored Tracks</h4>
+      <% profile.mentored_tracks.each do |track| %>
+        <span class="label label-default"><%= track %></span>
+      <% end %>
+    </div>
+
+    <br/>
+
+    <div>
+      <h4>Track Mentor Invitation</h4>
+      <%= erb :'account/_track_mentor_invite', locals: { profile: profile } %>
+    <% else %>
+      <p>Want to be a Track Mentor? Working on exercises and giving great feedback is the best way to get noticed!</p>
+    <% end %>
     </div>
   </article>
 </div>

--- a/app/views/user/show.erb
+++ b/app/views/user/show.erb
@@ -17,11 +17,14 @@
         <%= erb :"user/_exercise_progress", locals: { progress: profile.progress_hash } %>
       <% end %>
       <h3>Exercises</h3>
+      <h4>Current</h4>
       <% if profile.has_current_exercises? %>
         <%= erb :"user/_exercises_table", locals: { profile: profile, exercises: profile.exercises.current } %>
       <% else %>
         <p>No current exercises.</p>
       <% end %>
+
+      <br>
 
       <h4>Archived</h4>
       <% if profile.has_archived_exercises? %>

--- a/test/app/account_test.rb
+++ b/test/app/account_test.rb
@@ -1,0 +1,26 @@
+require_relative '../app_helper'
+
+class AppExercisesTest < Minitest::Test
+  include Rack::Test::Methods
+  include AppTestHelper
+  include DBCleaner
+
+  def app
+    ExercismWeb::App
+  end
+
+  attr_reader :bob, :alice
+
+  def setup
+    super
+  end
+
+  def test_track_mentor_invite
+    @bob = User.create(username: 'bob', github_id: 2, track_mentor: ['ruby'], email: "bob@example.com")
+    @alice = User.create(username: 'alice', github_id: 1, email: "alice@example.com")
+
+    post "/account/track-mentor/invite", {user_to_invite: "alice", track: "ruby"}, login(bob)
+    assert_equal 302, last_response.status
+    assert true, alice.track_mentor.include?("ruby")
+  end
+end


### PR DESCRIPTION
Related to larger story/issue #2501 

@kytrinyx 

I don't really expect a merge here. Just looking for some feedback and to see if I'm on the right track. And I'd love to write some unit and capybara tests (for good measure and just for practice).

Also, I know we talked about tying into notifications/inbox to alert the user of track mentor invitations and I also was thinking about that rake task that you had to unlock all exercises in the newly mentored track. Also maybe another endpoint for removing a users track mentor status (although I doubt that would happen).

Here are some examples:
**Before:**
<img width="626" alt="screen shot 2016-01-18 at 11 13 03 pm" src="https://cloud.githubusercontent.com/assets/8609429/12412536/342f06d2-be3c-11e5-8f6a-70bc7f993b6c.png">

<img width="841" alt="screen shot 2016-01-18 at 11 13 25 pm" src="https://cloud.githubusercontent.com/assets/8609429/12412541/3c5bc7fa-be3c-11e5-8f27-abe73cb72d99.png">

**After:**
<img width="951" alt="screen shot 2016-01-18 at 11 13 41 pm" src="https://cloud.githubusercontent.com/assets/8609429/12412562/709ff072-be3c-11e5-8346-5386a681b20a.png">

<img width="663" alt="screen shot 2016-01-18 at 11 13 58 pm" src="https://cloud.githubusercontent.com/assets/8609429/12412564/74dff8b2-be3c-11e5-8295-8ca525f16c6d.png">