### PR TITLE
Add a link from exercises table to track

### DIFF
--- a/app/views/user/_exercises_table.erb
+++ b/app/views/user/_exercises_table.erb
@@ -31,7 +31,11 @@
           <td><input type="checkbox" name="exercise_ids[]" value="<%= exercise.id %>"></td>
         <% end %>
 
-        <td><%= exercise.problem.language %></td>
+        <td>
+          <a href="/languages/<%= exercise.problem.track_id %>">
+            <%= exercise.problem.language %>
+          </a>
+        </td>
         <td>
           <% if profile.access?(exercise) %>
             <a href="/exercises/<%= exercise.key %>">


### PR DESCRIPTION
I was finding myself going to the exercises table to see which ones I'd
completed, then clicking languages, finding the language I'm working on, then
clicking Available Exercises.

This adds a link to the existing Language name to the track. (Tried to deep link
to the exercises section i.e. `/languages/ruby#exercises`, but it looks like
the anchors aren't working onload?)


<img width="914" alt="screen shot 2016-06-04 at 8 02 51 pm" src="https://cloud.githubusercontent.com/assets/3710766/15803388/9db02b62-2a8f-11e6-841f-192340e645be.png">
