### PR TITLE
User profile page: Fix broken team link

### DIFF
--- a/app/views/user/show.erb
+++ b/app/views/user/show.erb
@@ -14,7 +14,7 @@
       Teams:
       <% profile.teams.each do |team| %>
         <% if team.includes?(profile.current_user) %>
-          <a href=<%= "teams/#{team.name}" %>><%= team.name %></a><%="," unless team == profile.teams.last %>
+          <a href=<%= "teams/#{team.slug}" %>><%= team.name %></a><%="," unless team == profile.teams.last %>
         <% else %>
           <%= team.name %><%="," unless team == profile.teams.last %>
         <% end %>


### PR DESCRIPTION
This is a fix for the User's account profile page view: Use `team.slug` instead of `team.name` for team link on a user's profile page. 

The current `team.name` breaks for teams with multiple word names, like 'DTLA Pair Programming.' Instead of linking to http://exercism.io/teams/dtla-pair-programming/, it currently links to: http://exercism.io/teams/DTLA, which is a broken link. This commit will fix this bug.

What the bug looks like right now:

![screen shot 2016-03-23 at 12 44 58 pm](https://cloud.githubusercontent.com/assets/3673236/13998584/1ccf3a0c-f0f5-11e5-9259-fdf7b20109a2.png)
![screen shot 2016-03-23 at 12 45 04 pm](https://cloud.githubusercontent.com/assets/3673236/13998583/1cccded8-f0f5-11e5-98db-e239c6e6fea7.png)
