### PR TITLE
Return a `span` tag for the tooltip toggle

### DIFF
--- a/app/helpers/fuzzy_time.rb
+++ b/app/helpers/fuzzy_time.rb
@@ -10,20 +10,19 @@ module ExercismWeb
       def ago(timestamp)
         diff = (now - timestamp).to_i.to_f
         if diff < 24 * hours
-          # response = case diff
-          case diff
-          when less_than(2 * minutes)
-            "just now"
-          when less_than(55 * minutes)
-            "about #{(diff / (1 * minutes)).round} minutes ago"
-          when less_than(80 * minutes)
-            "about an hour ago"
-          when less_than(105 * minutes)
-            "about an hour and a half ago"
-          when less_than(23.5 * hours)
-            "about #{(diff / (1 * hours)).round} hours ago"
-          end
-          # "<a href='#' data-toggle='tooltip' title='#{timestamp.strftime("%e %B %Y at %H:%M %Z")}'>#{response}</a>"
+          response = case diff
+                     when less_than(2 * minutes)
+                       "just now"
+                     when less_than(55 * minutes)
+                       "about #{(diff / (1 * minutes)).round} minutes ago"
+                     when less_than(80 * minutes)
+                       "about an hour ago"
+                     when less_than(105 * minutes)
+                       "about an hour and a half ago"
+                     when less_than(23.5 * hours)
+                       "about #{(diff / (1 * hours)).round} hours ago"
+                     end
+          "<span data-toggle='tooltip' title='#{timestamp.strftime('%e %B %Y at %H:%M %Z')}'>#{response}</span>"
         else
           timestamp.strftime("%e %B %Y at %H:%M %Z")
         end

--- a/test/app/helpers/fuzzy_time_test.rb
+++ b/test/app/helpers/fuzzy_time_test.rb
@@ -16,9 +16,8 @@ class FuzzyTimeHelperTest < Minitest::Test
     @now ||= Time.utc(2013, 1, 2, 3, 4)
   end
 
-  def link_text(_date, link_text)
-    link_text
-    # "<a href='#' data-toggle='tooltip' title='#{date.strftime("%e %B %Y at %H:%M %Z")}'>#{link_text}</a>"
+  def link_text(date, link_text)
+    "<span data-toggle='tooltip' title='#{date.strftime('%e %B %Y at %H:%M %Z')}'>#{link_text}</span>"
   end
 
   def test_less_than_2_minutes_ago


### PR DESCRIPTION
Returns a `span` instead of a link for FuzzyTime. This will allow for the tooltip to be inserted within other links.

Fixes #2886