### PR TITLE
Add a profile share link

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -25,6 +25,7 @@ module ExercismWeb
       register Sinatra::Reloader
     end
 
+    use Routes::Profile
     use Routes::Inbox
     use Routes::Languages
     use Routes::Static

--- a/app/presenters/profile.rb
+++ b/app/presenters/profile.rb
@@ -2,13 +2,20 @@ module ExercismWeb
   module Presenters
     class Profile
 
-      def initialize(user, current_user=user)
+      DEFAULTS = { shared: false }
+
+      def initialize(user, current_user=user, options={})
         @user = user
         @current_user = current_user
+        @options = DEFAULTS.merge(options)
       end
 
       def username
         user.username
+      end
+
+      def shared?
+        @options[:shared]
       end
 
       def exercises
@@ -24,7 +31,7 @@ module ExercismWeb
       end
 
       def can_access?(exercise)
-        current_user.can_access?(exercise)
+        shared? || current_user.can_access?(exercise)
       end
 
       def has_current_exercises?
@@ -41,6 +48,10 @@ module ExercismWeb
 
       def has_teams?
         teams.any?
+      end
+
+      def has_share_key?
+        user.share_key
       end
 
       def archived_in(track_id)

--- a/app/routes.rb
+++ b/app/routes.rb
@@ -24,7 +24,8 @@ module ExercismWeb
       CommentThreads: 'comment_threads',
       Errors: 'errors',
       User: 'user',
-      GithubCallback: 'github_callback'
+      GithubCallback: 'github_callback',
+      Profile: 'profile'
     }.each do |name, file|
       autoload name, Exercism.relative_to_root('app', 'routes', file)
     end

--- a/app/routes/account.rb
+++ b/app/routes/account.rb
@@ -35,6 +35,18 @@ module ExercismWeb
         redirect "/account"
       end
 
+      put '/account/share-key/set' do
+        please_login
+        current_user.set_share_key
+        redirect "/account"
+      end
+
+      put '/account/share-key/unset' do
+        please_login
+        current_user.unset_share_key
+        redirect "/account"
+      end
+
       post '/account/track-mentor/invite' do
         please_login
 

--- a/app/routes/profile.rb
+++ b/app/routes/profile.rb
@@ -1,0 +1,16 @@
+module ExercismWeb
+  module Routes
+    class Profile < Core
+      get '/profiles/:username/:share_key' do |username, key|
+        user = ::User.find_by(username: username, share_key: key)
+        if user
+          title(user.username)
+          erb :"user/show", locals: { profile: Presenters::Profile.new(user, current_user, shared: true) }
+        else
+          status 404
+          erb :"errors/not_found"
+        end
+      end
+    end
+  end
+end

--- a/app/views/account/show.erb
+++ b/app/views/account/show.erb
@@ -8,6 +8,24 @@
 
     <hr>
 
+    <h3> Private share url </h3>
+    <p>Your profile page on Exercism is only visible to other Exercism users by default, who can only see your solutions if they've done the exercises themselves.</p>
+    <p> By creating a "private share" url, you can share your complete profile with specific people, and they will be able to see all of your solutions, provided you share the link with them. And the good thing is that they don't need to be an Exercism user themselves.</p>
+    <% if profile.has_share_key? %>
+      <p> Currently you have shared your profile. Here's the <a href="<%= "/profiles/#{profile.username}/#{profile.user.share_key}" %>"> url</a>.</p>
+      <% action = "/account/share-key/unset" %>
+      <% value = "Disable private share" %>
+    <% else %>
+      <% action = "/account/share-key/set" %>
+      <% value = "Enable private share" %>
+    <% end %>
+    <form action="<%= action %>" method="post">
+      <input type="hidden" name="_method" value="put">
+      <input type="submit" value="<%= value %>" class="btn btn-danger">
+    </form>
+
+    <hr>
+
     <h3>Avatar</h3>
     <p>You can update your <%= gravatar_tag current_user.avatar_url %> avatar on
     <a href="https://github.com/settings/profile">GitHub</a>.</p>

--- a/db/migrate/201601271354_add_share_key_to_users.rb
+++ b/db/migrate/201601271354_add_share_key_to_users.rb
@@ -1,0 +1,9 @@
+class AddShareKeyToUsers < ActiveRecord::Migration
+  def up
+    add_column :users, :share_key, :string
+  end
+
+  def down
+    remove_column :users, :share_key
+  end
+end

--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -29,6 +29,16 @@ class User < ActiveRecord::Base
     save
   end
 
+  def set_share_key
+    self.share_key = Exercism.uuid
+    save
+  end
+
+  def unset_share_key
+    self.share_key = nil
+    save
+  end
+
   def can_access?(problem)
     ACL.where(user_id: id, language: problem.track_id, slug: problem.slug).count > 0
   end

--- a/test/app/presenters/profile_test.rb
+++ b/test/app/presenters/profile_test.rb
@@ -1,0 +1,39 @@
+require_relative '../../test_helper'
+require_relative '../../../app/presenters/profile'
+require_relative '../../api_helper'
+require 'mocha/setup'
+
+class PresentersProfileTest < Minitest::Test
+  def setup
+    @user = User.new(username: "fred")
+  end
+
+  def test_shared_profile_with_guest
+    guest = Guest.new
+    assert ExercismWeb::Presenters::Profile.new(@user, guest, shared: true).can_access?(:exercise)
+  end
+
+  def test_shared_profile_with_another_user_having_no_exercise_access
+    current_user = User.new(username: "rudy")
+    current_user.stubs(:can_access?).with(:exercise).returns(false)
+    assert ExercismWeb::Presenters::Profile.new(@user, current_user, shared: true).can_access?(:exercise)
+  end
+
+  def test_shared_profile_with_another_user_having_exercise_access
+    current_user = User.new(username: "rudy")
+    current_user.stubs(:can_access?).with(:exercise).returns(true)
+    assert ExercismWeb::Presenters::Profile.new(@user, current_user, shared: true).can_access?(:exercise)
+  end
+
+  def test_private_profile_with_another_user_having_no_exercise_access
+    current_user = User.new(username: "rudy")
+    current_user.expects(:can_access?).with(:exercise).returns(false)
+    refute ExercismWeb::Presenters::Profile.new(@user, current_user).can_access?(:exercise)
+  end
+
+  def test_private_profile_with_another_user_having_exercise_access
+    current_user = User.new(username: "rudy")
+    current_user.expects(:can_access?).with(:exercise).returns(true)
+    assert ExercismWeb::Presenters::Profile.new(@user, current_user).can_access?(:exercise)
+  end
+end

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -147,6 +147,22 @@ class UserTest < Minitest::Test
     assert_equal 0, fred.daily_count
   end
 
+  def test_user_share_key
+    fred = User.create(username: 'fred')
+    assert_equal nil, fred.share_key
+    fred.set_share_key
+    refute_equal nil, fred.share_key
+    fred.unset_share_key
+    assert_equal nil, fred.share_key
+  end
+
+  def test_user_find_by_username_and_share_key
+    fred = User.create(username: 'fred')
+    assert_equal nil, User.find_by(username: 'fred', share_key: Exercism.uuid)
+    fred.set_share_key
+    assert_equal 'fred', User.find_by(username: 'fred', share_key: fred.share_key).username
+  end
+
   private
 
   def create_exercise_with_submission(user, language, slug)


### PR DESCRIPTION
Fixes #2731 

- Registered a new route class `Profile`
- Added an option to `profile` presenter in order to detect whether `guest/current_user` should be given access to `user's exercise`