### PR TITLE
Archived exercises layout fix

### DIFF
--- a/app/presenters/profile.rb
+++ b/app/presenters/profile.rb
@@ -30,6 +30,10 @@ module ExercismWeb
         @archived_exercises ||= user.exercises.where(archived: true).where('iteration_count > 0')
       end
 
+      def archived_grouped_exercises
+        @archived_exercises.group_by {|ex| ex.language }
+      end
+
       def can_access?(exercise)
         shared? || current_user.can_access?(exercise)
       end

--- a/app/views/user/_archived_exercises_table.erb
+++ b/app/views/user/_archived_exercises_table.erb
@@ -8,23 +8,26 @@
     </tr>
   </thead>
   <tbody>
-    <% profile.track_ids.each do |track_id| %>
+    <% profile.archived_grouped_exercises.each do |language| %>
       <tr>
         <td>
-          <% profile.archived_in(track_id).each do |exercise| %>
-              <% if profile.can_access?(exercise) %>
-                <a href="/exercises/<%= exercise.key %>">
-                  <%= exercise.problem.name %>
-                </a>
-              <% else %>
-                <i class="fa fa-lock"></i>
-                &nbsp;
-                <a href="/exercises/<%= exercise.track_id %>/<%= exercise.slug %>"><%= exercise.problem.name %></a>
-              <% end %>
-              <br/>
+          <% exercises = profile.archived_grouped_exercises[language]%>
+          <% exercises.each do |exercise| %>
+            <% if profile.can_access?(exercise) %>
+              <a href="/exercises/<%= exercise.key %>">
+                <%= exercise.problem.name %>
+              </a>
+            <% else %>
+            <i class="fa fa-lock"></i>
+              &nbsp;
+              <a href="/exercises/<%= exercise.track_id %>/<%= exercise.slug %>">
+                <%= exercise.problem.name %>
+              </a>
+            <% end %>
+            <%= ", " unless exercise = exercise.last %>
           <% end %>
         </td>
-        <td><%= Language.of(track_id) %></td>
+        <td><%=  language.capitalize %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/user/_archived_exercises_table.erb
+++ b/app/views/user/_archived_exercises_table.erb
@@ -3,15 +3,16 @@
   <col width="75%" />
   <thead>
     <tr>
-      <th>Exercises</th>
       <th>Language</th>
+      <th>Exercises</th>
     </tr>
   </thead>
   <tbody>
-    <% profile.archived_grouped_exercises.each do |language| %>
+    <% profile.archived_grouped_exercises.keys.each do |language| %>
       <tr>
+        <td><%= language.capitalize %></td>
         <td>
-          <% exercises = profile.archived_grouped_exercises[language]%>
+          <% exercises = profile.archived_grouped_exercises[language] %>
           <% exercises.each do |exercise| %>
             <% if profile.can_access?(exercise) %>
               <a href="/exercises/<%= exercise.key %>">
@@ -24,10 +25,9 @@
                 <%= exercise.problem.name %>
               </a>
             <% end %>
-            <%= ", " unless exercise = exercise.last %>
+            <%= ", " unless exercise == exercises.last %>
           <% end %>
         </td>
-        <td><%=  language.capitalize %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/user/_exercises_table.erb
+++ b/app/views/user/_exercises_table.erb
@@ -2,8 +2,8 @@
   <col width="25%" />
   <thead>
     <tr>
-      <th>Exercise</th>
       <th>Language</th>
+      <th>Exercise</th>
       <th>Iterations</th>
       <th data-sorted="true" data-sorted-direction="descending">Latest Iteration</th>
     </tr>
@@ -11,6 +11,7 @@
   <tbody>
   <% exercises.order(updated_at: :desc).each do |exercise| %>
     <tr>
+      <td><%= exercise.problem.language %></td>
       <td>
         <% if profile.can_access?(exercise) %>
           <a href="/exercises/<%= exercise.key %>">
@@ -22,7 +23,6 @@
           <a href="/exercises/<%= exercise.track_id %>/<%= exercise.slug %>"><%= exercise.problem.name %></a>
         <% end %>
       </td>
-      <td><%= exercise.problem.language %></td>
       <td><%= exercise.iteration_count %></td>
       <td data-value="<%= exercise.updated_at.to_i %>"><%= exercise.updated_at.strftime("%Y-%m-%d") %></td>
     </tr>


### PR DESCRIPTION
Fix for #2748

One exercise:
<img width="1030" alt="screen shot 2016-03-05 at 12 33 14 am" src="https://cloud.githubusercontent.com/assets/8609429/13546751/1a5c4306-e26c-11e5-86b6-bc87599409bd.png">

Multiple exercises:
<img width="1006" alt="screen shot 2016-03-05 at 12 46 39 am" src="https://cloud.githubusercontent.com/assets/8609429/13546753/1ea74abe-e26c-11e5-826a-8fc95671cde7.png">

@kytrinyx , thoughts?