### PR TITLE
Api return error if track does not exist

### DIFF
--- a/api/v1/routes/tracks.rb
+++ b/api/v1/routes/tracks.rb
@@ -6,6 +6,11 @@ module ExercismAPI
       get '/tracks/:id/status' do |id|
         require_key
 
+        if !Xapi.exists?(id)
+          message = "Track #{id} not found."
+          halt 404, { error: message }.to_json
+        end
+
         begin
           Homework.new(User.find_by(key: params[:key])).status(id).to_json
         rescue Exception => e

--- a/lib/exercism/xapi.rb
+++ b/lib/exercism/xapi.rb
@@ -3,8 +3,8 @@ module Xapi
     ENV.fetch('EXERCISES_API_URL') { "http://x.exercism.io" }
   end
 
-  def self.exists?(language, slug)
-    request('tracks', language, slug).status != 404
+  def self.exists?(language, slug=nil)
+    request(*['tracks', language, slug].compact).status != 404
   end
 
   def self.conn


### PR DESCRIPTION
Return 404 along with "Track <id> not found." if status is requested for a language we don't support.

This change came about due to exercism/cli#298