### PR TITLE
add link to newsletter archive on site index

### DIFF
--- a/app/views/site/index.erb
+++ b/app/views/site/index.erb
@@ -160,7 +160,7 @@
     <div class="row">
       <div class="col-md-8">
         <p>Exercism is many things: An experiment. A bunch of interesting people. Chaotic. An open source project.</p>
-        <p>If you want an informal glimpse into how things are going and what's going on, <a href="https://tinyletter.com/exercism">sign up for the "behind the scenes" mailing list</a>. You'll receive regular-ish emails with stories, musings, and updates.</p>
+        <p>If you want an informal glimpse into how things are going and what's going on, <a href="https://tinyletter.com/exercism">sign up for the "behind the scenes" mailing list</a>. You'll receive regular-ish emails with <a href="https://tinyletter.com/exercism/archive">stories, musings, and updates</a>.</p>
       </div>
       <div class="col-md-4">
 


### PR DESCRIPTION
closes #3038
adds link as suggested

[update]
before:
<img width="1278" alt="screen shot 2016-08-08 at 9 44 30 pm" src="https://cloud.githubusercontent.com/assets/8152930/17501985/12b4fc30-5db2-11e6-861f-af9857c0169f.png">

after:
<img width="1280" alt="screen shot 2016-08-08 at 9 45 25 pm" src="https://cloud.githubusercontent.com/assets/8152930/17501986/169888f8-5db2-11e6-95c9-5bc896d8901d.png">
