### PR TITLE
WIP refactor submissions js

### DIFF
--- a/app/views/submissions/submit_comment.erb
+++ b/app/views/submissions/submit_comment.erb
@@ -12,34 +12,3 @@
 </form>
 
 <% end %>
-
-<!-- pulled in jquery here, not sure where to put all this to load properly" -->
-<script src="//code.jquery.com/jquery-2.1.3.min.js"></script>
-<script>
-  function userIsInSession() {
-    return $('#navbar a[href="/login"]').length == 0;
-  }
-
-  function sessionHasKey(key) {
-    return localStorage.getItem(key) !== null;
-  }
-  // Check if comment is already stored in session
-  if (sessionHasKey(location.pathname)) {
-      // update input with nitpick
-      // had to use setTimeout, I think something is going on with the angular that causes
-      // a race condition
-      setTimeout(function(){
-        $('#submission_comment').val(localStorage.getItem(location.pathname));
-        localStorage.clear();
-      }, 1000);
-
-  // if user is not logged in
-  } else if (!userIsInSession()) {
-    // bind to the form with the submission key pattern
-    $('form[action^="/submissions/"]').on('submit', function(event){
-      // save nitpick comment in sessionStorage
-      var nitPickText = $(this).find('#submission_comment').val();
-      localStorage.setItem(location.pathname, nitPickText);
-    });
-  }
-</script>

--- a/frontend/app/js/app.coffee
+++ b/frontend/app/js/app.coffee
@@ -47,9 +47,6 @@ $ ->
     emojify.setConfig(emoticons_enabled: false)
     emojify.run(document.getElementsByClassName("comments")[0])
 
-userIsInSession = () ->
-  return $('#navbar a[href="/login"]').length == 0
-
 localStorageHasKey = (key) ->
   return localStorage.getItem(key) != null
 
@@ -62,7 +59,6 @@ recordText = () ->
     localStorage.setItem(location.pathname, nitPickText)
 
 initCommentMemory = () ->
-  # TODO figure out how to remove the comment from localstorate after a successful submission 
   if localStorageHasKey(location.pathname)
     loadCommentFromStorage()
   recordText()

--- a/frontend/app/js/app.coffee
+++ b/frontend/app/js/app.coffee
@@ -55,8 +55,8 @@ loadCommentFromStorage = () ->
 
 recordText = () ->
   $('#submission_comment').keyup (event) ->
-    nitPickText = $(this).val()
-    localStorage.setItem(location.pathname, nitPickText)
+    text = $(this).val()
+    localStorage.setItem(location.pathname, text)
 
 initCommentMemory = () ->
   if localStorageHasKey(location.pathname)

--- a/frontend/app/js/app.coffee
+++ b/frontend/app/js/app.coffee
@@ -14,6 +14,9 @@ $ ->
     onSelect: (e, term, item) ->
       $("[data-search=tags]").closest("form").submit();
 
+  if location.pathname.match(/submissions/)
+    initCommentMemory()
+
   $("#current_submission").theiaStickySidebar(additionalMarginTop: 70)
 
   $('.manager_delete').on 'click', ->
@@ -43,6 +46,26 @@ $ ->
   if _.any($('.comments'))
     emojify.setConfig(emoticons_enabled: false)
     emojify.run(document.getElementsByClassName("comments")[0])
+
+userIsInSession = () ->
+  return $('#navbar a[href="/login"]').length == 0
+
+localStorageHasKey = (key) ->
+  return localStorage.getItem(key) != null
+
+loadCommentFromStorage = () ->
+  $('#submission_comment').val(localStorage.getItem(location.pathname))
+
+recordText = () ->
+  $('#submission_comment').keyup (event) ->
+    nitPickText = $(this).val()
+    localStorage.setItem(location.pathname, nitPickText)
+
+initCommentMemory = () ->
+  # TODO figure out how to remove the comment from localstorate after a successful submission 
+  if localStorageHasKey(location.pathname)
+    loadCommentFromStorage()
+  recordText()
 
 destroyTeam = (slug) ->
   href = "/teams/" + slug

