### PR TITLE
Let the reader read the counts naturally from left to right

### DIFF
--- a/app/views/dashboard.erb
+++ b/app/views/dashboard.erb
@@ -12,13 +12,13 @@
                     <table width="100%">
                       <tr>
                         <td width="60%">
-                        <%= exercise.problem.name %> (<%= exercise.problem.language %>)
+                          <%= exercise.problem.name %> (<%= exercise.problem.language %>)
                         </td>
                         <td width="25%">
                           <%= exercise.comment_count %> comments
                         </td>
                         <td width="15%">
-                          iterations <%= exercise.iteration_count %>
+                          <%= exercise.iteration_count %> iterations
                         </td>
                       </tr>
                     </table>


### PR DESCRIPTION
Reading "Exercise name — 7 comments, 3 iterations" is a bit easier and more natural (for a westerner) than reading "Exercise name — 7 comments, iterations 3" 🙃