### PR TITLE
Adds a note regarding running PostgreSQL in the background

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ First, you need to get ahold of the code, so you have a copy of it locally that 
 
 ### Configuration
 
-In most cases, it is easiest to run the `bin/setup` script to automatically setup the defaults for the application.
+In most cases, it is easiest to run the `bin/setup` script to automatically setup the defaults for the application. Make sure you have PostgreSQL running in the background.
 
 The script will:
 


### PR DESCRIPTION
I just went through the instruction to set up the app locally, and didn't have Postgres running, which of course gave me errors. To help others avoid confusion, I figured it would be good to mention that the DB needs to be running before executing the setup script.

Since it's a one line change in a markdown file, I didn't branch. I'll resubmit if you prefer I do it properly.