### PR TITLE
Fix: Fix pagination error on team/:slug/streams URL.

### DIFF
--- a/app/routes/teams.rb
+++ b/app/routes/teams.rb
@@ -16,7 +16,7 @@ module ExercismWeb
 
           locals = {
             team: team,
-            stream: TeamStream.new(team, current_user.id, params["page"]),
+            stream: TeamStream.new(team, current_user.id, params['page'] || 1),
             active: 'stream',
           }
           erb :"teams/stream", locals: locals

--- a/app/routes/teams.rb
+++ b/app/routes/teams.rb
@@ -16,10 +16,9 @@ module ExercismWeb
 
           locals = {
             team: team,
-            stream: TeamStream.new(team, current_user.id),
+            stream: TeamStream.new(team, current_user.id, params["page"]),
             active: 'stream',
           }
-
           erb :"teams/stream", locals: locals
         end
       end


### PR DESCRIPTION
Bug: Given an Exercism user in a very active team viewing a certain amount of problems on the teams/:slug/streams page, when the user clicks on a pagination link, the URL changes but the view does not. 

This pull request: In the routes file for this get request, we added the `params[:page]` from the URL into the TeamStream class initialization. 

LA Open Source Pair Programming Meetup: 
@jendiamond
@machikoyasuda 
Jake Wilkins
Ed Vernon
Jamie Mendoza
John S.
Cathy Hillman
Michael
@lenkli67
Anna 
Eric Stevens
Cristine Meinders