### PR TITLE
Fix help request display on team stream. (fixes #3018)

### DIFF
--- a/app/views/stream/_main.erb
+++ b/app/views/stream/_main.erb
@@ -33,7 +33,7 @@
             <button type="submit" class="btn btn-link discrete">mark as read</button>
           </form>
           <% end %>
-          <% if exercise.help_requested %>
+          <% if exercise.help_requested? %>
             <span class="label label-danger">Requested help</span>
           <% end %>
         </span>

--- a/lib/exercism/stream_exercise.rb
+++ b/lib/exercism/stream_exercise.rb
@@ -17,5 +17,9 @@ module Stream
     def unread?
       !@viewed
     end
+
+    def help_requested?
+      help_requested
+    end
   end
 end

--- a/lib/exercism/team_stream.rb
+++ b/lib/exercism/team_stream.rb
@@ -114,6 +114,7 @@ class TeamStream
         row["last_activity"],
         row["last_activity_at"],
         row["iteration_count"].to_i,
+        row["help_requested"] == 't',
         row["username"],
         row["avatar_url"],
       ]
@@ -191,6 +192,7 @@ class TeamStream
         ex.last_activity,
         ex.last_activity_at,
         ex.iteration_count,
+        ex.help_requested,
         u.username,
         u.avatar_url
       FROM user_exercises ex

--- a/lib/exercism/track_stream.rb
+++ b/lib/exercism/track_stream.rb
@@ -67,7 +67,6 @@ class TrackStream
         row["help_requested"] == 't',
         row["username"],
         row["avatar_url"],
-
       ]
       ex = Stream::Exercise.new(*attrs)
       exx << ex

--- a/lib/exercism/user_exercise.rb
+++ b/lib/exercism/user_exercise.rb
@@ -51,10 +51,6 @@ class UserExercise < ActiveRecord::Base
     update_attributes(archived: false)
   end
 
-  def help_requested?
-    help_requested
-  end
-
   def request_help!
     update_attributes(help_requested: true)
   end

--- a/test/exercism/stream_exercise_test.rb
+++ b/test/exercism/stream_exercise_test.rb
@@ -1,0 +1,52 @@
+require_relative '../test_helper'
+require 'exercism'
+
+class StreamExerciseTest < Minitest::Test
+
+  # Also not constructed :/
+  def test_comment_count
+    exercise = Stream::Exercise.new()
+
+    expected = 0
+    new_value = 5
+
+    assert_equal expected, exercise.comment_count
+    exercise.comment_count = new_value
+    assert_equal new_value, exercise.comment_count
+
+  end
+
+  def test_at
+    date = '2016-08-01'
+    args = [:id, :uuid, :problem, :last_activity, date, :iteration_count, :last_activity_at, :help_requested, :avatar_url]
+    exercise = Stream::Exercise.new(*args)
+    expected = date.to_datetime
+    assert_equal expected, exercise.at
+  end
+
+  # It's not possible to construct a viewed exercise.
+  def test_viewed!
+    # See test_unread?
+  end
+
+  # It's not possible to construct an viewed exercise.
+  def test_unread?
+    exercise = Stream::Exercise.new()
+    assert exercise.unread?
+    exercise.viewed!
+    refute exercise.unread?
+  end
+
+  def test_help_requested_false?
+    args = []
+    exercise = Stream::Exercise.new(*args)
+    refute exercise.help_requested?
+  end
+
+  def test_help_requested_true?
+    args = [:id, :uuid, :problem, :last_activity, :last_activity_at, :iteration_count, :last_activity_at, :help_requested, :avatar_url]
+    exercise = Stream::Exercise.new(*args)
+    assert exercise.help_requested?, 'Help should be requested'
+  end
+
+end


### PR DESCRIPTION
`help_requested` also needs to be implemented in track_stream due to the code duplication between track_stream and team_stream.