### PR TITLE
Fix markdown code block display in comments. (Fixes #2915)

### DIFF
--- a/lib/exercism/converts_markdown_to_html.rb
+++ b/lib/exercism/converts_markdown_to_html.rb
@@ -5,9 +5,7 @@ class ConvertsMarkdownToHTML
   attr_reader :content
 
   def self.convert(input)
-    converter = new(input)
-    converter.convert
-    converter.content
+    new(input).convert
   end
 
   def initialize(input)
@@ -15,22 +13,26 @@ class ConvertsMarkdownToHTML
   end
 
   def convert
-    preprocess_markdown
-    convert_markdown_to_html
-    sanitize_html
+    preprocess_markdown!
+    convert_markdown_to_html!
+    sanitize_html!
   end
 
   private
 
-  def sanitize_html
+  def sanitize_html!
     @content = Loofah.fragment(@content).scrub!(:escape).to_s
   end
 
-  def convert_markdown_to_html
+  def convert_markdown_to_html!
     @content = ExercismLib::Markdown.render(@content)
   end
 
-  def preprocess_markdown
-    @content = @content.gsub(/^`{3}(.*?)`{3}$/im) { "\n#{$&}\n" }
+  def preprocess_markdown!
+    @content = filter_markdown_code_block(@content)
+  end
+
+  def filter_markdown_code_block(string)
+    string.gsub(/^`{3,}(.*?)`{3,}\s*$/m) { "\n#{$&}\n" }
   end
 end

--- a/test/exercism/converts_markdown_to_html_test.rb
+++ b/test/exercism/converts_markdown_to_html_test.rb
@@ -150,4 +150,40 @@ Post text)
     expected = "<p>&lt;3 This is lovely!</p>"
     assert_converts_to(input, expected)
   end
+
+  def test_no_newlines_before_and_after_code_in_backticks
+    input = "foo\n```ruby\nputs hi\n```\nbar"
+    expected = "<p>foo</p>\n<div class=\"highlight ruby\">\n<table style=\"border-spacing: 0;\"><tbody><tr>\n<td class=\"gutter gl\" style=\"text-align: right;\"><pre class=\"lineno\"><a href=\"#L1\">1</a></pre></td>\n<td class=\"code\"><pre><span id=\"L1\"><span class=\"nb\">puts</span> <span class=\"n\">hi</span>\n</span></pre></td>\n</tr></tbody></table>\n</div>\n\n<p>bar</p>"
+    assert_converts_to(input, expected)
+  end
+
+  def test_with_newlines_before_and_after_code_in_backticks
+    input = "foo\n\n```ruby\nputs hi\n```\n\nbar"
+    expected = "<p>foo</p>\n<div class=\"highlight ruby\">\n<table style=\"border-spacing: 0;\"><tbody><tr>\n<td class=\"gutter gl\" style=\"text-align: right;\"><pre class=\"lineno\"><a href=\"#L1\">1</a></pre></td>\n<td class=\"code\"><pre><span id=\"L1\"><span class=\"nb\">puts</span> <span class=\"n\">hi</span>\n</span></pre></td>\n</tr></tbody></table>\n</div>\n\n<p>bar</p>"
+    assert_converts_to(input, expected)
+  end
+
+  def test_no_newlines_before_and_after_code_in_backticks_without_language
+    input = "foo\n```\nputs hi\n```\nbar"
+    expected = "<p>foo</p>\n<div class=\"highlight plaintext\">\n<table style=\"border-spacing: 0;\"><tbody><tr>\n<td class=\"gutter gl\" style=\"text-align: right;\"><pre class=\"lineno\"><a href=\"#L1\">1</a></pre></td>\n<td class=\"code\"><pre><span id=\"L1\">puts hi\n</span></pre></td>\n</tr></tbody></table>\n</div>\n\n<p>bar</p>"
+    assert_converts_to(input, expected)
+  end
+
+  def test_code_in_backticks_with_carriage_returns_in_line_endings
+    input = "foo\r\n```ruby\r\nputs hi\r\n```\r\nbar"
+    expected = "<p>foo</p>\n<div class=\"highlight ruby\">\n<table style=\"border-spacing: 0;\"><tbody><tr>\n<td class=\"gutter gl\" style=\"text-align: right;\"><pre class=\"lineno\"><a href=\"#L1\">1</a></pre></td>\n<td class=\"code\"><pre><span id=\"L1\"><span class=\"nb\">puts</span> <span class=\"n\">hi</span>\n</span></pre></td>\n</tr></tbody></table>\n</div>\n\n<p>bar</p>"
+    assert_converts_to(input, expected)
+  end
+
+  def test_code_in_too_many_backticks
+    input = "too\r\n````\r\nmany\r\n`````\r\nbackticks"
+    expected = "<p>too</p>\n<div class=\"highlight plaintext\">\n<table style=\"border-spacing: 0;\"><tbody><tr>\n<td class=\"gutter gl\" style=\"text-align: right;\"><pre class=\"lineno\"><a href=\"#L1\">1</a></pre></td>\n<td class=\"code\"><pre><span id=\"L1\">many\n</span></pre></td>\n</tr></tbody></table>\n</div>\n\n<p>backticks</p>"
+    assert_converts_to(input, expected)
+  end
+
+  def test_class_convert_method
+    input = "<3 This is lovely!"
+    expected = "<p>&lt;3 This is lovely!</p>\n"
+    assert_equal expected, ConvertsMarkdownToHTML.convert(input)
+  end
 end

--- a/test/exercism/markdown_test.rb
+++ b/test/exercism/markdown_test.rb
@@ -1,6 +1,5 @@
 require_relative '../test_helper'
 require 'exercism/markdown'
-require 'exercism/converts_markdown_to_html'
 
 class MarkdownTest < Minitest::Test
   def test_mention
@@ -50,13 +49,4 @@ class MarkdownTest < Minitest::Test
                  ExercismLib::Markdown.render(markdown)
   end
 
-  def test_no_newlines_before_and_after_code
-    markdown = "foo\n```ruby\nputs hi\n```\nbar"
-    assert_match "<div class=\"highlight", ConvertsMarkdownToHTML.convert(markdown)
-  end
-
-  def test_no_newlines_before_and_after_code_without_language
-    markdown = "foo\n```\nputs hi\n```\nbar"
-    assert_match "<div class=\"highlight", ConvertsMarkdownToHTML.convert(markdown)
-  end
 end


### PR DESCRIPTION
Make markdown code blocks display the same in comments and in preview.

**Bug:** When trying to add a markdown code block to a comment on a solution the code block will show up correctly in the preview but not in the submitted comment.

**Cause:** The preview is submitted by JavaScript call and has "\n" line-breaks.
The real submit is handled by the browser using has "\r\n" line-breaks.

**Solution:** Update the code block regex to also accept "\r\n" line-breaks
Be more forgiving about what are valid characters at the end of code-block-closing backticks.

Other things this commit does:

Improves test coverage.
Adds tests for code in backticks surrounded by newlines.

Adds test coverage for convert class method.
Simplifies convert class method.

class ConvertsMarkdownToHtml now has 100% test coverage when the `test/exercism/converts_markdown_to_html_test.rb` test is run standalone.

Moves markdown conversion tests to more a appropriate location.
Removes unused dependency in `test/exercism/markdown_test.rb`