### PR TITLE
Have user_progress return a more descriptive hash

### DIFF
--- a/app/helpers/user_progress_bar.rb
+++ b/app/helpers/user_progress_bar.rb
@@ -1,13 +1,17 @@
 module ExercismWeb
   module Helpers
     module UserProgressBar
-      def percent progress_values
-        return "0" if (progress_values[1] || 0).zero?
-        (progress_values[0]/progress_values[1].to_f * 100).to_i.to_s
+
+      def percent language_progress
+        exercise_count = language_progress.user_exercises.count
+        exercise_count ||= 0 if exercise_count.nil?
+        track_count = language_progress.language_track.count.to_f
+        return '0' if track_count.nil? || track_count == 0
+        (exercise_count/track_count * 100).to_i.to_s
       end
 
-      def progress_ratio track, progress_values
-        "#{track}: #{progress_values[0]}/#{progress_values[1]} (#{percent progress_values}%)"
+      def progress_ratio language_progress
+        "#{language_progress.language}: #{language_progress.user_exercises.count}/#{language_progress.language_track.count} (#{percent language_progress}%)"
       end
     end
   end

--- a/app/presenters/profile.rb
+++ b/app/presenters/profile.rb
@@ -23,7 +23,7 @@ module ExercismWeb
       end
 
       def progress_hash
-        UserProgression.user_progress(user)
+        UserProgression.user_progress(user).sort_by(&:last_updated)
       end
 
       def archived_exercises

--- a/app/views/user/_exercise_progress.erb
+++ b/app/views/user/_exercise_progress.erb
@@ -1,8 +1,9 @@
-<% progress.each do |track, progress_values| %>
+<% progress.each do |language_progress| %>
   <div>
-    <span style='z-index:2; position: absolute; text-align: center; width: 100%;color: black;'> <%= progress_ratio track, progress_values %></span>
+    <span style='z-index:2; position: absolute; text-align: center; width: 100%;color: black;'> <%= progress_ratio language_progress %>
+      <%= language_progress.last_updated %></span>
     <div class='progress' style='position: relative;'>
-      <div class="progress-bar progress-bar-success progress-bar-striped" role="progressbar" style="position: absolute;width: <%= percent progress_values %>%;">
+      <div class="progress-bar progress-bar-success progress-bar-striped" role="progressbar" style="position: absolute;width: <%= percent language_progress %>%;">
       </div>
     </div>
   </div>

--- a/app/views/user/show.erb
+++ b/app/views/user/show.erb
@@ -1,20 +1,28 @@
 <div class="container">
   <section class="page-header">
-    <h1><%= profile.username %></h1>
+  <h1><%= profile.username %></h1>
   </section>
 
   <div class="row">
     <div class="col-md-12">
       <p>
-        GitHub Profile:
-        <a target="_blank" href="https://github.com/<%= profile.username %>">
-          <%= profile.username %>
-        </a>
+      GitHub Profile:
+      <a target="_blank" href="https://github.com/<%= profile.username %>">
+        <%= profile.username %>
+      </a>
       </p>
 
       <% if !profile.progress_hash.empty? %>
         <h3>Progress:</h3>
-        <%= erb :"user/_exercise_progress", locals: { progress: profile.progress_hash } %>
+        <% if params[:all] == 'true' %>
+          <%= erb :"user/_exercise_progress", locals: { progress: profile.progress_hash } %>
+          <a class="btn btn-success" href="/<%= profile.username %>?all=false"> Less Languages </a>
+        <% else %>
+          <%= erb :"user/_exercise_progress", locals: { progress: [profile.progress_hash.first] } %>
+          <% if profile.progress_hash.count > 1 %>
+            <a class="btn btn-success" href="/<%= profile.username %>?all=true"> More Languages </a> 
+          <% end %>
+        <% end %>
       <% end %>
       <h3>Exercises</h3>
       <h4>Current</h4>

--- a/lib/exercism/user_progression.rb
+++ b/lib/exercism/user_progression.rb
@@ -2,14 +2,38 @@ require_relative '../../x'
 class UserProgression
 
   def self.user_progress(user)
-    track_complete_exercises = Hash.new 0
-    user.exercises.where("language<>''").where('iteration_count > 0').each{|exe| track_complete_exercises[exe.problem.language] += 1}
-    tracks = track_counts
-    track_complete_exercises.each{|k, v| track_complete_exercises[k] = [v, tracks[k]]}
-    track_complete_exercises
+    track_complete_exercises = user.exercises.where("language<>''").where('iteration_count > 0').each_with_object({}) do |exe, bag|
+      bag[exe.problem.language] ||= LanguageProgress.new exe.problem.language
+      bag[exe.problem.language].add_user_exercise exe
+    end
+    tracks = track_count
+    track_complete_exercises.collect do |lang, language_progress|
+      language_progress.tap{ |lang_prog| lang_prog.language_track = tracks[lang] }
+    end
   end
 
