### PR TITLE
Add a separate seed task for Heroku seeding purposes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,23 @@ you'll need to do this manually.
 * Then you can access the local server at [localhost:4567](http://localhost:4567).
 * You can log in as a test user using the `assume` dropdown menu on the top right of the page without creating any new user for the app.
 
+To setup seed data to test out the application locally, use the rake
+tasks provided. You can get a list of all the rake tasks by running:
+
+    bundle exec rake -T
+
+To setup the seed data locally, run:
+
+    bundle exec rake db:seeds:fetch`
+    bundle exec rake db:seed
+
+The first command fetches the seed file and places it under the `db/`
+folder as `seeds.sql`. Note that if you're deploying the application to
+Heroku, `db:seed` task might fail since the database config file won't
+contain the necessary details to access the database. To work around the
+problem, there's a task `db:heroku_seed` that can be used.
+
+
 ### Running The Application In A Vagrant Environment
 _The following assumes your Vagrantfile is configured to forward port 3000 to 3030, adjust the port number to suit your environment_
 


### PR DESCRIPTION
As a follow up of the debugging that happened on #2949, it made sense to
document the seeding behaviour differences between local environment and
Heroku. Ideally seeding is intended to be run only on development machines, but
if it needs to be run on Heroku for testing out some feature or to demo it to
the core team, the current seed script needs to be modified. However,
because there is a chance that `db:seed` might be run by some plugin (or a
buildpack) in the setup pipeline, and we don't want it to happen on
production(😱), I've made it a separate task and documented accordingly.

- Add separate seeding task to be run on Heroku
- Add rudimentary documentation about seeding in CONTRIBUTING.md