### PR TITLE
Update team manage to handle sole manager scenario

### DIFF
--- a/app/views/teams/manage.erb
+++ b/app/views/teams/manage.erb
@@ -60,16 +60,19 @@
       <button type="submit" class="btn btn-primary">Add manager</button>
     </form>
 
-    <% if team.managers.count > 1 %>
-        <% (team.managers - [current_user]).each do |manager| %>
-          <form accept-charset="UTF-8" action="/teams/<%= team.slug %>/managers" method="post">
-            <input type="hidden" name="_method" value="delete" />
-            <input type="hidden" name="username" value="<%= manager.username %>" />
-            <button type="submit" class="btn btn-xs btn-danger manager_delete" data-username="<%= manager.username %>" style="margin: 10px 10px 10px 0">Remove</button>
-            <%= gravatar_tag manager.avatar_url, size: 20 %>
-            <a href="/<%= manager.username %>"><%= manager.username %></a>
-          </form>
-        <% end %>
+    <% team.managers.each do |manager| %>
+      <% if team.managers.count == 1 && team.managers.first == current_user %>
+        <button type="button" class="disabled btn btn-xs btn-danger manager_delete" data-toggle="tooltip" data-placement="bottom" title="You must add another manager before you can remove yourself as the last manager." style="margin: 10px 10px 10px 0">Remove</button>
+      <% else %>
+        <form accept-charset="UTF-8" action="/teams/<%= team.slug %>/managers" method="post">
+          <input type="hidden" name="_method" value="delete" />
+          <input type="hidden" name="username" value="<%= manager.username %>" />
+          <button type="submit" class="btn btn-xs btn-danger manager_delete" data-username="<%= manager.username %>" style="margin: 10px 10px 10px 0">Remove</button>
+        </form>
+      <% end %>
+
+      <%= gravatar_tag manager.avatar_url, size: 20 %>
+      <a href="/<%= manager.username %>"><%= manager.username %></a>
     <% end %>
   </div>
 

--- a/test/acceptance/team_test.rb
+++ b/test/acceptance/team_test.rb
@@ -20,5 +20,23 @@ class TeamAcceptanceTest < AcceptanceTestCase
       assert_content 'joining_user'
     end
   end
+
+  def test_managing_a_team_as_sole_manager
+    user = create_user(username: 'foobar', github_id: 123)
+
+    attributes = { slug: 'some-team', name: 'Some Team' }
+    Team.by(user).defined_with(attributes, user).save!
+
+    with_login(user) do
+      click_on 'Account'
+      click_on 'Some Team'
+      click_on 'Manage'
+
+      within('#managers') do
+        assert_content 'foobar'
+        assert_selector 'button.manager_delete.disabled'
+      end
+    end
+  end
   # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
This PR tweaks the Manage page of a team to do two things:

- Display the current user in the list of managers if they are one so
  that they can see they are a manager, as well as remove themself as a
  manager if there are other managers.
- If the current user is the only manager, a disabled removal button is
  shown with a tooltip explaining that the user must add another manager
  before they can remove themself as the last manager.

This change was made so that when a manager is trying to leave a team
they know they are a manager and that they must add a new manager before
removing themself as a manager.

This commit also adds an acceptance test for viewing the Manage page of
a team and asserting the current user is in the list, as well as that
there is a disabled remove button since that user is the sole manager.

Here is what the UI looks like:

<img width="503" alt="screen shot 2016-04-26 at 8 09 10 am" src="https://cloud.githubusercontent.com/assets/928367/14823107/30751616-0b86-11e6-82f3-e21816ce1614.png">

Fixes https://github.com/exercism/exercism.io/issues/2836