### PR TITLE
Update statistic endpoint to reflect accurate data

### DIFF
--- a/lib/exercism/user_exercise.rb
+++ b/lib/exercism/user_exercise.rb
@@ -12,6 +12,7 @@ class UserExercise < ActiveRecord::Base
       where('views.last_viewed_at > ?', 30.days.ago).order('views.last_viewed_at DESC')
   }
   scope :current, ->{ where(archived: false).where.not(iteration_count: 0).order('language, id ASC') }
+  scope :completed, ->{ where.not(iteration_count: 0).order('language, id ASC') }
   scope :archived, ->{ where(archived: true).where('iteration_count > 0') }
   scope :for, lambda { |problem| where(language: problem.track_id, slug: problem.slug) }
   scope :randomized, ->{ order('RANDOM()') }

--- a/lib/exercism/user_statistics.rb
+++ b/lib/exercism/user_statistics.rb
@@ -11,7 +11,7 @@ class UserStatistics
   end
 
   def self.problem_completion(user, track)
-    user.exercises.where(language: track.id).map do |exercise|
+    user.exercises.completed.where(language: track.id).map do |exercise|
       exercise.slug
     end
   end

--- a/test/api/users_test.rb
+++ b/test/api/users_test.rb
@@ -63,7 +63,7 @@ class UsersApiTest < Minitest::Test
     X::Xapi.stub(:get, [200, File.read(f)]) do
       user = User.create(username: 'alice')
       submission = Submission.create(user: user, language: 'Animal', slug: 'hello-world', solution: {'hello_world.rb' => 'CODE'})
-      UserExercise.create(user: user, submissions: [submission], language: 'animal', slug: 'hello-world', iteration_count: 1)
+      UserExercise.create(user: user, submissions: [submission], language: 'animal', slug: 'hello-world', iteration_count: 0)
       submission2 = Submission.create(user: user, language: 'Fake', slug: 'apple', solution: {'apple.js' => 'CODE'})
       UserExercise.create(user: user, submissions: [submission2], language: 'fake', slug: 'apple', iteration_count: 1)
       submission3 = Submission.create(user: user, language: 'Animal', slug: 'one', solution: {'one.rb' => 'CODE'})
@@ -74,7 +74,7 @@ class UsersApiTest < Minitest::Test
       response = JSON.parse(last_response.body)
       assert_equal 200, last_response.status
       assert_equal 4, response["statistics"].count
-      assert_equal 2, response["statistics"].first["completed"].count
+      assert_equal 1, response["statistics"].first["completed"].count
       assert_equal 1, response["statistics"][1]["completed"].count
       count = response["statistics"].select do |language|
         language["completed"].count == 0


### PR DESCRIPTION
The statistics endpoint currently returns user.exercises, which includes exercises with iteration counts of 0. Because of this, the returned data is incorrect as it lists all fetched exercises as completed.

By scoping into exercises.completed, a new scope added to user_exercises for this purpose, exercises with 0 iterations will be excluded and will show accurate completion data.