### PR TITLE
Exclude node_modules/* from Rubocop scan

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'frontend/**/*'
     - 'vendor/**/*'
     - 'test/**/*'
+    - 'node_modules/**/*'
 Style/IfUnlessModifier:
   Enabled: false
 Style/DoubleNegation:


### PR DESCRIPTION
`node_modules` includes `lineman` which contains some Rakefiles that
Rubocop does not like. Since these are vendor provided we will not lint
them ourselves.

(This issue is not present during CI because the Rubocop scan is run
BEFORE the node modules are installed.)