### PR TITLE
displays user teams on profile page

### DIFF
--- a/app/views/user/show.erb
+++ b/app/views/user/show.erb
@@ -11,7 +11,15 @@
         <%= profile.username %>
       </a>
       </p>
-
+      Teams:
+      <% profile.teams.each do |team| %>
+        <% if team.includes?(profile.current_user) %>
+          <a href=<%= "teams/#{team.name}" %>><%= team.name %></a><%="," unless team == profile.teams.last %>
+        <% else %>
+          <%= team.name %><%="," unless team == profile.teams.last %>
+        <% end %>
+      <% end %>
+      
       <% if !profile.progress_hash.empty? %>
         <h3>Progress:</h3>
         <% if params[:all] == 'true' %>


### PR DESCRIPTION
This PR addresses first part of #2766, displaying user teams on profile page.  Team names will be displayed as links, which link to the team's page.  Not sure if want unconfirmed teams as well, but for now just using the existing teams method on profile presenter.  Let me know what you think, thanks

![screen shot 2016-03-19 at 11 05 08 am](https://cloud.githubusercontent.com/assets/3260042/13899358/972f8ada-edc2-11e5-8df0-3c9a18ffd941.png)