--- a/frontend/app/js/script.js
+++ b/frontend/app/js/script.js
@@ -36,6 +36,7 @@ $(function() {
   });
 
   $('form').on('submit', function() {
+    localStorage.clear(location.pathname);
     var $this = $(this).find(':submit');
     window.setTimeout(function() { $this.attr('disabled', true); }, 1);
   });

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30962,13 +30962,16 @@ $(".track-activity-chart").each(function(index, element) {
 
 
 (function() {
-  var destroyTeam, dismissTeamManager, dismissTeamMember;
+  var destroyTeam, dismissTeamManager, dismissTeamMember, initCommentMemory, loadCommentFromStorage, localStorageHasKey, recordText, userIsInSession;
 
   angular.module('exercism', ['ui.bootstrap']);
 
   $(function() {
     if (location.pathname !== '/' && $('h1, h2, h3').length && document.title === 'exercism.io') {
       document.title = "" + ($($('h1, h2, h3').get(0)).text()) + " - exercism.io";
+    }
+    if (location.pathname.match(/submissions/)) {
+      initCommentMemory();
     }
     $("[data-toggle=tooltip]").tooltip();
     $("[data-search=tags]").autoComplete({
@@ -31021,6 +31024,33 @@ $(".track-activity-chart").each(function(index, element) {
       return emojify.run(document.getElementsByClassName("comments")[0]);
     }
   });
+
+  userIsInSession = function() {
+    return $('#navbar a[href="/login"]').length === 0;
+  };
+
+  localStorageHasKey = function(key) {
+    return localStorage.getItem(key) !== null;
+  };
+
+  loadCommentFromStorage = function() {
+    return $('#submission_comment').val(localStorage.getItem(location.pathname));
+  };
+
+  recordText = function() {
+    return $('#submission_comment').keyup(function(event) {
+      var nitPickText;
+      nitPickText = $(this).val();
+      return localStorage.setItem(location.pathname, nitPickText);
+    });
+  };
+
+  initCommentMemory = function() {
+    if (localStorageHasKey(location.pathname)) {
+      loadCommentFromStorage();
+    }
+    return recordText();
+  };
 
   destroyTeam = function(slug) {
     var form, href, method_input;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -30836,6 +30836,7 @@ $(function() {
   });
 
   $('form').on('submit', function() {
+    localStorage.clear(location.pathname);
     var $this = $(this).find(':submit');
     window.setTimeout(function() { $this.attr('disabled', true); }, 1);
   });
@@ -30962,16 +30963,13 @@ $(".track-activity-chart").each(function(index, element) {
 
 
 (function() {
-  var destroyTeam, dismissTeamManager, dismissTeamMember, initCommentMemory, loadCommentFromStorage, localStorageHasKey, recordText, userIsInSession;
+  var destroyTeam, dismissTeamManager, dismissTeamMember, initCommentMemory, loadCommentFromStorage, localStorageHasKey, recordText;
 
   angular.module('exercism', ['ui.bootstrap']);
 
   $(function() {
     if (location.pathname !== '/' && $('h1, h2, h3').length && document.title === 'exercism.io') {
       document.title = "" + ($($('h1, h2, h3').get(0)).text()) + " - exercism.io";
-    }
-    if (location.pathname.match(/submissions/)) {
-      initCommentMemory();
     }
     $("[data-toggle=tooltip]").tooltip();
     $("[data-search=tags]").autoComplete({
@@ -30987,6 +30985,9 @@ $(".track-activity-chart").each(function(index, element) {
         return $("[data-search=tags]").closest("form").submit();
       }
     });
+    if (location.pathname.match(/submissions/)) {
+      initCommentMemory();
+    }
     $("#current_submission").theiaStickySidebar({
       additionalMarginTop: 70
     });
@@ -31024,10 +31025,6 @@ $(".track-activity-chart").each(function(index, element) {
       return emojify.run(document.getElementsByClassName("comments")[0]);
     }
   });
-
-  userIsInSession = function() {
-    return $('#navbar a[href="/login"]').length === 0;
-  };
 
   localStorageHasKey = function(key) {
     return localStorage.getItem(key) !== null;


### PR DESCRIPTION
Fixes #2957

I've successfully added the ability to save iteration specific comments to localstorage, but still need to figure out how to remove them after a successful form submission. I'll need to look more into Angular.

I'm also attempting to move the comment submission code into `frontend/app/js/app.coffee`. I imagine, that in the future, it'd be nice to break that JS code up into page specific portions. 

Since we'll be storing comments to localstorage, I believe we can remove the page exit confirmations...but perhaps it's worth it in case there's a JS race condition that doesn't save their comment or they have JS turned off.