### PR TITLE
Add test:everything rake task

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -463,9 +463,3 @@ Style/UnneededPercentQ:
 # SupportedStyles: percent, brackets
 Style/WordArray:
   Enabled: false
-
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/ZeroLengthPredicate:
-  Exclude:
-    - 'lib/exercism/submission.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ rvm:
   - 2.2.2
 script:
   - 'createuser exercism --superuser && createdb -O exercism exercism_test'
-  - 'RACK_ENV=test CI=1 bundle exec rake db:migrate test_with_coverage'
-  - '( cd frontend && npm install && lineman spec-ci )'
+  - 'RACK_ENV=test CI=1 bundle exec rake db:migrate test:everything'
   - "! git grep ' $' -- \\*.rb"
 cache:
   - bundler

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,10 +201,19 @@ user.submissions
 
 ### Testing
 
-1. Create and migrate a test database: `RACK_ENV=test rake db:setup db:migrate`
-1. Run the test suite: `rake` or `rake test`
+The test suite is comprised of various checks to ensure everything is working and styled as expected.
 
-To run a single test suite, you can do so with:
+Before any tests can be run, create and migrate a test database: `RACK_ENV=test rake db:setup db:migrate`
+
+The entire test suite can then be run with `bundle exec rake test:everything` or just `bundle exec rake` since `test:everthing` is the default Rake task.
+
+The current checks include:
+
+- [MiniTest](https://github.com/seattlerb/minitest) `rake test` or `rake test:minitest` - Ruby unit and feature tests
+- [RuboCop](https://github.com/bbatsov/rubocop) - `rake rubocop` - Ruby style enforcement
+- [Lineman Spec](http://linemanjs.com/) - `rake test:lineman` - Front-end tests
+
+To run a single Ruby test, you can do so with:
 
 ```bash
 ruby path/to/the_test.rb

--- a/Rakefile
+++ b/Rakefile
@@ -1,31 +1,4 @@
 $:.unshift File.expand_path("./../lib", __FILE__)
 Dir.glob("lib/tasks/*.rake").each { |r| import r }
 
-require 'rake/testtask'
-
-Rake::TestTask.new do |t|
-  require 'bundler'
-  Bundler.require
-  t.test_files = FileList['test/**/*_test.rb'].exclude('test/fixtures/**/*')
-end
-
-desc "Run each test file independently"
-namespace :test do
-  task :each do
-    files = FileList['test/**/*_test.rb'].exclude('test/fixtures/**/*')
-    failures = files.reject do |file|
-      puts "ruby %s" % file
-      system("ruby #{file}")
-    end
-
-    unless failures.empty?
-      puts "FAILURES IN:"
-      failures.each do |failure|
-        puts failure
-      end
-      exit 1
-    end
-  end
-end
-
-task default: :test
+task default: %w(test:everything)

--- a/api/v1/routes/iterations.rb
+++ b/api/v1/routes/iterations.rb
@@ -3,7 +3,6 @@ require './lib/jobs/hello'
 
 module ExercismAPI
   module Routes
-    # rubocop:disable Metrics/ClassLength
     class Iterations < Core
       # Mark exercise as skipped.
       # Called from the CLI.
@@ -137,5 +136,4 @@ module ExercismAPI
       end
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/presenters/tracks.rb
+++ b/app/presenters/tracks.rb
@@ -44,7 +44,7 @@ module ExercismWeb
       def self.fetch_tracks
         status, body = Xapi.get("tracks")
         if status != 200
-          raise "something fishy in x-api: (#{status}) - #{body}"
+          fail "something fishy in x-api: (#{status}) - #{body}"
         end
         tracks = JSON.parse(body)["tracks"]
         tracks.map {|track| Track.new(track)}

--- a/app/routes/account.rb
+++ b/app/routes/account.rb
@@ -54,11 +54,11 @@ module ExercismWeb
           user_to_invite = ::User.find_by_username(params[:user_to_invite])
           track = params[:track]
 
-          user_to_invite.present? or raise "couldn't find user for #{user_to_invite.username}"
-          track.present? or raise "track cannot be blank"
-          !(user_to_invite == current_user) or raise "you cannot invite yourself"
-          current_user.track_mentor.include?(track) or raise "you must be mentor for #{track} first"
-          !user_to_invite.track_mentor.include?(track) or raise "#{user_to_invite.username} is already a mentor for #{track}"
+          user_to_invite.present? or fail "couldn't find user for #{user_to_invite.username}"
+          track.present? or fail "track cannot be blank"
+          !(user_to_invite == current_user) or fail "you cannot invite yourself"
+          current_user.track_mentor.include?(track) or fail "you must be mentor for #{track} first"
+          !user_to_invite.track_mentor.include?(track) or fail "#{user_to_invite.username} is already a mentor for #{track}"
 
           user_to_invite.invite_to_track_mentor(track)
 

--- a/app/routes/static.rb
+++ b/app/routes/static.rb
@@ -49,7 +49,7 @@ module ExercismWeb
       end
 
       get '/bork' do
-        raise RuntimeError.new("Hi Bugsnag, you're awesome!")
+        fail RuntimeError.new("Hi Bugsnag, you're awesome!")
       end
 
       get '/no-such-page' do

--- a/app/routes/stats.rb
+++ b/app/routes/stats.rb
@@ -2,7 +2,7 @@ module ExercismWeb
   module Routes
     class Stats < Core
       get '/stats' do
-        redirect "/stats/#{tracks.select(&:active?).first.slug}"
+        redirect "/stats/#{tracks.find(&:active?).slug}"
       end
 
       get '/stats/:track_id' do |track_id|

--- a/config.ru
+++ b/config.ru
@@ -10,7 +10,7 @@ if ENV['RACK_ENV'] == 'development'
   require 'db/connection'
   DB::Connection.establish
   if defined?(ActiveRecord::Migrator) && ActiveRecord::Migrator.needs_migration?
-    raise 'Migrations are pending run `rake db:migrate` to resolve the issue.'
+    fail 'Migrations are pending run `rake db:migrate` to resolve the issue.'
   end
 end
 

--- a/lib/db/config.rb
+++ b/lib/db/config.rb
@@ -26,7 +26,7 @@ module DB
 
       unless result
         error = "No environment '#{environment}' configured in #{file}"
-        raise UnconfiguredEnvironment.new(error)
+        fail UnconfiguredEnvironment.new(error)
       end
 
       result

--- a/lib/exercism/locale.rb
+++ b/lib/exercism/locale.rb
@@ -6,7 +6,7 @@ class UnknownLocale
   end
 
   def language
-    raise Exercism::UnknownLanguage.new(error_message)
+    fail Exercism::UnknownLanguage.new(error_message)
   end
 
   private

--- a/lib/rouge/formatters/html_exercism.rb
+++ b/lib/rouge/formatters/html_exercism.rb
@@ -51,6 +51,7 @@ module Rouge
         yield "</code></pre>\n" if @wrap
       end
 
+      # rubocop:disable Metrics/AbcSize, MethodLength
       def stream_tableized(tokens)
         num_lines = 0
         last_val = ''
@@ -97,6 +98,7 @@ module Rouge
         yield "</tr></tbody></table>\n"
         yield "</div>\n" if @wrap
       end
+      # rubocop:enable Metrics/AbcSize, MethodLength
 
       TABLE_FOR_ESCAPE_HTML = {
         '&' => '&amp;',
@@ -110,14 +112,12 @@ module Rouge
 
         if shortname.empty?
           yield val
-        else
-          if @inline_theme
-            rules = @inline_theme.style_for(tok).rendered_rules
+        elsif @inline_theme
+          rules = @inline_theme.style_for(tok).rendered_rules
 
-            yield "<span style=\"#{rules.to_a.join(';')}\">#{val}</span>"
-          else
-            yield "<span class=\"#{shortname}\">#{val}</span>"
-          end
+          yield "<span style=\"#{rules.to_a.join(';')}\">#{val}</span>"
+        else
+          yield "<span class=\"#{shortname}\">#{val}</span>"
         end
       end
     end

--- a/lib/rouge/formatters/html_exercism.rb
+++ b/lib/rouge/formatters/html_exercism.rb
@@ -43,9 +43,10 @@ module Rouge
         end
       end
 
-    private
+      private
+
       def stream_untableized(tokens, &b)
-        yield "<pre#@css_class><code>" if @wrap
+        yield "<pre#{@css_class}><code>" if @wrap
         tokens.each{ |tok, val| span(tok, val, &b) }
         yield "</code></pre>\n" if @wrap
       end
@@ -77,9 +78,9 @@ module Rouge
         end
 
         # generate a string of newline-separated line numbers for the gutter>
-        gutter = %<<pre class="lineno">#{line_numbers.join("\n")}</pre>>
+        gutter = %(<pre class="lineno">#{line_numbers.join("\n")}</pre>)
 
-        yield "<div#@css_class>" if @wrap
+        yield "<div#{@css_class}>" if @wrap
         yield '<table style="border-spacing: 0"><tbody><tr>'
 
         # the "gl" class applies the style for Generic.Lineno
@@ -101,11 +102,11 @@ module Rouge
         '&' => '&amp;',
         '<' => '&lt;',
         '>' => '&gt;',
-      }
+      }.freeze
 
       def span(tok, val)
         val = val.gsub(/[&<>]/, TABLE_FOR_ESCAPE_HTML)
-        shortname = tok.shortname or raise "unknown token: #{tok.inspect} for #{val.inspect}"
+        shortname = tok.shortname or fail "unknown token: #{tok.inspect} for #{val.inspect}"
 
         if shortname.empty?
           yield val

--- a/lib/tasks/coveralls.rake
+++ b/lib/tasks/coveralls.rake
@@ -1,9 +1,0 @@
-if ENV['RACK_ENV'].to_s == "test"
-  require 'coveralls/rake/task'
-  Coveralls::RakeTask.new
-  task :test_with_coverage do
-    ENV['COVERAGE'] = '1'
-    Rake::Task["test"].invoke
-    Rake::Task["coveralls:push"].invoke
-  end
-end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,0 +1,7 @@
+begin
+  require 'rubocop/rake_task'
+  RuboCop::RakeTask.new
+rescue LoadError => error
+  puts "RuboCop's rake task could not be loaded"
+  puts error.message
+end

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,50 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  require 'bundler'
+  Bundler.require
+  t.test_files = FileList['test/**/*_test.rb'].exclude('test/fixtures/**/*')
+end
+
+namespace :test do
+  desc "Run each test file independently"
+  task :each do
+    files = FileList['test/**/*_test.rb'].exclude('test/fixtures/**/*')
+    failures = files.reject do |file|
+      puts "ruby %s" % file
+      system("ruby #{file}")
+    end
+
+    unless failures.empty?
+      puts "FAILURES IN:"
+      failures.each do |failure|
+        puts failure
+      end
+      exit 1
+    end
+  end
+
+  desc 'Run the front-end lineman specs'
+  task :lineman do
+    exit 1 unless system('cd frontend && npm install && lineman spec-ci')
+  end
+
+  desc 'Run the Ruby MiniTest suite'
+  task :minitest do
+    if ENV['CI'] == '1'
+      ENV['COVERAGE'] = '1'
+      require 'coveralls/rake/task'
+      Coveralls::RakeTask.new
+    end
+
+    Rake::Task["test"].invoke
+    Rake::Task["coveralls:push"].invoke if ENV['CI'] == '1'
+  end
+
+  desc 'Run all tests, linters, and checks'
+  task everything: %w(
+    test:minitest
+    rubocop
+    test:lineman
+  )
+end

--- a/scripts/console.rb
+++ b/scripts/console.rb
@@ -9,7 +9,7 @@ require 'active_record'
 require 'db/connection'
 DB::Connection.establish
 if defined?(ActiveRecord::Migrator) && ActiveRecord::Migrator.needs_migration?
-  raise 'Migrations are pending run `rake db:migrate` to resolve the issue.'
+  fail 'Migrations are pending run `rake db:migrate` to resolve the issue.'
 end
 
 def user(username)

--- a/test/active_record_helper.rb
+++ b/test/active_record_helper.rb
@@ -10,7 +10,7 @@ I18n.enforce_available_locales = false
 DB::Connection.establish
 
 if defined?(ActiveRecord::Migrator) && ActiveRecord::Migrator.needs_migration?
-  raise 'Migrations are pending run `rake db:migrate RACK_ENV=test` to resolve the issue.'
+  fail 'Migrations are pending run `rake db:migrate RACK_ENV=test` to resolve the issue.'
 end
 
 DatabaseCleaner.strategy = :transaction

--- a/test/api/users_test.rb
+++ b/test/api/users_test.rb
@@ -77,9 +77,9 @@ class UsersApiTest < Minitest::Test
       assert_equal 4, response["statistics"].count
       assert_equal 1, response["statistics"].first["completed"].count
       assert_equal 1, response["statistics"][1]["completed"].count
-      count = response["statistics"].select do |language|
+      count = response["statistics"].count do |language|
         language["completed"].count == 0
-      end.count
+      end
       assert_equal 2, count
     end
   end

--- a/test/app/helpers/fuzzy_time_test.rb
+++ b/test/app/helpers/fuzzy_time_test.rb
@@ -17,7 +17,7 @@ class FuzzyTimeHelperTest < Minitest::Test
     @now ||= Time.utc(2013, 1, 2, 3, 4)
   end
 
-  def link_text date, link_text
+  def link_text _date, link_text
     link_text
     # "<a href='#' data-toggle='tooltip' title='#{date.strftime("%e %B %Y at %H:%M %Z")}'>#{link_text}</a>"
   end

--- a/test/app/helpers/fuzzy_time_test.rb
+++ b/test/app/helpers/fuzzy_time_test.rb
@@ -48,8 +48,9 @@ class FuzzyTimeHelperTest < Minitest::Test
   end
 
   def test_a_bit_more_than_23_hours_ago
-    ago = helper.ago(now-(23*60*60 + 29*60))
-    assert_equal link_text(now-(23*60*60 + 29*60), "about 23 hours ago"), ago
+    more_than_23_hours = (23*60*60 + 29*60)
+    ago = helper.ago(now-more_than_23_hours)
+    assert_equal link_text(now-more_than_23_hours, "about 23 hours ago"), ago
   end
 
   def test_bit_more_than_a_day

--- a/test/db/config_test.rb
+++ b/test/db/config_test.rb
@@ -1,80 +1,82 @@
 require_relative '../test_helper'
 require 'db/config'
 
-class DB::ConfigTest < Minitest::Test
-  def relative_to_root(*paths)
-    File.expand_path(File.join(__FILE__, '..', '..', '..', *paths))
-  end
-
-  def test_default_file
-    file = relative_to_root('config', 'database.yml')
-    assert_equal file, DB::Config.new('env').file
-  end
-
-  def test_database_name_comes_from_environment_by_default
-    assert_equal 'exercism_development', DB::Config.new('development').options['database']
-  end
-
-  def test_defaults_to_the_current_environment
-    assert_equal 'test', DB::Config.new.environment
-  end
-
-  def test_uses_environment_from_RACK_ENV
-    original_rack_env = ENV.delete('RACK_ENV')
-    ENV['RACK_ENV'] = 'custom'
-    assert_equal 'custom', DB::Config.new.environment
-  ensure
-    ENV['RACK_ENV'] = original_rack_env if original_rack_env
-  end
-
-  def test_defaults_to_development_if_RACK_ENV_unset
-    original_rack_env = ENV.delete('RACK_ENV')
-    assert_equal 'development', DB::Config.new.environment
-  ensure
-    ENV['RACK_ENV'] = original_rack_env if original_rack_env
-  end
-
-  def test_override_file
-    file = relative_to_root('test', 'fixtures', 'database.yml')
-    assert_equal file, DB::Config.new('env', file).file
-  end
-
-  def test_read_environment_specific_values
-    file = relative_to_root('test', 'fixtures', 'database.yml')
-    config = DB::Config.new('fake', file)
-    options = {
-      'adapter' => 'postgresql',
-      'database' => 'exercism_fake'
-    }
-    assert_equal options, config.options
-  end
-
-  def test_blow_up_for_unknown_environment
-    file = relative_to_root('test', 'fixtures', 'database.yml')
-    config = DB::Config.new('real', file)
-
-    assert_raises DB::Config::UnconfiguredEnvironment do
-      config.options
+module DB
+  class ConfigTest < Minitest::Test
+    def relative_to_root(*paths)
+      File.expand_path(File.join(__FILE__, '..', '..', '..', *paths))
     end
-  end
 
-  def example_config
-    DB::Config.new('test', relative_to_root('test', 'fixtures', 'database.yml'))
-  end
+    def test_default_file
+      file = relative_to_root('config', 'database.yml')
+      assert_equal file, DB::Config.new('env').file
+    end
 
-  def test_exposes_database
-    assert_equal 'exercism_test', example_config.database
-  end
+    def test_database_name_comes_from_environment_by_default
+      assert_equal 'exercism_development', DB::Config.new('development').options['database']
+    end
 
-  def test_exposes_host
-    assert_equal 'localhost', example_config.host
-  end
+    def test_defaults_to_the_current_environment
+      assert_equal 'test', DB::Config.new.environment
+    end
 
-  def test_exposes_password
-    assert_equal 'secret', example_config.password
-  end
+    def test_uses_environment_from_RACK_ENV
+      original_rack_env = ENV.delete('RACK_ENV')
+      ENV['RACK_ENV'] = 'custom'
+      assert_equal 'custom', DB::Config.new.environment
+    ensure
+      ENV['RACK_ENV'] = original_rack_env if original_rack_env
+    end
 
-  def test_exposes_username
-    assert_equal 'alice', example_config.username
+    def test_defaults_to_development_if_RACK_ENV_unset
+      original_rack_env = ENV.delete('RACK_ENV')
+      assert_equal 'development', DB::Config.new.environment
+    ensure
+      ENV['RACK_ENV'] = original_rack_env if original_rack_env
+    end
+
+    def test_override_file
+      file = relative_to_root('test', 'fixtures', 'database.yml')
+      assert_equal file, DB::Config.new('env', file).file
+    end
+
+    def test_read_environment_specific_values
+      file = relative_to_root('test', 'fixtures', 'database.yml')
+      config = DB::Config.new('fake', file)
+      options = {
+        'adapter' => 'postgresql',
+        'database' => 'exercism_fake'
+      }
+      assert_equal options, config.options
+    end
+
+    def test_blow_up_for_unknown_environment
+      file = relative_to_root('test', 'fixtures', 'database.yml')
+      config = DB::Config.new('real', file)
+
+      assert_raises DB::Config::UnconfiguredEnvironment do
+        config.options
+      end
+    end
+
+    def example_config
+      DB::Config.new('test', relative_to_root('test', 'fixtures', 'database.yml'))
+    end
+
+    def test_exposes_database
+      assert_equal 'exercism_test', example_config.database
+    end
+
+    def test_exposes_host
+      assert_equal 'localhost', example_config.host
+    end
+
+    def test_exposes_password
+      assert_equal 'secret', example_config.password
+    end
+
+    def test_exposes_username
+      assert_equal 'alice', example_config.username
+    end
   end
 end

--- a/test/exercism/markdown_test.rb
+++ b/test/exercism/markdown_test.rb
@@ -39,7 +39,7 @@ class MarkdownTest < Minitest::Test
   def test_mention_ignores_fenced_code_blocks
     markdown = "```\n@goose\n```"
     assert_match "<pre><span id=\"L1\">@goose\n</span>",
-      ExercismLib::Markdown.render(markdown)
+                 ExercismLib::Markdown.render(markdown)
   end
 
   def test_no_newlines_before_and_after_code

--- a/test/exercism/team_stream_test.rb
+++ b/test/exercism/team_stream_test.rb
@@ -76,7 +76,7 @@ class TeamStreamTest < Minitest::Test
     Comment.create!(submission_id: s2.id, user_id: [alice.id, bob.id, charlie.id].sample, body: "OHAI")
 
     stream = TeamStream.new(team, alice.id)
-    exercise = stream.exercises.select {|ex| ex.id == ex2.id}.first
+    exercise = stream.exercises.find {|ex| ex.id == ex2.id}
     assert_equal 3, exercise.comment_count
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/x/docs/launch.rb
+++ b/x/docs/launch.rb
@@ -10,6 +10,7 @@ module X
       end
 
       private
+
       attr_reader :repository
 
       def read


### PR DESCRIPTION
This PR adds a new rake task called `test:everything` that, as the name implies, tests everything. It runs all of the checks to ensure the code is 👌 💯 ✨  before a PR is submitted and merged.

Right now, that new task runs MiniTest, RuboCop, and Lineman Spec.

The commits in this PR get the app setup for this task and adjust RuboCop to make it happy since it was a little grumpy. 🚨 🚔 

See each commit for details.

Closes #2846