### PR TITLE
Clarify that submissions are owned by their author

### DIFF
--- a/app/views/site/about.erb
+++ b/app/views/site/about.erb
@@ -20,6 +20,7 @@
         <p>An overwhelmingly large number of people have <a href="https://github.com/exercism/exercism.io/graphs/contributors" target="blank">contributed to the codebase</a>.
         </p>
         <p>An even larger number of people have contributed through participation; by completing exercises and participating in the discussions about code.</p>
+        <p>Individual exercise submissions are owned by their author, and may or may not be distributed under an open source license.</p>
       </div>
     </article>
     <hr>


### PR DESCRIPTION
Most submissions don't include any kind of explicit license, so something like http://choosealicense.com/no-license/ would apply.  It's probably overkill to try and explain that here, as is requiring that all submissions are made under a default license like codingame.com does (requiring GPLv3).  However, what *is* important to note is that exercism.io is not trying to claim any ownership of these submissions.

/cc @gmlewis