### PR TITLE
Add syntax highlighting for lisp track

### DIFF
--- a/lib/exercism/syntax_highlighter.rb
+++ b/lib/exercism/syntax_highlighter.rb
@@ -6,6 +6,8 @@ module ExercismLib
     ROUGE_LANG = {
       'objective-c' => 'objective_c',
       'elisp'       => 'common_lisp',
+      'lisp'        => 'common_lisp',
+      'lfe'         => 'common_lisp',
       'plsql'       => 'sql',
       'ecmascript'  => 'javascript',
       'perl5'       => 'perl',


### PR DESCRIPTION
See #2988

<img width="588" alt="xlisp" src="https://cloud.githubusercontent.com/assets/276834/17201032/b08efa4c-5447-11e6-8601-6e1e78fb4804.png">


@verdammelt would you eyeball this and let me know if it looks right?