### PR TITLE
Properly handle multiline comments (or any other tokens that span more than one line)

### DIFF
--- a/lib/rouge/formatters/html_exercism.rb
+++ b/lib/rouge/formatters/html_exercism.rb
@@ -75,7 +75,7 @@ module Rouge
       }.freeze
 
       def span(tok, val)
-        val = val.gsub(/[&<>]/, TABLE_FOR_ESCAPE_HTML)
+        val = html_escaped(val)
         shortname = tok.shortname or fail "unknown token: #{tok.inspect} for #{val.inspect}"
         if shortname.empty?
           yield val
@@ -118,7 +118,7 @@ module Rouge
         tokens.each do |tok, val|
           # Some tokens span multiple lines, such as Python triplequoted strings, or
           # delimited comments in other languages.
-          html_escaped(val).lines.each do |line|
+          val.lines.each do |line|
             # Wrap each line of this token in the same class
             span(tok, line) { |str| formatted << str }
 

--- a/lib/rouge/formatters/html_exercism.rb
+++ b/lib/rouge/formatters/html_exercism.rb
@@ -59,8 +59,16 @@ module Rouge
 
         tokens.each do |tok, val|
           last_val = val
-          num_lines += val.scan(/\n/).size
-          span(tok, val) { |str| formatted << str }
+          lines = val.scan(/\n/).size
+          if lines > 1
+            val.split(/\n/).each do |line|
+              span(tok, line) { |str| formatted << str }
+              formatted << "\n"
+            end
+          else
+            span(tok, val) { |str| formatted << str }
+          end
+          num_lines += lines
         end
 
         formatted = formatted.lines.map.with_index(1) do |line, index|

--- a/lib/rouge/formatters/html_exercism.rb
+++ b/lib/rouge/formatters/html_exercism.rb
@@ -128,7 +128,7 @@ module Rouge
             formatted << end_line << start_line(line_counter)
           end
         end
-        formatted << end_line
+        formatted.gsub(start_line(line_counter), '')
       end
 
       def count_newlines(tokens)

--- a/lib/rouge/formatters/html_exercism.rb
+++ b/lib/rouge/formatters/html_exercism.rb
@@ -51,62 +51,22 @@ module Rouge
         yield "</code></pre>\n" if @wrap
       end
 
-      # rubocop:disable Metrics/AbcSize, MethodLength
       def stream_tableized(tokens)
