### PR TITLE
[#2780] Add completed exercises in languages page

### DIFF
--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -7,7 +7,9 @@ module ExercismWeb
         tracks = X::Track.all
         active, inactive = tracks.partition { |t| t.active? }
         inactive.sort! { |a, b| b.problems.count <=> a.problems.count }
-        erb :"languages/index", locals: { active: active, inactive: inactive }
+        submissions_count = current_user.submissions_per_language
+        erb :"languages/index", locals: { active: active, inactive: inactive,
+                                          submissions_count: submissions_count }
       end
 
       get '/languages/:track_id' do |track_id|

--- a/app/views/languages/_block.erb
+++ b/app/views/languages/_block.erb
@@ -2,6 +2,10 @@
   <div class="text-center">
     <%= track_icon(track.id) %>
     <p><%= track.language %></p>
-    <p><%= track.problems.count %> Problems</p>
+    <% if submissions %>
+      <p><%= submissions[track.language.downcase] %> / <%= track.problems.count %> Completed</p>
+    <% else %>
+      <p><%= track.problems.count %> Problems</p>
+    <% end %>
   </div>
 </a>

--- a/app/views/languages/index.erb
+++ b/app/views/languages/index.erb
@@ -6,7 +6,7 @@
     <% active.each_slice(6) do |tracks| %>
       <div class="row">
         <% tracks.each do |t| %>
-          <%= erb :'languages/_block', locals: { track: t } %>
+          <%= erb :'languages/_block', locals: { track: t, submissions: submissions_count } %>
         <% end %>
       </div>
     <% end %>
@@ -17,7 +17,7 @@
     <% inactive.each_slice(6) do |tracks| %>
       <div class="row">
         <% tracks.each do |t| %>
-          <%= erb :'languages/_block', locals: { track: t }  if t.problems.any? %>
+          <%= erb :'languages/_block', locals: { track: t, submissions: nil }  if t.problems.any? %>
         <% end %>
       </div>
     <% end %>

--- a/lib/exercism/guest.rb
+++ b/lib/exercism/guest.rb
@@ -29,4 +29,8 @@ class Guest
   def show_dailies?
     false
   end
+
+  def submissions_per_language
+    nil
+  end
 end

--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -95,6 +95,14 @@ class User < ActiveRecord::Base
     submissions.order('id DESC').where(language: problem.track_id, slug: problem.slug)
   end
 
+  def submissions_per_language
+    submissions_count = Hash.new(0)
+    submissions.pluck(:language).each do |name|
+      submissions_count[name.downcase] += 1
+    end
+    submissions_count
+  end
+
   def guest?
     false
   end

--- a/test/exercism/guest_test.rb
+++ b/test/exercism/guest_test.rb
@@ -2,9 +2,11 @@ require_relative '../test_helper'
 require 'exercism/guest'
 
 class GuestTest < Minitest::Test
-
   def test_guest_is_guest
     assert Guest.new.guest?
   end
 
+  def test_guest_submissions_per_language_is_nil
+    assert Guest.new.submissions_per_language == nil
+  end
 end

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -194,6 +194,17 @@ class UserTest < Minitest::Test
     assert_equal total_ruby_exercises_count, freds_ruby_acls_count
   end
 
+  def test_user_submissions_per_language
+    julia = User.create(username: 'julia')
+    create_exercise_with_submission(julia, 'ruby', 'hamming')
+    create_exercise_with_submission(julia, 'python', 'hamming')
+    Submission.create!(user: julia, language: 'python', slug: 'hamming')
+
+    assert_equal 1, julia.submissions_per_language['ruby']
+    assert_equal 2, julia.submissions_per_language['python']
+    assert_equal 0, julia.submissions_per_language['javascript']
+  end
+
   private
 
   def create_exercise_with_submission(user, language, slug)


### PR DESCRIPTION
This PR adds the feature requested in issue #2780. When a user is logged in the page shows the completed exercises out of the total for each language. This label appears only on active exercises, upcoming ones keep the "# problems" tag. If the user is not logged in all the languages in the page show the "# problems" tag. The picture shows how the new completed exercises are shown on the page. The idea was to keep the view as simple as possible while adding the completion tag.
I'm not sure if someone else was working on this so I hope this helps.

<img width="395" alt="screen shot 2016-04-26 at 7 05 24 pm" src="https://cloud.githubusercontent.com/assets/1483625/14837192/2e63b176-0be4-11e6-9c80-4cb11573b5a3.png">
