### PR TITLE
Add username and ask for password for `rake db:drop`

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -42,7 +42,7 @@ namespace :db do
       system 'psql', '-h', config.host, '-p', config.port, '-c', sql, '-d', 'postgres'
     end
 
-    system 'createdb', '-h', config.host, '-p', config.port, '-O', config.username, config.database
+    system 'createdb', '-h', config.host, '-p', config.port, '-U', config.username, config.database
     fail "Failed to create database" unless $CHILD_STATUS.success?
   end
 
@@ -51,13 +51,13 @@ namespace :db do
 
   desc "drop your database"
   task :drop do
-    system 'dropdb', '-h', config.host, config.database
+    system 'dropdb', '-h', config.host, config.database, '-U', config.username
     fail "Failed to drop database" unless $CHILD_STATUS.success?
   end
 
   desc "create your database"
   task :create do
-    system 'createdb', '-h', config.host, '-O', config.username, config.database
+    system 'createdb', '-h', config.host, config.database, '-U', config.username
     fail "Failed to create database" unless $CHILD_STATUS.success?
   end
 


### PR DESCRIPTION
`db:drop` command currently fails trying to log in with the existing
user (for me existing user is `tejas` while the db user is `exercism`).

There is no way to supply password to `createdb` and `dropdb`
commands. It prompts for password by default. Also using `-U` for user
instead of `-O` for owner.