### PR TITLE
closes #2819. Add track icon to lang pages.

### DIFF
--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -3,7 +3,7 @@
   <div class="row" style="padding-top: 40px;">
     <div class="col-md-4"></div>
     <div class="col-md-8">
-      <h1><%= "#{track.language} #{track_icon(track.id, 30)}"  %></h1>
+      <h1><%= "#{track_icon(track.id, 30)} #{track.language}"%></h1>
     </div>
   </div>
 

--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -3,7 +3,7 @@
   <div class="row" style="padding-top: 40px;">
     <div class="col-md-4"></div>
     <div class="col-md-8">
-      <h1><%= track.language %></h1>
+      <h1><%= "#{track.language} #{track_icon(track.id, 30)}"  %></h1>
     </div>
   </div>
 


### PR DESCRIPTION
I think 30px suits better than the default 40px for the language page.
Do you guys think that `"#{track.language} #{track_icon(track.id, 30)}"` should be in a helper?
Please let me know what you think.