### PR TITLE
Group unsubmitted exercises by language and in a collapsible

### DIFF
--- a/app/presenters/dashboard.rb
+++ b/app/presenters/dashboard.rb
@@ -7,11 +7,15 @@ module ExercismWeb
       end
 
       def current_exercises
-        user.exercises.current
+        @current_exercises ||= user.exercises.current
       end
 
       def unsubmitted_exercises
-        user.exercises.unsubmitted
+        @unsubmitted_exercises ||= user.exercises.unsubmitted
+      end
+
+      def unsubmitted_grouped_exercises
+        @unsubmitted_grouped_exercises ||= user.exercises.unsubmitted.group_by { |ex| ex.language }
       end
 
       def has_activity?

--- a/app/views/dashboard.erb
+++ b/app/views/dashboard.erb
@@ -33,27 +33,30 @@
             <p>You are not currently working on any exercises.</p>
           <% end %>
           <% if dashboard.unsubmitted_exercises.present? %>
-            <p>You've fetched these problems. Now solve them!</p>
-            <ul class="nav nav-stacked" id="menu-current" role="menu">
-              <% dashboard.unsubmitted_exercises.limit(5).each do |exercise| %>
-                <li class="looks-list-item">
-                  <a role="menuitem"
-                     tabindex="-1"
-                     href=<%= "/exercises/#{exercise.language}/#{exercise.slug}/readme" %>>
-                    <table width="100%">
-                      <tr>
-                        <td width="60%">
-                          <%= "#{exercise.problem.name} (#{exercise.problem.language})" %>
-                        </td>
-                      </tr>
-                    </table>
-                  </a>
-                </li>
-              <% end %>
-              <% if dashboard.unsubmitted_exercises.size > 5 %>
-                <p>You have <%= dashboard.unsubmitted_exercises.size %> unsubmitted problems.</p>
-              <% end %>
-            </ul>
+            <p>You've fetched <%= dashboard.unsubmitted_exercises.count.to_s %> problems. Now solve them!</p>
+            <% dashboard.unsubmitted_grouped_exercises.keys.each_with_index do |language, index| %>
+              <div class="panel-group" id="accordion">
+                <div class="panel panel-default">
+                  <div class="panel-heading">
+                    <h4 class="panel-title">
+                      <a data-toggle="collapse" data-parent="#accordion" href='<%= "#collapse#{index}" %>'>
+                        <%= language.capitalize %>
+                        <b class="caret fuchsia"></b>
+                      </a>
+                    </h4>
+                  </div>
+                  <div id='<%= "collapse#{index}" %>' class="panel-collapse <%= 'collapse' if index > 4 %>">
+                    <div class="panel-body">
+                      <% dashboard.unsubmitted_grouped_exercises[language].each do |exercise| %>
+                        <a href='<%= "/exercises/#{exercise.language}/#{exercise.slug}/readme" %>'>
+                          <%= exercise.slug.capitalize %>
+                        </a><%= "&middot;" unless exercise == dashboard.unsubmitted_grouped_exercises[language].last %>
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            <% end %>
           <% else %>
             <p>You do not have any unsubmitted problems.</p>
           <% end %>
@@ -99,7 +102,7 @@
           <ul class="nav nav-stacked">
             <% (current_user.teams | current_user.managed_teams).each do |team| %>
               <li>
-                <a role="menuiytem" tabindex="-1" href="/teams/<%= team.slug %>">
+                <a role="menuitem" tabindex="-1" href="/teams/<%= team.slug %>">
                   <table width="100%">
                     <tr>
                       <td width="60%">


### PR DESCRIPTION
One idea to fix #2737

@kytrinyx, thoughts?

Less:
<img width="742" alt="screen shot 2016-02-12 at 12 44 12 am" src="https://cloud.githubusercontent.com/assets/8609429/13002314/5cc52a56-d122-11e5-9e5f-d4e81dce2945.png">


More:
<img width="720" alt="screen shot 2016-02-12 at 12 44 04 am" src="https://cloud.githubusercontent.com/assets/8609429/13002312/58f0fd1a-d122-11e5-80c5-57339b1ac633.png">