-  def self.track_counts
-    Hash[X::Track.all.collect{|t| [t.language, t.problems.count]}]
+  class LanguageProgress
+    attr_reader :language, :user_exercises, :last_updated
+    attr_accessor :language_track
+
+    def initialize language
+      @language = language
+      @user_exercises = []
+      @language_track = []
+    end
+
+    def add_user_exercise exe
+      if @last_updated.present? && @last_updated > exe.updated_at
+        @last_updated = exe.updated_at
+      end
+      @user_exercises.push exe
+    end
+
   end
+
+  private
+  def self.track_count
+    Hash[X::Track.all.collect{|t| [t.language, t.problems]}]
+  end
+
 end

--- a/test/app/helpers/user_progress_bar_test.rb
+++ b/test/app/helpers/user_progress_bar_test.rb
@@ -7,31 +7,48 @@ class AppHelperUserProgressBarTest < Minitest::Test
     @helper.extend ExercismWeb::Helpers::UserProgressBar
   end
 
+  def create_progress_mock(user_exe, lang_tracks, calls: 1)
+    language_progress = Minitest::Mock.new
+    calls.times do
+      language_progress.expect(:user_exercises, Array.new(user_exe || 0, true))
+      language_progress.expect(:language_track, Array.new(lang_tracks || 0, true))
+    end
+    language_progress
+  end
+
   def test_percent_100
-    assert_equal '100', @helper.percent([1, 1])
+    progress_mock = create_progress_mock 1, 1
+    assert_equal '100', @helper.percent(progress_mock)
   end
 
   def test_percent_decimal
-    assert_equal '33', @helper.percent([1, 3])
+    progress_mock = create_progress_mock 1, 3
+    assert_equal '33', @helper.percent(progress_mock)
   end
 
   def test_percent_0
-    assert_equal '0', @helper.percent([0, 1])
+    progress_mock = create_progress_mock 0, 1
+    assert_equal '0', @helper.percent(progress_mock)
   end
 
   def test_infinity
-    assert_equal '0', @helper.percent([0, 0])
+    progress_mock = create_progress_mock 0, 0
+    assert_equal '0', @helper.percent(progress_mock)
   end
 
   def test_nil
-    assert_equal '0', @helper.percent([0, nil])
+    progress_mock = create_progress_mock 0, nil
+    assert_equal '0', @helper.percent(progress_mock)
   end
 
   def test_missing
-    assert_equal '0', @helper.percent([0])
+    progress_mock = create_progress_mock nil, 0
+    assert_equal '0', @helper.percent(progress_mock)
   end
 
   def test_progress_ratio_javascript_50_percent
-    assert_equal 'Javascript: 25/50 (50%)', @helper.progress_ratio('Javascript', [25, 50])
+    progress_mock = create_progress_mock 25, 50, calls: 2
+    progress_mock.expect(:language, 'Javascript')
+    assert_equal 'Javascript: 25/50 (50%)', @helper.progress_ratio(progress_mock)
   end
 end

--- a/test/exercism/user_progression_test.rb
+++ b/test/exercism/user_progression_test.rb
@@ -13,38 +13,37 @@ class UserProgressionTest < Minitest::Test
 
   def test_user_progress_for_100_percent
     X::Xapi.stub(:get, [200, File.read(@f)]) do
-      expected = {'Animal'=>[1, 1]}
       UserExercise.create(user: @user, language: 'Animal', iteration_count: 1)
       actual = UserProgression.user_progress(@user)
-      assert_equal actual, expected
+      assert_equal 'Animal', actual.first.language
+      assert_equal 1, actual.first.user_exercises.count
+      assert_equal 1, actual.first.language_track.count
     end
   end
 
   def test_user_progress_for_1_out_of_4
     X::Xapi.stub(:get, [200, File.read(@f)]) do
-      expected = {'Fake'=>[1, 4]}
       UserExercise.create(user: @user, language: 'Fake', iteration_count: 1)
       actual = UserProgression.user_progress(@user)
-      assert_equal actual, expected
+      assert_equal 'Fake', actual.first.language
+      assert_equal 1, actual.first.user_exercises.count
+      assert_equal 4, actual.first.language_track.count
     end
   end
 
   def test_user_progress_ignores_exercises_without_iterations
     X::Xapi.stub(:get, [200, File.read(@f)]) do
-      expected = {}
       UserExercise.create(user: @user, language: 'Fake')
       actual = UserProgression.user_progress(@user)
-      assert_equal actual, expected
+      assert_equal [], actual
     end
   end
 
 
   def test_user_progress_for_0_percent
     X::Xapi.stub(:get, [200, File.read(@f)]) do
-      expected = {}
       actual = UserProgression.user_progress(@user)
-      assert_equal actual, expected
+      assert_equal actual, []
     end
   end
-
 end


### PR DESCRIPTION
- sorts languages by the last time they were updated
- adds a more/less option for the user_progress page
- cleaned up the test suite to match minitest standards