### PR TITLE
Comments in dashboard feedback section

### DIFF
--- a/app/presenters/dashboard.rb
+++ b/app/presenters/dashboard.rb
@@ -16,9 +16,9 @@ module ExercismWeb
 
       def notifications
         @notifications ||= user.notifications
-          .includes(:actor, iteration:[:comments])
-          .unread.feedback
-          .reject { |note| note.iteration.nil? || note.iteration.user.nil? }
+                               .includes(:actor, iteration: [:comments])
+                               .unread.feedback
+                               .reject { |note| note.iteration.nil? || note.iteration.user.nil? }
       end
     end
   end

--- a/app/presenters/dashboard.rb
+++ b/app/presenters/dashboard.rb
@@ -15,7 +15,10 @@ module ExercismWeb
       end
 
       def notifications
-        @notifications ||= user.notifications.includes(:iteration, :actor).unread.feedback.reject { |note| note.iteration.nil? || note.iteration.user.nil? }
+        @notifications ||= user.notifications
+          .includes(:actor, iteration:[:comments])
+          .unread.feedback
+          .reject { |note| note.iteration.nil? || note.iteration.user.nil? }
       end
     end
   end

--- a/app/views/dashboard.erb
+++ b/app/views/dashboard.erb
@@ -48,10 +48,11 @@
 
     <div class="col-md-6">
       <h2>Feedback</h2>
-      <div class="well">
+      <div>
         <% if dashboard.has_activity? %>
             <% dashboard.notifications.each do |notification| %>
-                <li style="list-style-type: none; margin: 5px;">
+              <div class="panel panel-default">
+                <div class="panel-heading">
                   <span style="padding-right: 15px;" class="fa fa-<%= notification.icon %>"></span>
 
                   <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
@@ -68,7 +69,8 @@
                 <span style="float: right;">
                   <%= track_icon(notification.iteration.track_id, 20) %>
                 </span>
-                </li>
+                </div>
+              </div>
             <% end %>
         <% else %>
             <p>No new feedback.</p>

--- a/app/views/dashboard.erb
+++ b/app/views/dashboard.erb
@@ -50,30 +50,36 @@
       <h2>Feedback</h2>
       <div>
         <% if dashboard.has_activity? %>
-            <% dashboard.notifications.each do |notification| %>
-              <div class="panel panel-default">
-                <div class="panel-heading">
-                  <span style="padding-right: 15px;" class="fa fa-<%= notification.icon %>"></span>
+          <% dashboard.notifications.each do |notification| %>
 
-                  <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
-                  <a href="/<%= notification.actor.username %>">
-                    <%= notification.actor.username %>
-                  </a>
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
+                <a href="/<%= notification.actor.username %>">
+                  <%= notification.actor.username %>
+                </a>
 
-                  &mdash;
+                &mdash;
 
-                  <a href="/submissions/<%= notification.iteration.uuid %>">
-                    <%= notification.iteration.name %> &middot; <%= Language.of(notification.iteration.track_id) %>
-                  </a>
+                <a href="/submissions/<%= notification.iteration.uuid %>">
+                  <%= notification.iteration.name %> &middot; <%= Language.of(notification.iteration.track_id) %>
+                </a>
 
-                <span style="float: right;">
+                <span class="pull-right">
                   <%= track_icon(notification.iteration.track_id, 20) %>
                 </span>
-                </div>
               </div>
-            <% end %>
+
+              <div class="list-group">
+                <% notification.iteration.comments.where(user: notification.actor).each do |comment| %>
+                  <div class="list-group-item"><%= comment.excerpt(160) %></div>
+                <% end %>
+              </div>
+
+            </div>
+          <% end %>
         <% else %>
-            <p>No new feedback.</p>
+          <p>No new feedback.</p>
         <% end %>
       </div>
     </div>

--- a/lib/exercism/comment.rb
+++ b/lib/exercism/comment.rb
@@ -1,4 +1,5 @@
 require 'exercism/markdown'
+require 'exercism/excerpt'
 
 class Comment < ActiveRecord::Base
   belongs_to :user
@@ -41,6 +42,10 @@ class Comment < ActiveRecord::Base
 
   def mention_ids
     @mention_ids ||= User.where(username: mentions).pluck(:id).map(&:to_i)
+  end
+
+  def excerpt(length)
+    Excerpt.new(html_body).limit(length)
   end
 
   private

--- a/lib/exercism/excerpt.rb
+++ b/lib/exercism/excerpt.rb
@@ -1,0 +1,26 @@
+class Excerpt
+  def initialize(text)
+    @html_text = text
+  end
+
+  def limit(length)
+    text[0..(length - 1)].strip + ellipsis(length)
+  end
+
+  private
+
+  def text
+    @_raw_text ||= begin
+      document = Nokogiri::HTML(@html_text)
+      remove_whitespace(document.text)
+    end
+  end
+
+  def remove_whitespace(string)
+    string.split("\n").map(&:strip).join(' ').strip
+  end
+
+  def ellipsis(length)
+    text.length < length ? '' : '&hellip;'
+  end
+end

--- a/test/exercism/excerpt_test.rb
+++ b/test/exercism/excerpt_test.rb
@@ -1,0 +1,34 @@
+require_relative '../test_helper'
+require 'exercism/excerpt'
+require 'nokogiri'
+
+class ExcerptTest < Minitest::Test
+  def test_limits_length_for_html
+    excerpt = Excerpt.new(<<-EOS)
+      <div>
+        Thus, programs must be written for
+        <i>people to read</i>,
+        and only incidentally for machines to execute.
+      </div>
+    EOS
+
+    assert_equal excerpt.limit(30), 'Thus, programs must be written&hellip;'
+  end
+
+  def test_limits_length_for_plain_text
+    excerpt = Excerpt.new(<<-EOS)
+      Thus, programs must be written for people to read,
+      and only incidentally for machines to execute.
+    EOS
+
+    assert_equal excerpt.limit(30), 'Thus, programs must be written&hellip;'
+  end
+
+  def test_excludes_ellipsis_if_limit_is_longer_than_text_length
+    excerpt = Excerpt.new(<<-EOS)
+      <div>Hello, world!</div>
+    EOS
+
+    assert_equal excerpt.limit(30), 'Hello, world!'
+  end
+end


### PR DESCRIPTION
Fixes #2752. Based on the discussion on #2867, I have cleaned up the UI, and cut off the comments if the length exceeds 160 characters.

This is what the feedback section looks like now:

<img width="1183" alt="screen shot 2016-05-17 at 8 20 40 pm" src="https://cloud.githubusercontent.com/assets/121782/15329153/4c26f1b8-1c75-11e6-81da-82a3ea8c97c7.png">
