### PR TITLE
Note that `bin/setup` runs best with `bundle exec`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ First, you need to get ahold of the code, so you have a copy of it locally that 
 
 ### Configuration
 
-In most cases, it is easiest to run the `bin/setup` script to automatically setup the defaults for the application.
+In most cases, it is easiest to run the `bin/setup` script via `bundle exec bin/setup` to automatically setup the defaults for the application.
 
 The script will:
 
@@ -128,7 +128,7 @@ You don't need to fill in the EXERCISES_API value unless you're going to be work
 
 ### Data
 
-If you ran `bin/setup` you should be all set.
+If you ran `bundle exec bin/setup` you should be all set.
 
 You can easily reset an existing database to its original state and add the fake data in one step:
 


### PR DESCRIPTION
Inform users to run `bundle exec bin/setup` to avoid gem dependency mismatches.

On my first run, I ran `bin/setup` directly, but it failed with this error:

```
rake aborted!
Gem::LoadError: You have already activated rake 10.4.2, but your Gemfile requires rake 10.5.0. Prepending `bundle exec` to your command may solve this.
/Users/{username}/src/exercism.io/lib/tasks/db.rake:5:in `block in <top (required)>'
/Users/{username}/src/exercism.io/lib/tasks/db.rake:1:in `<top (required)>'
(See full trace by running task with --trace
```

Running via `bundle exec bin/setup` succeeded, so I modified CONTRIBUTING.md to reflect this.