### PR TITLE
explicitly require tilt/erb to suppress non thread safe warning

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,7 @@ require 'sinatra/reloader'
 require 'will_paginate'
 require 'will_paginate/active_record'
 require 'kss'
+require 'tilt/erb'
 
 require_relative './app/presenters'
 require_relative './lib/exercism/xapi'


### PR DESCRIPTION
Closes #2821 

Not sure if this is the best place to require this gem... Might be better to track down the place it gets autoloaded (maybe in `app/routes.rb` when one route calls `erb :some_view`)...