### PR TITLE
Fix sole RuboCop offense in Exercism::UserExercise

### DIFF
--- a/lib/exercism/user_exercise.rb
+++ b/lib/exercism/user_exercise.rb
@@ -88,5 +88,4 @@ class UserExercise < ActiveRecord::Base
       "N/A"
     end
   end
-
 end


### PR DESCRIPTION
This gets RuboCop (and thus the builds) passing since this offense was
introduced before 10591be6d5de31a789fab0e5e0cebe15716b766c was merged.

-----

I noticed the build was failing after recent merges, so this fix should get CI
builds passing again.

Something worth exploring might be requiring Travis CI status checks and forcing
a branch to be up to date before it can be merged, [which GitHub introduced recently](https://github.com/blog/2051-protected-branches-and-required-status-checks).