### PR TITLE
Add comments count to exercises table

### DIFF
--- a/app/views/user/_exercises_table.erb
+++ b/app/views/user/_exercises_table.erb
@@ -21,6 +21,7 @@
         <th>Exercise</th>
         <th>Iterations</th>
         <th>Latest Iteration</th>
+        <th>Comments</th>
       </tr>
     </thead>
     <tbody>
@@ -49,6 +50,7 @@
         </td>
         <td><%= exercise.iteration_count %></td>
         <td data-value="<%= exercise.last_iteration_at.to_i %>"><%= exercise.last_iteration_at.strftime("%Y-%m-%d") %></td>
+        <td><%= exercise.comment_count %></td>
       </tr>
     <% end %>
     </tbody>


### PR DESCRIPTION
I added the number of comments to the exercises table on the user page. I would find this helpful for seeing at a glance which of my (or others') past exercises got a lot of feedback for reviewing after the fact.

![2016-07-09-103431_1988x413_scrot](https://cloud.githubusercontent.com/assets/1302406/16708410/c7fed71e-45c0-11e6-8649-47f95ac158ac.png) 
