### PR TITLE
Add origin of exercism name to about page

### DIFF
--- a/app/views/site/about.erb
+++ b/app/views/site/about.erb
@@ -45,6 +45,20 @@
 
     <article class="article-block">
       <div class="article-contents">
+        <h4 class="header">Origin of Exercism's name</h4>
+        <p> What's with the name "Exericism"?</p>
+        <p>Despite being one vowel away from "exorcism", the name has nothing to do with demons or fixing "evil code".</p>
+        <p>Instead, it's a pun on <i>exercise</i>. The way Katrina came to think about each exercise is
+        that they are small, trivial, and seemingly simple. However, when it comes to solving an exercise, <i>the devil is often in the details</i>. In other words, that simple exercise is suddenly more challenging
+        once you think about the finer details.</p>
+
+        <p>Following that idea, the icon came into existence after Katrina mentioned the idea of <i>the devil is in the details</i> to a designer.</p>
+      </div>
+    </article>
+    <hr>
+
+    <article class="article-block">
+      <div class="article-contents">
         <h4 class="header">Creator: Katrina Owen</h4>
         <p>Katrina is a polyglot developer and Ruby Hero award winner who accidentally became a developer while pursuing a degree in molecular biology.</p>
         <p>She began nitpicking code back in 2006 while volunteering at JavaRanch, and got hooked. When programming, her focus is on automation, workflow optimization, and refactoring. She cares deeply about open source and contributes to several projects outside of exercism.</p>


### PR DESCRIPTION
Add's a bit of background on the naming of Exercism.

In reference to https://github.com/exercism/exercism.io/issues/2940