### PR TITLE
Add tags for teams.

### DIFF
--- a/app/views/teams/manage.erb
+++ b/app/views/teams/manage.erb
@@ -41,6 +41,15 @@
       </div>
 
       <div class="row">
+        <div class="form-group col-sm-8">
+          <label for="team_slug">Tags</label>
+          <div class="controls">
+            <textarea name="team[tags]" id="team_tags" class="form-control" placeholder="Comma separated values, e.g., ruby, exercism, learning"><%= team.all_tags %></textarea>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
         <button type="submit" class="btn btn-primary" style="margin-left: 15px">Update</button>
       </div>
     </form><br/>

--- a/app/views/teams/new.erb
+++ b/app/views/teams/new.erb
@@ -45,6 +45,12 @@
             </div>
           </div>
           <div class="form-group">
+            <label class="control-label col-sm-3" for="team_tags">Tags</label>
+            <div class="col-sm-9">
+              <textarea rows="5" class="form-control" name="team[tags]" id="team_tags" placeholder="Comma separated values, e.g., ruby, exercism, learning"><%= team.all_tags %></textarea>
+            </div>
+          </div>
+          <div class="form-group">
             <div class="col-sm-offset-3 col-sm-9">
               <button type="submit" class="btn btn-primary">Save</button>
             </div>

--- a/db/migrate/201607131820_create_tags_table.rb
+++ b/db/migrate/201607131820_create_tags_table.rb
@@ -1,0 +1,11 @@
+class CreateTagsTable < ActiveRecord::Migration
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps null: false
+    end
+
+    add_index :tags, [:name], unique: true
+  end
+end

--- a/db/migrate/201607131825_add_tags_to_team.rb
+++ b/db/migrate/201607131825_add_tags_to_team.rb
@@ -1,0 +1,6 @@
+class AddTagsToTeam < ActiveRecord::Migration
+  def change
+    add_column :teams, :tags, :integer, array: true, default: []
+    add_index  :teams, [:tags], using: :gin
+  end
+end

--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -44,6 +44,7 @@ require 'exercism/view'
 require 'exercism/user_lookup'
 require 'exercism/daily'
 require 'exercism/todo_stream'
+require 'exercism/tag'
 
 require 'db/connection'
 DB::Connection.establish

--- a/lib/exercism/tag.rb
+++ b/lib/exercism/tag.rb
@@ -1,0 +1,8 @@
+class Tag < ActiveRecord::Base
+  def self.create_from_text(tags)
+    tags.to_s.downcase.split(",").reject(&:blank?).uniq.map do |tag|
+      tag = Tag.where(name: tag.strip).first_or_create!
+      tag.id
+    end
+  end
+end

--- a/lib/exercism/team.rb
+++ b/lib/exercism/team.rb
@@ -37,12 +37,13 @@ class Team < ActiveRecord::Base
     managers << user unless managed_by?(user)
   end
 
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def defined_with(options, inviter=nil)
     self.slug = options[:slug]
     self.name = options[:name]
     self.description = options[:description]
     self.public = options[:public].present?
+    self.tags = Tag.create_from_text(options[:tags])
 
     recruits = User.find_or_create_in_usernames(potential_recruits(options[:usernames])) if options[:usernames]
     recruits = options[:users] if options[:users]
@@ -95,6 +96,10 @@ class Team < ActiveRecord::Base
 
   def all_members
     members + unconfirmed_members
+  end
+
+  def all_tags
+    Tag.where(id: tags).pluck(:name).join(', ')
   end
 
   private

--- a/test/exercism/tag_test.rb
+++ b/test/exercism/tag_test.rb
@@ -1,0 +1,28 @@
+require_relative '../integration_helper'
+
+class TagTest < Minitest::Test
+  include DBCleaner
+
+  def test_create_tags_from_text
+    assert_equal 0, Tag.count
+    values = Tag.create_from_text('implementing, tags, for, teams')
+    assert_equal 4, Tag.count
+    assert_equal 4, values.size
+  end
+
+  def test_create_tags_from_text_ignores_empty_tags
+    assert_equal 0, Tag.count
+    values = Tag.create_from_text('test,,empty, , tags')
+    assert_equal 3, Tag.count
+    assert_equal 3, values.size
+  end
+
+  def test_create_tags_from_text_uses_existing_tags
+    Tag.create_from_text('old, tag')
+    assert_equal 2, Tag.count
+
+    values = Tag.create_from_text('new, tag')
+    assert_equal 3, Tag.count
+    assert_equal 2, values.size
+  end
+end

--- a/test/exercism/team_test.rb
+++ b/test/exercism/team_test.rb
@@ -222,4 +222,20 @@ class TeamTest < Minitest::Test
     team.confirm(bob.username)
     assert team.includes?(bob), "bob should now be a member"
   end
+
+  def test_all_tags_converts_tag_ids_into_tag_names
+    attributes = { slug: 'tags', tags: 'team, tags' }
+    team = Team.by(alice).defined_with(attributes, alice)
+    team.save
+
+    assert_equal 'team, tags', team.all_tags
+  end
+
+  def test_all_tags_returns_empty_string_when_team_has_no_tags
+    team = Team.by(alice).defined_with(slug: 'no_tags')
+    team.save
+
+    assert_equal 0, team.tags.size
+    assert_equal '', team.all_tags
+  end
 end


### PR DESCRIPTION
This PR was motivated by [this](https://github.com/exercism/exercism.io/issues/2944) discussion, this is the 3rd step in the roadmap.

With this we will have tags associated with a team, the next step will be adding a page to search for teams containing a specific tag.

The UI/UX is pretty simple for now, there is no javascript os CSS involved, but we can discuss if we want to style tags.