### PR TITLE
Use singular version of "comment" as receiver of call to pluralize.

### DIFF
--- a/app/views/stream/_main.erb
+++ b/app/views/stream/_main.erb
@@ -21,7 +21,7 @@
               <p>
                 <%= exercise.iteration_count %> <%= "iteration".pluralize(exercise.iteration_count) %>
                 &middot;
-                <%= exercise.comment_count %> <%= "comments".pluralize(exercise.comment_count) %>
+                <%= exercise.comment_count %> <%= "comment".pluralize(exercise.comment_count) %>
               </p>
               <p><%= ago(exercise.at.to_time) %></p>
             </div>


### PR DESCRIPTION
Fixes [#2903](https://github.com/exercism/exercism.io/issues/2903).