### PR TITLE
Add /version route that returns meta information

### DIFF
--- a/app/routes/static.rb
+++ b/app/routes/static.rb
@@ -60,6 +60,10 @@ module ExercismWeb
         status 404
         erb :"errors/not_found"
       end
+
+      get '/version' do
+        erb :'site/version.json', layout: false
+      end
     end
   end
 end

--- a/app/views/site/version.json.erb
+++ b/app/views/site/version.json.erb
@@ -1,0 +1,7 @@
+<%=
+{
+  'repository' => 'https://github.com/exercism/exercism.io',
+  'contributing' => 'https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md',
+  'build_id' => BUILD_ID,
+}.to_json
+%>

--- a/config/build_id.rb
+++ b/config/build_id.rb
@@ -1,1 +1,1 @@
-BuildID = (ENV['BUILD_ID'] || 'unknown').strip
+BUILD_ID = (ENV['BUILD_ID'] || 'unknown').strip

--- a/test/app/static_pages_test.rb
+++ b/test/app/static_pages_test.rb
@@ -1,0 +1,15 @@
+require_relative '../app_helper'
+
+class StaticPagesTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    ExercismWeb::App
+  end
+
+  def test_route_version
+    get "/version"
+    assert_equal 200, last_response.status
+    assert_match /\A{.*"build_id".*}\n\z/, last_response.body
+  end
+end


### PR DESCRIPTION
Add a '/version' route that returns a json string with information about the current build.
(This is similar to what is provided as default by http://x.exercism.io/)

Example:
```json
{"repository":"https://github.com/exercism/exercism.io","contributing":"https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md","build_id":"ef04547"}
```

In order for the app to display the current build an environment variable needs to be set on the server before running the app. One way to do this:

```bash
export BUILD_ID=$(git rev-parse --short HEAD)
```