### PR TITLE
Code missing final newline was highlighted incorrectly.

### DIFF
--- a/lib/rouge/formatters/html_exercism.rb
+++ b/lib/rouge/formatters/html_exercism.rb
@@ -128,11 +128,20 @@ module Rouge
             formatted << end_line << start_line(line_counter)
           end
         end
-        formatted.gsub(start_line(line_counter), '')
+        adjust_final_lines formatted, line_counter
+      end
+
+      def adjust_final_lines(formatted, line_counter)
+        formatted << end_line
+        formatted.gsub final_blank_line(line_counter), ''
       end
 
       def count_newlines(tokens)
         tokens.inject(0) { |acc, (_, val)| acc + val.scan("\n").size }
+      end
+
+      def final_blank_line(counter)
+        start_line(counter) + end_line
       end
     end
   end

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -19,6 +19,7 @@ class HTMLFormatterTest < MiniTest::Test
       original_line = @raw_lines[lineno - 1].rstrip
       assert_equal original_line, line,  "Comment text in line #{lineno} should be preserved"
     end
+
   end
 
   def test_python_docstring
@@ -28,6 +29,16 @@ class HTMLFormatterTest < MiniTest::Test
     assert_equal 3, @doc.css('span.s').size, "There should be exactly 3 string tokens in the code"
     assert_equal '', @doc.css('span#L4').text.rstrip, "Line 4 should be blank"
     assert_equal '', @doc.css('span#L5').text.rstrip, "Line 5 should be blank"
+
+  end
+
+  def test_swift
+    load_sample 'swift', 'swift'
+
+    assert_equal 121, @doc.css('span[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal "}", @doc.css('span#L121').text.rstrip, "Line 121 should have only a closing brace"
+    assert_equal "    }", @doc.css('span#L120').text.rstrip, "Line 120 should have a four space indent and closing brace"
+
   end
 
   private
@@ -37,11 +48,11 @@ class HTMLFormatterTest < MiniTest::Test
   end
 
   def load_sample(name, language)
-    code = load_example name
-    @raw_lines = code.lines
+    @code = load_example name
+    @raw_lines = @code.lines
     lexer = get_lexer language
 
-    @lexemes = lexer.lex(code)
+    @lexemes = lexer.lex(@code)
     @output = @formatter.format(@lexemes)
 
     @doc = Loofah::HTML::DocumentFragment.parse(@output)

--- a/test/fixtures/code_formatting/swift
+++ b/test/fixtures/code_formatting/swift
@@ -1,0 +1,121 @@
+//
+//  PhoneNumber.swift
+//  PhoneNumber
+//
+//  Created by Tom Holland on 8/13/16.
+//  Copyright © 2016 Tom Holland. All rights reserved.
+//
+import Foundation
+
+///
+/// Represents a United States Phone Number
+///
+struct PhoneNumber: CustomStringConvertible
+{
+    private let phoneNumber: PhoneNumberComponents?
+
+    init(_ _phoneNumber: String)
+    {
+        let trimmedNumber = _phoneNumber
+            .components(separatedBy: CharacterSet(charactersIn: "0123456789").inverted)
+            .joined(separator: "")
+
+        if let components = PhoneNumberComponents(withString: trimmedNumber)
+        {
+            self.phoneNumber = components
+
+        } else {
+
+            self.phoneNumber = PhoneNumberComponents(withString: "0000000000")
+        }
+    }
+
+    ///
+    /// The Phone Number's digits without formatting
+    ///
+    var number: String
+    {
+        return "\(self.phoneNumber!.areaCode)\(self.phoneNumber!.prefix)\(self.phoneNumber!.line)"
+    }
+
+    ///
+    /// The Phone Number's Area Code digits without formatting
+    ///
+    var areaCode: String
+    {
+        return "\(self.phoneNumber!.areaCode)"
+    }
+
+    ///
+    /// The Phone Number digits formatted in standard U.S. format
+    ///
+    /// This is a custom string value for this type
+    ///
+    var description: String
+    {
+        return "(\(self.phoneNumber!.areaCode)) \(self.phoneNumber!.prefix)-\(self.phoneNumber!.line)"
+    }
+}
+
+///
+/// Represents the components of a U.S. Phone Number - area code, prefix and line
+///
+struct PhoneNumberComponents {
+
+    private let number: String
+
+    ///
+    /// Optional initializer will only instantiate with valid input string
+    ///
+    init?(withString _number: String) {
+
+        // The number must be 10 or 11 digits long
+        guard 10...11 ~= _number.characters.count else
+        {
+            return nil
+        }
+
+        if _number.characters.count == 11
+        {
+            // Make sure that the first 2 digits are "11"
+            guard "11" == _number.substring(to: _number.index(_number.startIndex, offsetBy: 2)) else
+            {
+                return nil
+            }
+
+            // First 2 digits are "11" so we need to trim the first "1"
+            self.number = _number.substring(from: _number.index(_number.startIndex, offsetBy: 1))
+
+        } else {
+
+            // Good to go!
+            self.number = _number
+        }
+    }
+
+    ///
+    /// The Phone Number's Area Code component
+    ///
+    var areaCode: String
+    {
+        return self.number.substring(to: self.number.index(self.number.startIndex, offsetBy: 3))
+    }
+
+    ///
+    /// The Phone Number's Prefix component
+    ///
+    var prefix: String
+    {
+        let prefixRange = self.number.index(self.number.startIndex, offsetBy: 3)..<self.number.index(self.number.startIndex, offsetBy: 6)
+
+        return self.number.substring(with: prefixRange)
+    }
+
+    ///
+    /// The Phone Number's Line Number component
+    ///
+    var line: String
+    {
+        return self.number.substring(from: self.number.index(self.number.endIndex, offsetBy: -4))
+    }
+}


### PR DESCRIPTION
Addresses #3050.

The issue here was that, for input missing the final newline, the final increment line step was not performed. This time we always finish the line on end of token stream, possibly introducing a blank one, but then strip it out entirely. If the final line was not blank, the strip does nothing.

The swift example file included contains @codesman's submission code verbatim. If using it here due to copyrights is an issue, we can easily replace it with something else. Also note that it has no final newline (and should not have one), which is important to this issue.