### PR TITLE
Join language docs and 'better' boilerplate with newline

### DIFF
--- a/x/docs/track.rb
+++ b/x/docs/track.rb
@@ -23,7 +23,7 @@ module X
         if data[topic].empty?
           read(topic).gsub('REPO', repository)
         else
-          data[topic].strip + better(topic)
+          [data[topic].strip, better(topic)].join("\n")
         end
       end
 


### PR DESCRIPTION
Fixes #2784 

@petertseng, how does this look?

No astericks:
<img width="816" alt="screen shot 2016-03-05 at 11 33 57 am" src="https://cloud.githubusercontent.com/assets/8609429/13549927/3e163888-e2c6-11e5-83f9-8c10a8092671.png">
