### PR TITLE
Add description field to Team.

### DIFF
--- a/app/views/teams/directory.erb
+++ b/app/views/teams/directory.erb
@@ -3,6 +3,11 @@
   <%= erb :"teams/_tabs", locals: {active: active, team: team} %>
 
   <h3><%= h(team.name) %> (<%= team.confirmed_members.size %> <%= 'member'.pluralize(team.confirmed_members.size) %>)</h3>
+
+  <% if team.description.present? %>
+    <h4><%= team.description %></h4>
+  <% end %>
+
   <p>Click on a team member's name to go to their profile.</p>
 
   <% team.confirmed_members.each_slice(3) do |row| %>

--- a/app/views/teams/manage.erb
+++ b/app/views/teams/manage.erb
@@ -23,6 +23,15 @@
       </div>
 
       <div class="row">
+        <div class="form-group col-sm-8">
+          <label for="team_slug">Description</label>
+          <div class="controls">
+            <textarea name="team[description]" id="team_description" class="form-control" placeholder="e.g., People interested in learning new programming languages"><%= team.description %></textarea>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
         <button type="submit" class="btn btn-primary" style="margin-left: 15px">Update</button>
       </div>
     </form><br/>

--- a/app/views/teams/new.erb
+++ b/app/views/teams/new.erb
@@ -32,6 +32,12 @@
             </div>
           </div>
           <div class="form-group">
+            <label class="control-label col-sm-3" for="team_description">Description</label>
+            <div class="col-sm-9">
+              <textarea rows="5" class="form-control" name="team[description]" id="team_description" placeholder="e.g., People interested in learning new programming languages"><%= team.description %></textarea>
+            </div>
+          </div>
+          <div class="form-group">
             <div class="col-sm-offset-3 col-sm-9">
               <button type="submit" class="btn btn-primary">Save</button>
             </div>

--- a/db/migrate/201606261414_add_description_to_team.rb
+++ b/db/migrate/201606261414_add_description_to_team.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToTeam < ActiveRecord::Migration
+  def change
+    add_column :teams, :description, :text
+  end
+end

--- a/lib/exercism/team.rb
+++ b/lib/exercism/team.rb
@@ -37,9 +37,11 @@ class Team < ActiveRecord::Base
     managers << user unless managed_by?(user)
   end
 
+  # rubocop:disable Metrics/MethodLength
   def defined_with(options, inviter=nil)
     self.slug = options[:slug]
     self.name = options[:name]
+    self.description = options[:description]
     recruits = User.find_or_create_in_usernames(potential_recruits(options[:usernames])) if options[:usernames]
     recruits = options[:users] if options[:users]
 

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -115,16 +115,26 @@ class TeamsTest < Minitest::Test
   end
 
   def test_team_creation_with_name
-    post '/teams', { team: { name: 'No Members', slug: 'no_members', usernames: "" } }, login(alice)
+    post '/teams', { team: { name: 'No Members', slug: 'no_members', usernames: '', description: '' } }, login(alice)
     team = Team.first
 
     assert_equal 'No Members', team.name
   end
 
+  def test_team_creation_with_description
+    post '/teams', {
+      team: { slug: 'no_members', usernames: '' , description: 'Team without members' }
+    }, login(alice)
+
+    team = Team.first
+
+    assert_equal 'Team without members', team.description
+  end
+
   def test_team_creation_with_no_members
     assert_equal 0, alice.managed_teams.size
 
-    post '/teams', { team: { slug: 'no_members', usernames: "" } }, login(alice)
+    post '/teams', { team: { slug: 'no_members', usernames: '' } }, login(alice)
 
     team = Team.first
 
@@ -296,14 +306,15 @@ class TeamsTest < Minitest::Test
     refute Team.exists?(slug: 'delete')
   end
 
-  def test_edit_teams_name_and_slug
-    team = Team.by(alice).defined_with(slug: 'edit', usernames: bob.username.to_s)
+  def test_edit_teams_name_and_slug_and_description
+    team = Team.by(alice).defined_with(slug: 'edit', usernames: bob.username.to_s, description: 'No name')
     team.save
 
-    put "/teams/#{team.slug}", { team: { name: 'New name', slug: 'new_slug' } }, login(alice)
+    put "/teams/#{team.slug}", { team: { name: 'New name', slug: 'new_slug', description: 'With name'} }, login(alice)
 
     assert_response_status(302)
     assert team.reload.name == 'New name'
+    assert team.reload.description == 'With name'
   end
 
   def test_unconfirmed_memberships_after_invitation


### PR DESCRIPTION
The motivation for this PR can be found [here](https://github.com/exercism/exercism.io/issues/2944).

For now I didn't try to come up with any design decisions and would love to receive suggestions regarding the current layout.

**User profile:**
![screen shot 2016-06-26 at 2 53 05 pm](https://cloud.githubusercontent.com/assets/428984/16364041/17c23384-3bb4-11e6-97e3-2ddfd6d638f1.png)

**Team page with a team that has a description:**
![screen shot 2016-06-26 at 2 53 21 pm](https://cloud.githubusercontent.com/assets/428984/16364043/17c65d60-3bb4-11e6-8077-f900860cfd83.png)

**Team page with a team without a description:**
![screen shot 2016-06-26 at 2 53 34 pm](https://cloud.githubusercontent.com/assets/428984/16364042/17c5a14a-3bb4-11e6-8dc6-e560227431fe.png)

**Managing a team:**
![screen shot 2016-06-26 at 3 06 39 pm](https://cloud.githubusercontent.com/assets/428984/16364044/17cbc1ba-3bb4-11e6-82c4-dfba60a5c01a.png)