-        num_lines = 0
-        last_val = ''
-        formatted = ''
-
-        tokens.each do |tok, val|
-          last_val = val
-          lines = val.scan(/\n/).size
-          if lines > 1
-            val.split(/\n/).each do |line|
-              span(tok, line) { |str| formatted << str }
-              formatted << "\n"
-            end
-          else
-            span(tok, val) { |str| formatted << str }
-          end
-          num_lines += lines
-        end
-
-        formatted = formatted.lines.map.with_index(1) do |line, index|
-          "<span id='#{@line_numbers_id}#{index}'>#{line}</span>"
-        end.join
-
-        # add an extra line for non-newline-terminated strings
-        if last_val[-1] != "\n"
-          num_lines += 1
-          span(Token::Tokens::Text::Whitespace, "\n") { |str| formatted << str }
-        end
-
-        # wrap line numbers with <a> tags
-        line_numbers = (@start_line..num_lines + @start_line - 1).map do |number|
-          "<a href=\"#L#{number}\">#{number}</a>"
-        end
-
-        # generate a string of newline-separated line numbers for the gutter>
-        gutter = %(<pre class="lineno">#{line_numbers.join("\n")}</pre>)
+        num_lines = count_newlines(tokens)
 
         yield "<div#{@css_class}>" if @wrap
         yield '<table style="border-spacing: 0"><tbody><tr>'
 
         # the "gl" class applies the style for Generic.Lineno
-        yield '<td class="gutter gl" style="text-align: right">'
-        yield gutter
-        yield '</td>'
+        yield '<td class="gutter gl" style="text-align: right">' << gutter(num_lines) << '</td>'
 
         yield '<td class="code">'
-        yield '<pre>'
-        yield formatted
-        yield '</pre>'
+        yield '<pre>' << formatted_code(tokens, @start_line) << '</pre>'
         yield '</td>'
 
         yield "</tr></tbody></table>\n"
         yield "</div>\n" if @wrap
       end
-      # rubocop:enable Metrics/AbcSize, MethodLength
 
       TABLE_FOR_ESCAPE_HTML = {
         '&' => '&amp;',
@@ -117,16 +77,62 @@ module Rouge
       def span(tok, val)
         val = val.gsub(/[&<>]/, TABLE_FOR_ESCAPE_HTML)
         shortname = tok.shortname or fail "unknown token: #{tok.inspect} for #{val.inspect}"
-
         if shortname.empty?
           yield val
         elsif @inline_theme
           rules = @inline_theme.style_for(tok).rendered_rules
-
           yield "<span style=\"#{rules.to_a.join(';')}\">#{val}</span>"
         else
           yield "<span class=\"#{shortname}\">#{val}</span>"
         end
+      end
+
+      def start_line(num)
+        %(<span id="L#{num}">)
+      end
+
+      def end_line
+        "</span>"
+      end
+
+      def line_numbers(num_lines)
+        # wrap line numbers with <a> tags
+        (@start_line..num_lines + @start_line - 1).map do |number|
+          "<a href=\"#L#{number}\">#{number}</a>"
+        end
+      end
+
+      def gutter(num_lines)
+        # generate a string of newline-separated line numbers for the gutter>
+        %(<pre class="lineno">#{line_numbers(num_lines).join("\n")}</pre>)
+      end
+
+      def html_escaped(text)
+        text.gsub(/[&<>]/, TABLE_FOR_ESCAPE_HTML)
+      end
+
+      def formatted_code(tokens, line_counter)
+        # Reuse argument as line counter
+        formatted = start_line(line_counter)
+
+        tokens.each do |tok, val|
+          # Some tokens span multiple lines, such as Python triplequoted strings, or
+          # delimited comments in other languages.
+          html_escaped(val).lines.each do |line|
+            # Wrap each line of this token in the same class
+            span(tok, line) { |str| formatted << str }
+
+            # Increase line number only when the actual token text contained a newline
+            next unless line.include? "\n"
+            line_counter += 1
+            formatted << end_line << start_line(line_counter)
+          end
+        end
+        formatted << end_line
+      end
+
+      def count_newlines(tokens)
+        tokens.inject(0) { |acc, (_, val)| acc + val.scan("\n").size }
       end
     end
   end

--- a/test/exercism/converts_markdown_to_html_test.rb
+++ b/test/exercism/converts_markdown_to_html_test.rb
@@ -125,12 +125,12 @@ Post text)
 <a href="#L2">2</a>
 <a href="#L3">3</a></pre></td>
 <td class="code"><pre><span id="L1"><span class="p">(</span><span class="k">defn</span><span class="w"> </span><span class="n">to-rna</span><span class="w">
-</span><span id="L2">  </span><span class="p">[</span><span class="n">dna-string</span><span class="p">]</span><span class="w">
-</span><span id="L3">  </span><span class="p">(</span><span class="nf">clojure.string/replace</span><span class="w"> </span><span class="n">dna-string</span><span class="w"> </span><span class="sc">\T</span><span class="w"> </span><span class="sc">\U</span><span class="p">))</span><span class="w">
-</span><span id="L4"></span></span></pre></td>
+</span></span><span id="L2"><span class="w">  </span><span class="p">[</span><span class="n">dna-string</span><span class="p">]</span><span class="w">
+</span></span><span id="L3"><span class="w">  </span><span class="p">(</span><span class="nf">clojure.string/replace</span><span class="w"> </span><span class="n">dna-string</span><span class="w"> </span><span class="sc">\T</span><span class="w"> </span><span class="sc">\U</span><span class="p">))</span><span class="w">
+</span></span></pre></td>
 </tr></tbody></table>
 </div>'
-    assert_converts_to(input, expected)
+    assert_converts_to(input.strip, expected)
   end
 
   def test_stubby_lambda

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -1,4 +1,3 @@
-require 'byebug'
 require_relative '../test_helper'
 require 'rouge'
 require 'loofah'

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -1,0 +1,38 @@
+require_relative '../test_helper'
+require 'byebug'
+require 'rouge'
+require 'loofah'
+require_relative '../../lib/rouge/formatters/html_exercism'
+
+class HTMLFormatterTest < MiniTest::Test
+  def setup
+  end
+
+  def test_ocaml_comment
+    code = %{
+    (* reverse the first list, then prepend it to the second list. (In
+       other words, one by one, move the head of the first list onto the head
+       of the second.) *)
+    let rec backward_prepend = function
+    | ([], lst) -> ([], lst)
+    | (hd::tl, lst) -> backward_prepend (tl, hd::lst)
+    }.gsub('    ', '')
+    raw_lines = code.split "\n"
+
+    lexer = Rouge::Lexer.find_fancy('ocaml')
+    formatter = Rouge::Formatters::HTMLExercism.new(line_numbers: true)
+
+    lexemes = lexer.lex(code)
+    output = formatter.format(lexemes)
+
+    doc = Loofah::HTML::DocumentFragment.parse(output)
+
+    assert_equal 3, doc.css('span.c').size, "Multiline comment should be split into individual lines with proper style"
+    assert_equal 8, doc.css('span[id^=L]').size, "Comments are not properly included in line count"
+
+    (2..4).each do |lineno|
+      line = doc.css("span[id=L#{lineno}]")
+      assert_equal raw_lines[lineno - 1], line.text.rstrip,  "Comment text in line #{lineno} should be preserved"
+    end
+  end
+end

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -11,7 +11,7 @@ class HTMLFormatterTest < MiniTest::Test
   def test_ocaml_comment
     load_sample 'ocaml', 'ocaml'
 
-    assert_equal 7, @doc.css('span[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal 6, @doc.css('span[id^=L]').size, "Formatting should preserve linecount"
     assert_equal 3, @doc.css('span.c').size, "Multiline comment should be split into individual lines with proper style"
 
     (1..3).each do |lineno|
@@ -24,7 +24,7 @@ class HTMLFormatterTest < MiniTest::Test
   def test_python_docstring
     load_sample 'python', 'python'
 
-    assert_equal 13, @doc.css('span[id^=L]').size, "Formatting should preserve linecount but add terminating line"
+    assert_equal 12, @doc.css('span[id^=L]').size, "Formatting should preserve linecount"
     assert_equal 3, @doc.css('span.s').size, "There should be exactly 3 string tokens in the code"
     assert_equal '', @doc.css('span#L4').text.rstrip, "Line 4 should be blank"
     assert_equal '', @doc.css('span#L5').text.rstrip, "Line 5 should be blank"
@@ -41,8 +41,8 @@ class HTMLFormatterTest < MiniTest::Test
     @raw_lines = code.lines
     lexer = get_lexer language
 
-    lexemes = lexer.lex(code)
-    @output = @formatter.format(lexemes)
+    @lexemes = lexer.lex(code)
+    @output = @formatter.format(@lexemes)
 
     @doc = Loofah::HTML::DocumentFragment.parse(@output)
   end

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -1,5 +1,4 @@
 require_relative '../test_helper'
-require 'byebug'
 require 'rouge'
 require 'loofah'
 require_relative '../../lib/rouge/formatters/html_exercism'

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -1,3 +1,4 @@
+require 'byebug'
 require_relative '../test_helper'
 require 'rouge'
 require 'loofah'
@@ -5,33 +6,50 @@ require_relative '../../lib/rouge/formatters/html_exercism'
 
 class HTMLFormatterTest < MiniTest::Test
   def setup
+    @formatter = Rouge::Formatters::HTMLExercism.new line_numbers: true
   end
 
   def test_ocaml_comment
-    code = %{
-    (* reverse the first list, then prepend it to the second list. (In
-       other words, one by one, move the head of the first list onto the head
-       of the second.) *)
-    let rec backward_prepend = function
-    | ([], lst) -> ([], lst)
-    | (hd::tl, lst) -> backward_prepend (tl, hd::lst)
-    }.gsub('    ', '')
-    raw_lines = code.split "\n"
+    load_sample 'ocaml', 'ocaml'
 
-    lexer = Rouge::Lexer.find_fancy('ocaml')
-    formatter = Rouge::Formatters::HTMLExercism.new(line_numbers: true)
+    assert_equal 7, @doc.css('span[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal 3, @doc.css('span.c').size, "Multiline comment should be split into individual lines with proper style"
+
+    (1..3).each do |lineno|
+      line = @doc.css("span[id=L#{lineno}]").text.rstrip
+      original_line = @raw_lines[lineno - 1].rstrip
+      assert_equal original_line, line,  "Comment text in line #{lineno} should be preserved"
+    end
+  end
+
+  def test_python_docstring
+    load_sample 'python', 'python'
+
+    assert_equal 13, @doc.css('span[id^=L]').size, "Formatting should preserve linecount but add terminating line"
+    assert_equal 3, @doc.css('span.s').size, "There should be exactly 3 string tokens in the code"
+    assert_equal '', @doc.css('span#L4').text.rstrip, "Line 4 should be blank"
+    assert_equal '', @doc.css('span#L5').text.rstrip, "Line 5 should be blank"
+  end
+
+  private
+
+  def get_lexer(language)
+    Rouge::Lexer.find_fancy language
+  end
+
+  def load_sample(name, language)
+    code = load_example name
+    @raw_lines = code.lines
+    lexer = get_lexer language
 
     lexemes = lexer.lex(code)
-    output = formatter.format(lexemes)
+    @output = @formatter.format(lexemes)
 
-    doc = Loofah::HTML::DocumentFragment.parse(output)
+    @doc = Loofah::HTML::DocumentFragment.parse(@output)
+  end
 
-    assert_equal 3, doc.css('span.c').size, "Multiline comment should be split into individual lines with proper style"
-    assert_equal 8, doc.css('span[id^=L]').size, "Comments are not properly included in line count"
-
-    (2..4).each do |lineno|
-      line = doc.css("span[id=L#{lineno}]")
-      assert_equal raw_lines[lineno - 1], line.text.rstrip,  "Comment text in line #{lineno} should be preserved"
-    end
+  def load_example(name)
+    path = File.join(File.expand_path('../../fixtures/code_formatting', __FILE__), name)
+    File.read path
   end
 end

--- a/test/fixtures/approvals/markdown_double_braces.approved.txt
+++ b/test/fixtures/approvals/markdown_double_braces.approved.txt
@@ -2,6 +2,6 @@
 <table style="border-spacing: 0;"><tbody><tr>
 <td class="gutter gl" style="text-align: right;"><pre class="lineno"><a href="#L1">1</a></pre></td>
 <td class="code"><pre><span id="L1"><span class="p">{</span><span class="err">{x:</span><span class="w"> </span><span class="err">y</span><span class="p">}</span><span class="err">}</span><span class="w">
-</span><span id="L2"></span></span></pre></td>
+</span></span></pre></td>
 </tr></tbody></table>
 </div>

--- a/test/fixtures/code_formatting/ocaml
+++ b/test/fixtures/code_formatting/ocaml
@@ -1,0 +1,6 @@
+(* reverse the first list, then prepend it to the second list. (In
+   other words, one by one, move the head of the first list onto the head
+   of the second.) *)
+let rec backward_prepend = function
+| ([], lst) -> ([], lst)
+| (hd::tl, lst) -> backward_prepend (tl, hd::lst)

--- a/test/fixtures/code_formatting/python
+++ b/test/fixtures/code_formatting/python
@@ -1,0 +1,12 @@
+"""
+Implementation of the "word-count" exercise.
+"""
+
+
+def word_count(phrase):
+    book = {}
+    for word in phrase.split():
+        if word not in book:
+            book[word] = 0
+        book[word] += 1
+    return book


### PR DESCRIPTION
This adresses #3044, and possibly also #2891, although I haven't tested for that yet.

The solution is to check if a returned token has newlines inside, and if so, produce as many style span elements as there are lines, following each one with a newline. This in turn gets properly wrapped in line-numbers.