### PR TITLE
Add lax spacing for better markdown list processing and better tests for lists

### DIFF
--- a/lib/exercism/markdown.rb
+++ b/lib/exercism/markdown.rb
@@ -53,15 +53,10 @@ module ExercismLib
         tables: true,
         space_after_headers: true,
         xhtml: true,
+        lax_spacing: true,
       }
     end
     # rubocop:enable Metrics/MethodLength
-
-    def preprocess(text_content)
-      # patch while redcarpet doesn't support lists without newline issue#2759
-      # captures line before list and adds another newline
-      text_content.gsub(/^\w+\n(?=[*|-]\s\w+)/, "\\0\n")
-    end
 
     def postprocess(html_content)
       dom = Nokogiri::HTML(html_content)

--- a/test/exercism/markdown_test.rb
+++ b/test/exercism/markdown_test.rb
@@ -18,8 +18,16 @@ class MarkdownTest < Minitest::Test
   end
 
   def test_lists_without_blank_lines
-    markdown = "foo\n* one\n* two"
-    expected = "<p>foo</p>\n\n<ul>\n<li>one</li>\n<li>two</li>\n</ul>\n"
+    markdown = "foo bar baz\n* one two three\n* cats dogs and frogs"
+    expected = "<p>foo bar baz</p>\n\n<ul>\n<li>one two three</li>\n" \
+               "<li>cats dogs and frogs</li>\n</ul>\n"
+    assert_equal expected, ExercismLib::Markdown.render(markdown)
+  end
+
+  def test_lists_without_blank_lines
+    markdown = "foo bar baz\n* one two three\n* cats dogs and frogs"
+    expected = "<p>foo bar baz</p>\n\n<ul>\n<li>one two three</li>\n" \
+               "<li>cats dogs and frogs</li>\n</ul>\n"
     assert_equal expected, ExercismLib::Markdown.render(markdown)
   end
 


### PR DESCRIPTION
Fixes #2759 
Also closes out #2775 because using commonmarker required buildpacks and lots of other nonsense

Also removed `preprocess` because I wrote terrible terrible regex for that.