### PR TITLE
[WIP] Sort dates correctly

### DIFF
--- a/app/views/user/_exercises_table.erb
+++ b/app/views/user/_exercises_table.erb
@@ -17,14 +17,14 @@
           <th></th>
         <% end %>
 
-        <th>Language</th>
+        <th data-sorted="true"  data-sorted-direction="ascending">Language</th>
         <th>Exercise</th>
         <th>Iterations</th>
-        <th data-sorted="true" data-sorted-direction="descending">Latest Iteration</th>
+        <th>Latest Iteration</th>
       </tr>
     </thead>
     <tbody>
-    <% exercises.order(updated_at: :desc).each do |exercise| %>
+    <% exercises.each do |exercise| %>
       <tr>
 
         <% if profile.own? %>


### PR DESCRIPTION
Potential fix for the following date sorting issue:

Here are two screenshots of sorting of Latest Iteration column of Current Exercises table as it appears on a user's profile page:
![screen shot 2016-03-25 at 21 56 49](https://cloud.githubusercontent.com/assets/374340/14057408/ff1381f8-f2d4-11e5-9b5f-0c10ad32ad0c.png)
![screen shot 2016-03-25 at 21 59 23](https://cloud.githubusercontent.com/assets/374340/14057409/ff139724-f2d4-11e5-9344-d0a09de8237c.png)

It currently treats dates as text and 11 is not sorted correctly with 6 and 8. I do wonder if `Sortable` module doesn't consider '0' to come before '1' in text form.

**Warning**: I have not yet been able to verify that this works, not much experience with JS.
My `bin/setup` fails with `Gem::LoadError: You have already activated rake 10.4.2, but your Gemfile requires rake 10.5.0. Prepending `bundle exec` to your command may solve this.`
Then if I try `bundle exec rake db:setup`, I get the following:
```
PG::ConnectionBad: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
```

I also tried adding this attribute directly in HTML using Chrome Dev Tools, but apparently JS is not as dynamic enough as I would imagine. Any help or easier way to test the change is welcome and much appreciated.