### PR TITLE
Sort /languages/X/contribute problems by implementations

### DIFF
--- a/x/todos/todo.rb
+++ b/x/todos/todo.rb
@@ -22,6 +22,8 @@ module X
 
     def with_implementations
       todos.select { |x| x.implementations.any? }
+           .sort_by { |x| x.implementations.count }
+           .reverse
     end
 
     def any?


### PR DESCRIPTION
For #2989

This is not a `button to change` sorting as mentioned in the issue,
but a quick ruby fix which sorts them using number of implementations
by default. I think this looks good. If you think otherwise,
I can put together a button and some `javascript` to sort in place.