### PR TITLE
Link to relevant activity stream from submission page

### DIFF
--- a/app/views/submissions/show.erb
+++ b/app/views/submissions/show.erb
@@ -41,16 +41,19 @@
       submitted by <%= gravatar_tag submission.user.avatar_url, size: 20 %>
       <%= profile_link(submission.user) %>
       <%= ago(submission.created_at) %>
-      <br/>
-      see other implementations of
-      <a href="<%= "/tracks/#{submission.problem.track_id}/exercises/#{submission.problem.slug}" %>">
-      <%= submission.problem.name %>
-      in
-      <%= submission.language.capitalize %>
-      </a>
+
       <% if submission.user_exercise.archived? %>
         <span class="label label-danger">Archived</span>
       <% end %>
+
+      <div class="pull-right">
+        See other implementations of
+        <a href="<%= "/tracks/#{submission.track_id}/exercises/#{submission.slug}" %>">
+        <%= submission.problem.name %>
+        in
+        <%= submission.problem.language %>
+        </a>
+      </div>
     </div>
   </div>
 

--- a/app/views/submissions/show.erb
+++ b/app/views/submissions/show.erb
@@ -41,6 +41,13 @@
       submitted by <%= gravatar_tag submission.user.avatar_url, size: 20 %>
       <%= profile_link(submission.user) %>
       <%= ago(submission.created_at) %>
+      <br/>
+      see other implementations of
+      <a href="<%= "/tracks/#{submission.problem.track_id}/exercises/#{submission.problem.slug}" %>">
+      <%= submission.problem.name %>
+      in
+      <%= submission.language.capitalize %>
+      </a>
       <% if submission.user_exercise.archived? %>
         <span class="label label-danger">Archived</span>
       <% end %>

--- a/app/views/submissions/show.erb
+++ b/app/views/submissions/show.erb
@@ -57,17 +57,6 @@
     </div>
   </div>
 
-  <% if current_user.owns?(submission) %>
-    <div class="submission-alerts">
-      <% if submission.user_exercise.archived? && UserExercise.for(submission).archived.count > 0 %>
-        <div class="alert alert-info" role="alert">
-          <p>See <a href="/code/<%= submission.track_id %>/<%= submission.slug %>/random">someone else's solution</a> to this exercise.</p>
-          <p>View <a href="<%= language_path_for_slug(submission.language, submission.slug) %>">all other solutions</a> to this problem.</p>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
-
   <div class="submission-iterations">
     <ul class="pull-right nav nav-pills hidden-xs">
       <li>


### PR DESCRIPTION
This fixes #2859 based on the feedback from @kytrinyx and @jkrmr on the issue and on @juliatjoy's pull request #2869.

- Moved the link to other implementations to the top right (screenshot attached)
- Removed the section visible in archived pages, with links to other implementations.

<img width="1170" alt="exercism-2859" src="https://cloud.githubusercontent.com/assets/121782/15214408/8045e1ca-186a-11e6-8f3b-2d8416408ce7.png">