### PR TITLE
orders assumable_users by username asc to make easier to find

### DIFF
--- a/lib/exercism/assumable_user.rb
+++ b/lib/exercism/assumable_user.rb
@@ -9,7 +9,7 @@ class AssumableUser
   end
 
   def self.all
-    ::User.order('created_at DESC').limit(100).map {|user|
+    ::User.order('username ASC').limit(100).map {|user|
       Identity.new(user.username, user.github_id)
     }
   end


### PR DESCRIPTION
I think it would be much more helpful to order assumable_users by username.  A lot of the time if I'm trying to find some users with data matching something I'm trying to test/look for I'll get a username and then assume the user that way.  Would be much easier to find the user by username rather than created at.

example.  I was working on fixing issue to list a user's team names on profile.  First I need to find a user with multiple teams.

User.joins(:teams)... find username.  Now assume that user's identity by username.