### PR TITLE
Add public flag to Team.

### DIFF
--- a/app/views/teams/manage.erb
+++ b/app/views/teams/manage.erb
@@ -7,6 +7,15 @@
     <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}" %>" method="post">
       <input type="hidden" name="_method" value="put" />
       <div class="row">
+        <div class="form-group col-sm-8">
+          <label for="team_public">Public (should people be able to find your team?)</label>
+          <div class="controls">
+            <input type="checkbox" id="team_public" name="team[public]" value="1" <%= 'checked' if team.public %>/>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
         <div class="form-group col-sm-4">
           <label for="team_slug">Slug (in URL)</label>
           <div class="controls">

--- a/app/views/teams/new.erb
+++ b/app/views/teams/new.erb
@@ -14,6 +14,13 @@
             </div>
           <% end %>
           <div class="form-group">
+            <label class="control-label col-sm-3" for="team_public">Public</label>
+            <div class="col-sm-9">
+              <input type="checkbox" id="team_public" name="team[public]" value="1" <%= 'checked' if team.public %>/>
+              <span><em>(should people be able to find your team?)</em></span>
+            </div>
+          </div>
+          <div class="form-group">
             <label class="control-label col-sm-3" for="team_slug">Slug</label>
             <div class="col-sm-9">
               <input type="text" name="team[slug]" id="team_slug" placeholder="e.g.,  gocowboys" value="<%= team.slug %>" class="form-control">

--- a/db/migrate/201606291508_add_public_flag_to_team.rb
+++ b/db/migrate/201606291508_add_public_flag_to_team.rb
@@ -1,0 +1,6 @@
+class AddPublicFlagToTeam < ActiveRecord::Migration
+  def change
+    add_column :teams, :public, :boolean, default: false
+    add_index :teams, [:public]
+  end
+end

--- a/lib/exercism/team.rb
+++ b/lib/exercism/team.rb
@@ -42,6 +42,8 @@ class Team < ActiveRecord::Base
     self.slug = options[:slug]
     self.name = options[:name]
     self.description = options[:description]
+    self.public = options[:public].present?
+
     recruits = User.find_or_create_in_usernames(potential_recruits(options[:usernames])) if options[:usernames]
     recruits = options[:users] if options[:users]
 

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -131,6 +131,16 @@ class TeamsTest < Minitest::Test
     assert_equal 'Team without members', team.description
   end
 
+  def test_public_team_creation
+    post '/teams', {
+      team: { slug: 'no_members', usernames: '' , description: 'Team without members', public: '1' }
+    }, login(alice)
+
+    team = Team.first
+
+    assert team.public?
+  end
+
   def test_team_creation_with_no_members
     assert_equal 0, alice.managed_teams.size
 
@@ -306,15 +316,18 @@ class TeamsTest < Minitest::Test
     refute Team.exists?(slug: 'delete')
   end
 
-  def test_edit_teams_name_and_slug_and_description
+  def test_edit_teams_attributes
     team = Team.by(alice).defined_with(slug: 'edit', usernames: bob.username.to_s, description: 'No name')
     team.save
 
-    put "/teams/#{team.slug}", { team: { name: 'New name', slug: 'new_slug', description: 'With name'} }, login(alice)
+    refute team.public?
+
+    put "/teams/#{team.slug}", { team: { name: 'New name', slug: 'new_slug', description: 'With name', public: '1'} }, login(alice)
 
     assert_response_status(302)
     assert team.reload.name == 'New name'
     assert team.reload.description == 'With name'
+    assert team.reload.public?
   end
 
   def test_unconfirmed_memberships_after_invitation


### PR DESCRIPTION
This PR was motivated by [this](https://github.com/exercism/exercism.io/issues/2944) discussion.

This flag will be useful when we implement the feature that allow an user to search for teams (only public teams will be returned).

Current layout:

* **Create:**

![screen shot 2016-06-29 at 5 54 18 pm](https://cloud.githubusercontent.com/assets/428984/16468697/9275775a-3e23-11e6-870e-d59685fbc7f0.png)

* **Update:**


![screen shot 2016-06-29 at 5 53 59 pm](https://cloud.githubusercontent.com/assets/428984/16468698/927633d4-3e23-11e6-9bef-f4d554a13d65.png)
