### PR TITLE
Only (git)ignore root vendor path.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ db/seeds.sql
 db/schema.sql
 db/migrations.sql
 Procfile_Vagrant
-vendor
+/vendor
 
 # JavaScript
 node_modules


### PR DESCRIPTION
Local versions of Ruby gems can be installed in /vendor and should be ignored.

Some of the js assets live in frontend/vendor/js and need to be able to be checked in.