### PR TITLE
Set page titles using Javascript

### DIFF
--- a/frontend/app/js/app.coffee
+++ b/frontend/app/js/app.coffee
@@ -1,6 +1,9 @@
 angular.module('exercism', ['ui.bootstrap'])
 
 $ ->
+  if $('h1, h2, h3').length && document.title == 'exercism.io'
+    document.title = "#{$($('h1, h2, h3').get(0)).text()} - exercism.io"
+
   $("[data-toggle=tooltip]").tooltip();
 
   $("#current_submission").theiaStickySidebar(additionalMarginTop: 70)

--- a/frontend/app/js/app.coffee
+++ b/frontend/app/js/app.coffee
@@ -1,7 +1,7 @@
 angular.module('exercism', ['ui.bootstrap'])
 
 $ ->
-  if $('h1, h2, h3').length && document.title == 'exercism.io'
+  if location.pathname != '/' && $('h1, h2, h3').length && document.title == 'exercism.io'
     document.title = "#{$($('h1, h2, h3').get(0)).text()} - exercism.io"
 
   $("[data-toggle=tooltip]").tooltip();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30425,7 +30425,7 @@ $(".track-activity-chart").each(function(index, element) {
   angular.module('exercism', ['ui.bootstrap']);
 
   $(function() {
-    if ($('h1, h2, h3').length && document.title === 'exercism.io') {
+    if (location.pathname !== '/' && $('h1, h2, h3').length && document.title === 'exercism.io') {
       document.title = "" + ($($('h1, h2, h3').get(0)).text()) + " - exercism.io";
     }
     $("[data-toggle=tooltip]").tooltip();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30425,6 +30425,9 @@ $(".track-activity-chart").each(function(index, element) {
   angular.module('exercism', ['ui.bootstrap']);
 
   $(function() {
+    if ($('h1, h2, h3').length && document.title === 'exercism.io') {
+      document.title = "" + ($($('h1, h2, h3').get(0)).text()) + " - exercism.io";
+    }
     $("[data-toggle=tooltip]").tooltip();
     $("#current_submission").theiaStickySidebar({
       additionalMarginTop: 70


### PR DESCRIPTION
The website doesn't set page titles so using the browser history is impossible. They all say 'exercism.io'. This change adds some Javascript to grab the first H1, H2, or H3 and use that to build the page title
setting it to the text value of the header plus " - exercism.io" -- but only if the page title isn't already set to something special.

<img width="511" alt="screen shot 2016-04-11 at 9 43 52 pm" src="https://cloud.githubusercontent.com/assets/16705/14449985/813a7a68-002e-11e6-82dc-4a458323c616.png">