### PR TITLE
Require English library in db.rake for $CHILD_STATUS

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,7 @@
 namespace :db do
   require 'open3'
   require 'bundler'
+  require 'English'
   Bundler.require
   require_relative '../db/config'
   require_relative '../db/connection'


### PR DESCRIPTION
While setting up the database locally. I kept running into an undefined method error originating from `db.rake` file:

```
NoMethodError: undefined method `success?' for nil:NilClass
/Users/#######/code/open-source_contrib/exercism.io/lib/tasks/db.rake:45:in `block (2 levels) in <top (required)>'
```

The error was 3 lines all similar to this:

```
fail "Failed to create database" unless $CHILD_STATUS.success?
```

`$CHILD_STATUS` was `nil` and therefore the error. In order to use the variable `$CHILD_STATUS`, you have to require the English Library in Ruby and that is all I did. I searched the rest of the project and found no reference to this global variable. The alternative would to have been replace all instances of `$CHILD_STATUS` with `$?`, but I prefer the more readable version. 

This is my first commit, so let me know if I missed something. 

P.S. After reviewing the Contribution guide one last time before creating this PR, I ran rubocop and found 5 issues stating that `raise` should be used instead of `fail`. I amended the PR to conform to rubocop rules.