### PR TITLE
Sort exerises by last iteration instead of language name

### DIFF
--- a/app/views/user/_exercises_table.erb
+++ b/app/views/user/_exercises_table.erb
@@ -15,10 +15,10 @@
         <th></th>
       <% end %>
 
-      <th data-sorted="true"  data-sorted-direction="ascending">Language</th>
+      <th>Language</th>
       <th>Exercise</th>
       <th>Iterations</th>
-      <th>Latest Iteration</th>
+      <th data-sorted="true" data-sorted-direction="descending">Latest Iteration</th>
       <th>Comments</th>
     </tr>
   </thead>


### PR DESCRIPTION
I think it is better to have the exercises sorted by the time of submission rather than
languages. With a lot of languages, old exercises show up at the top while latest submissions are somewhere below. Most recent submissions should be at the top.

![screen shot 2016-07-27 at 1 52 33 am](https://cloud.githubusercontent.com/assets/980783/17154018/dd958296-539c-11e6-973f-6caad0132efd.png)

Sorted by the last iteration timestamp in descending order (most recent first).