### PR TITLE
Bugfix: Make core 500 error handler work for Guests (fixes #3002)

### DIFF
--- a/app/routes/core.rb
+++ b/app/routes/core.rb
@@ -28,7 +28,7 @@ module ExercismWeb
           },
           context: request.path_info,
           app: {
-            version: ENV["BUILD_ID"] || "unknown",
+            version: BUILD_ID,
           },
         }
         Bugsnag.auto_notify($ERROR_INFO, metadata, request)

--- a/lib/exercism/guest.rb
+++ b/lib/exercism/guest.rb
@@ -1,5 +1,11 @@
+require 'exercism/user_exercise'
+
 class Guest
   def id
+  end
+
+  def username
+    'guest'
   end
 
   def fetched?

--- a/test/exercism/guest_test.rb
+++ b/test/exercism/guest_test.rb
@@ -1,8 +1,51 @@
 require_relative '../test_helper'
+require_relative '../active_record_helper'
 require 'exercism/guest'
 
 class GuestTest < Minitest::Test
-  def test_guest_is_guest
-    assert Guest.new.guest?
+  def test_guest?
+    subject = Guest.new
+    assert subject.guest?
+  end
+
+  def test_id
+    subject = Guest.new
+    assert_nil subject.id
+  end
+
+  def test_username
+    subject = Guest.new
+    assert_equal 'guest', subject.username
+  end
+
+  def test_show_dailies?
+    subject = Guest.new
+    refute subject.show_dailies?
+  end
+
+  def test_onboarded?
+    subject = Guest.new
+    refute subject.onboarded?
+  end
+
+  def test_owns?
+    subject = Guest.new
+    refute subject.owns?('anything')
+  end
+
+  def test_access?
+    subject = Guest.new
+    refute subject.access?('anything')
+  end
+
+  def test_fetched?
+    subject = Guest.new
+    refute subject.fetched?
+  end
+
+  def test_exercises
+    subject = Guest.new
+    expected = UserExercise.where('1=2')
+    assert_equal expected, subject.exercises
   end
 end


### PR DESCRIPTION
The error handler was erroring if the user was not logged in because the Guest class did not have a `username` method.

Add `username` method to Guest.
100% unit test coverage of Guest

Also, `BUILD_ID` is now availiable as a constant so use that instead of the environment variable.
