### PR TITLE
Case insensitive solution paths (Fixes #2468)

### DIFF
--- a/api/v1/routes/iterations.rb
+++ b/api/v1/routes/iterations.rb
@@ -65,7 +65,7 @@ module ExercismAPI
             # nothing we can do.
             halt 400, "please upgrade your exercism command-line client"
           end
-          data['language'] = segments[0]
+          data['language'] = segments[0].downcase
           data['problem'] = segments[1]
           data['path'] = segments[2..-1].join("/")
         end

--- a/lib/exercism/iteration.rb
+++ b/lib/exercism/iteration.rb
@@ -8,7 +8,7 @@ class Iteration
 
     @solution = {}
     solution.each do |path, contents|
-      filename = path.split(/\\|\//).join('/').gsub(/^\/?#{track_id}\/#{slug}\//, "")
+      filename = path.split(/\\|\//).join('/').gsub(/^\/?#{track_id}\/#{slug}\//i, "")
       @solution[filename] = contents.strip
     end
   end

--- a/test/api/iterations_test.rb
+++ b/test/api/iterations_test.rb
@@ -141,4 +141,23 @@ class IterationsApiTest < Minitest::Test
     expected = { "binary.go" => "Hello, World!" }
     assert_equal expected, submission.solution
   end
+
+  def test_submit_problem_with_mixed_case_track_and_no_language
+    submission = {
+      "key" => @alice.key,
+      "path" => "/Go/binary/binary.go",
+      "code" => "Hello, World!",
+      "dir" => "/path/to/exercism/dir",
+    }
+
+    Xapi.stub(:exists?, true) do
+      post '/user/assignments', submission.to_json
+    end
+
+    submission = Submission.first
+    assert_equal "binary", submission.slug
+    expected = { "binary.go" => "Hello, World!" }
+    assert_equal expected, submission.solution
+    assert_equal "go", submission.language
+  end
 end

--- a/test/exercism/iteration_test.rb
+++ b/test/exercism/iteration_test.rb
@@ -33,4 +33,13 @@ class IterationTest < Minitest::Test
     }
     assert_equal expected_solution, iteration.solution
   end
+
+  def test_path_filter_is_case_insensitive
+    fixture = { filename: 'somefile.rb', content: 'some ruby code'}
+    solution = { "Ruby/One/#{fixture[:filename]}" => fixture[:content]}
+    iteration = Iteration.new(solution, 'ruby', 'one')
+    expected_solution = { fixture[:filename] => fixture[:content] }
+    assert_equal expected_solution, iteration.solution
+  end
+
 end


### PR DESCRIPTION
When using an old version of the CLI that does not submit the track id
as part of the data, Exercism tries to guess the track from the path of
the submitted filename.

However paths could come in with mixed case names and since all language
track_id's are lowercase track_id matching would fail.

This patch makes sure the deduced track_id is all lowercase.

This also required modification to the Iteration class due to
duplication of path parsing logic.