### PR TITLE
Add comment stats to user stats endpoint and redesign submission stats json

### DIFF
--- a/lib/exercism/user_statistics.rb
+++ b/lib/exercism/user_statistics.rb
@@ -5,8 +5,34 @@ class UserStatistics
 
   def self.by_username(user)
     {
-      user: user.public_user_attributes,
-      statistics: user_problem_statistcs(user),
+      user_info: user.public_user_attributes,
+      comment_statistics: user_comment_statistics(user),
+      submission_statistics: user_problem_statistcs(user),
+    }
+  end
+
+  def self.user_comment_statistics(user)
+    {
+      total_comments_received: total_comments_received(user),
+      total_comments_received_from_others: comments_received_from_others(user).length,
+      total_comments_created: user.comments.count,
+      total_comments_given_to_others: comments_given_to_others(user),
+      days_since_last_comment_given: days_since_last_comment_given(user),
+      days_since_last_comment_received: days_since_last_comment_received(user),
+    }
+  end
+
+  def self.user_problem_statistcs(user)
+    X::Track.all.map do |track|
+      [track.id, track_stats_hash(user, track)]
+    end.to_h
+  end
+
+  def self.track_stats_hash(user, track)
+    {
+      language: track.language,
+      total: track.problems.count,
+      completed: problem_completion(user, track),
     }
   end
 
@@ -14,12 +40,27 @@ class UserStatistics
     user.exercises.completed.where(language: track.id).map(&:slug)
   end
 
-  def self.user_problem_statistcs(user)
-    X::Track.all.map do |track|
-      { track_id: track.id,
-        language: track.language,
-        total: track.problems.count,
-        completed: problem_completion(user, track) }
+  def self.total_comments_received(user)
+    user.submissions.joins(:comments).count
+  end
+
+  def self.comments_received_from_others(user)
+    user.submissions.joins(:comments).where.not("comments.user_id = #{user.id}")
+  end
+
+  def self.days_since_last_comment_given(user)
+    unless user.comments.empty?
+      (Date.today - user.comments.order(:created_at).last.created_at.to_date).to_i
     end
+  end
+
+  def self.days_since_last_comment_received(user)
+    comments = Comment.where.not(user_id: user.id).joins(:submission).where("submissions.user_id = #{user.id}").order(:created_at)
+
+    (Date.today - comments.last.created_at.to_date).to_i unless comments.empty?
+  end
+
+  def self.comments_given_to_others(user)
+    user.comments.joins(:submission).where.not("submissions.user_id = #{user.id}").count
   end
 end


### PR DESCRIPTION
We added stats listing the following data points: total_comments_received, total_comments_received_from_others, total_comments_created, total_comments_given_to_others, days_since_last_comment_given, days_since_last_comment_received.

Additionally, we redesiged the json structure for the submission statistics. Now, the submission_statistics hash has a value which is a hash that has track_ids as keys.

@adriennedomingus
@adamhundley 