### PR TITLE
Add required rake version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'pg'
 gem 'pry', require: false
 gem 'puma', '~> 2.15.0'
 gem 'rack-flash3', require: 'rack-flash'
-gem 'rake'
+gem 'rake', '~> 10.5.0'
 gem 'redcarpet', '~> 3.1'
 gem 'rouge', '~> 1.3'
 gem 'sinatra', '~> 1.4.4', require: 'sinatra/base'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ DEPENDENCIES
   puma (~> 2.15.0)
   rack-flash3
   rack-test
-  rake
+  rake (~> 10.5.0)
   redcarpet (~> 3.1)
   rouge (~> 1.3)
   rubocop
@@ -224,6 +224,3 @@ DEPENDENCIES
   timecop
   will_paginate
   will_paginate-bootstrap
-
-BUNDLED WITH
-   1.11.2


### PR DESCRIPTION
New app installations require rake 10.5.0. However, that version was not
specified in the Gemfile. This throws an error during 'bin/setup'
installation and having to install it manually. I had version 10.4.0 and I kept getting the error trying to setup the app to run locally. After I got the error I had to use the 'Troubleshooting' part of the guide to finalize the setup manually. With this rake version request, the full setup should run automatically as explained in the guides.