### PR TITLE
Simplify syntax highlighter and add support for multiline comments/tokens

### DIFF
--- a/lib/exercism/syntax_highlighter.rb
+++ b/lib/exercism/syntax_highlighter.rb
@@ -34,12 +34,7 @@ module ExercismLib
     end
 
     def formatter
-      options = {
-        css_class:    "highlight #{lexer.tag}",
-        line_numbers: true,
-      }
-
-      Rouge::Formatters::HTMLExercism.new(options)
+      Rouge::Formatters::HTMLExercism.new(css_class: "highlight #{lexer.tag}")
     end
 
     def normalize_language(language)

--- a/lib/rouge/formatters/html_exercism.rb
+++ b/lib/rouge/formatters/html_exercism.rb
@@ -6,6 +6,8 @@ module Rouge
     class HTMLExercism < Formatter
       tag 'html'
 
+      attr_reader :num_lines
+
       # @option opts [String] :css_class ('highlight')
       # @option opts [true/false] :line_numbers (false)
       # @option opts [String] :line_numbers_id ('L')
@@ -32,10 +34,13 @@ module Rouge
         @inline_theme = Theme.find(@inline_theme).new if @inline_theme.is_a? String
 
         @wrap = opts.fetch(:wrap, true)
+
+        @html_formatter = Rouge::Formatters::HTML.new
       end
 
-      # @yield the html output.
       def stream(tokens, &b)
+        @num_lines = token_lines(tokens).count
+
         if @line_numbers
           stream_tableized(tokens, &b)
         else
@@ -43,81 +48,60 @@ module Rouge
         end
       end
 
-      private
-
       def stream_untableized(tokens, &b)
         yield "<pre#{@css_class}><code>" if @wrap
         tokens.each { |tok, val| span(tok, val, &b) }
         yield "</code></pre>\n" if @wrap
       end
 
-      # rubocop:disable Metrics/AbcSize, MethodLength
-      def stream_tableized(tokens)
-        num_lines = 0
-        last_val = ''
-        formatted = ''
-
-        tokens.each do |tok, val|
-          last_val = val
-          num_lines += val.scan(/\n/).size
-          span(tok, val) { |str| formatted << str }
-        end
-
-        formatted = formatted.lines.map.with_index(1) do |line, index|
-          "<span id='#{@line_numbers_id}#{index}'>#{line}</span>"
-        end.join
-
-        # add an extra line for non-newline-terminated strings
-        if last_val[-1] != "\n"
-          num_lines += 1
-          span(Token::Tokens::Text::Whitespace, "\n") { |str| formatted << str }
-        end
-
-        # wrap line numbers with <a> tags
-        line_numbers = (@start_line..num_lines + @start_line - 1).map do |number|
-          "<a href=\"#L#{number}\">#{number}</a>"
-        end
-
-        # generate a string of newline-separated line numbers for the gutter>
-        gutter = %(<pre class="lineno">#{line_numbers.join("\n")}</pre>)
-
+      def stream_tableized(tokens, &b)
         yield "<div#{@css_class}>" if @wrap
         yield '<table style="border-spacing: 0"><tbody><tr>'
 
         # the "gl" class applies the style for Generic.Lineno
-        yield '<td class="gutter gl" style="text-align: right">'
-        yield gutter
-        yield '</td>'
+        yield '<td class="gutter gl" style="text-align: right">' << gutter << '</td>'
 
         yield '<td class="code">'
         yield '<pre>'
-        yield formatted
+        format_code(tokens, &b)
         yield '</pre>'
         yield '</td>'
 
         yield "</tr></tbody></table>\n"
         yield "</div>\n" if @wrap
       end
-      # rubocop:enable Metrics/AbcSize, MethodLength
 
-      TABLE_FOR_ESCAPE_HTML = {
-        '&' => '&amp;',
-        '<' => '&lt;',
-        '>' => '&gt;',
-      }.freeze
+      private
 
-      def span(tok, val)
-        val = val.gsub(/[&<>]/, TABLE_FOR_ESCAPE_HTML)
-        shortname = tok.shortname or fail "unknown token: #{tok.inspect} for #{val.inspect}"
+      def format_code(tokens)
+        # Very similar to Rouge::Formatters::HTMLLinewise#stream, which is not customizable enough
+        token_lines(tokens) do |line|
+          yield next_line
+          line.each do |tok, val|
+            yield @html_formatter.span(tok, val)
+          end
+          yield end_line
+        end
+      end
 
-        if shortname.empty?
-          yield val
-        elsif @inline_theme
-          rules = @inline_theme.style_for(tok).rendered_rules
+      def next_line
+        @lineno ||= @start_line - 1
+        %(<span id="#{@line_numbers_id}#{@lineno += 1}">)
+      end
 
-          yield "<span style=\"#{rules.to_a.join(';')}\">#{val}</span>"
-        else
-          yield "<span class=\"#{shortname}\">#{val}</span>"
+      def end_line
+        # NOTE: the newline is for test compatibility.
+        # It's unnecessary for presentation if we use divs instead (and display: block for lines)
+        "\n</span>"
+      end
+
+      def gutter
+        %(<pre class="lineno">#{line_numbers.join("\n")}</pre>)
+      end
+
+      def line_numbers
+        (@start_line..num_lines + @start_line - 1).map do |number|
+          "<a href=\"##{@line_numbers_id}#{number}\">#{number}</a>"
         end
       end
     end

--- a/test/exercism/converts_markdown_to_html_test.rb
+++ b/test/exercism/converts_markdown_to_html_test.rb
@@ -118,19 +118,7 @@ Post text)
   (clojure.string/replace dna-string \T \U))
 ```'
 
-    expected = '<p>Check out this code:</p>
-<div class="highlight clojure">
-<table style="border-spacing: 0;"><tbody><tr>
-<td class="gutter gl" style="text-align: right;"><pre class="lineno"><a href="#L1">1</a>
-<a href="#L2">2</a>
-<a href="#L3">3</a></pre></td>
-<td class="code"><pre><span id="L1"><span class="p">(</span><span class="k">defn</span><span class="w"> </span><span class="n">to-rna</span><span class="w">
-</span><span id="L2">  </span><span class="p">[</span><span class="n">dna-string</span><span class="p">]</span><span class="w">
-</span><span id="L3">  </span><span class="p">(</span><span class="nf">clojure.string/replace</span><span class="w"> </span><span class="n">dna-string</span><span class="w"> </span><span class="sc">\T</span><span class="w"> </span><span class="sc">\U</span><span class="p">))</span><span class="w">
-</span><span id="L4"></span></span></pre></td>
-</tr></tbody></table>
-</div>'
-    assert_converts_to(input, expected)
+    Approvals.verify(ConvertsMarkdownToHTML.new(input).convert, name: 'markdown_with_clojure_code')
   end
 
   def test_stubby_lambda

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -38,9 +38,9 @@ class HTMLFormatterTest < MiniTest::Test
     tokens = load_sample 'swift', 'swift'
     doc = parse @formatter.format(tokens)
 
-    assert_equal 121, doc.css('span[id^=L]').size, "Formatting should preserve linecount"
-    assert_equal "}", doc.css('span#L121').text.rstrip, "Line 121 should have only a closing brace"
-    assert_equal "    }", doc.css('span#L120').text.rstrip, "Line 120 should have a four space indent and closing brace"
+    assert_equal 15, doc.css('span[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal "}", doc.css('span#L15').text.rstrip, "Line 15 should have only a closing brace"
+    assert_equal "    }", doc.css('span#L14').text.rstrip, "Line 14 should have a four space indent and closing brace"
   end
 
   private

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -1,0 +1,66 @@
+require_relative '../test_helper'
+require 'rouge'
+require 'loofah'
+require_relative '../../lib/rouge/formatters/html_exercism'
+
+class HTMLFormatterTest < MiniTest::Test
+  def setup
+    @formatter = Rouge::Formatters::HTMLExercism.new line_numbers: true
+  end
+
+  def test_ocaml_comment
+    tokens = load_sample 'ocaml', 'ocaml'
+    doc = parse @formatter.format(tokens)
+    raw_lines = load_example('ocaml').lines
+
+    assert_equal 6, doc.css('div[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal 3, doc.css('span.c').size, "Multiline comment should be split into individual lines with proper style"
+
+    (1..3).each do |lineno|
+      line = doc.css("div[id=L#{lineno}]").text.rstrip
+      original_line = raw_lines[lineno - 1].rstrip
+      assert_equal original_line, line,  "Comment text in line #{lineno} should be preserved"
+    end
+  end
+
+  def test_python_docstring
+    tokens = load_sample 'python', 'python'
+    doc = parse @formatter.format(tokens)
+
+    assert_equal 12, doc.css('div[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal 3, doc.css('span.s').size, "There should be exactly 3 string tokens in the code"
+    assert_equal '', doc.css('div#L4').text.rstrip, "Line 4 should be blank"
+    assert_equal '', doc.css('div#L5').text.rstrip, "Line 5 should be blank"
+  end
+
+  def test_swift
+    tokens = load_sample 'swift', 'swift'
+    doc = parse @formatter.format(tokens)
+
+    assert_equal 121, doc.css('div[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal "}", doc.css('div#L121').text.rstrip, "Line 121 should have only a closing brace"
+    assert_equal "    }", doc.css('div#L120').text.rstrip, "Line 120 should have a four space indent and closing brace"
+  end
+
+  private
+
+  def get_lexer(language)
+    Rouge::Lexer.find_fancy language
+  end
+
+  def load_sample(name, language)
+    code = load_example name
+    lexer = get_lexer language
+
+    lexer.lex(code)
+  end
+
+  def parse(output)
+    Loofah::HTML::DocumentFragment.parse(output)
+  end
+
+  def load_example(name)
+    path = File.join(File.expand_path('../../fixtures/code_formatting', __FILE__), name)
+    File.read path
+  end
+end

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -39,6 +39,11 @@ class HTMLFormatterTest < MiniTest::Test
     doc = parse @formatter.format(tokens)
 
     assert_equal 15, doc.css('span[id^=L]').size, "Formatting should preserve linecount"
+
+    # Swift, has separate single- and multi-line comments
+    assert doc.css('span#L3 span.c1').size == 1, "Line 3 should contain a single-line comment"
+    assert doc.css('span#L9 span.cm').size == 1, "Line 9 should contain a multiline comment"
+    assert doc.css('span#L10 span.cm').size == 1, "Line 10 should contain a multiline comment"
     assert_equal "}", doc.css('span#L15').text.rstrip, "Line 15 should have only a closing brace"
     assert_equal "    }", doc.css('span#L14').text.rstrip, "Line 14 should have a four space indent and closing brace"
   end

--- a/test/exercism/html_formatter_test.rb
+++ b/test/exercism/html_formatter_test.rb
@@ -10,14 +10,15 @@ class HTMLFormatterTest < MiniTest::Test
 
   def test_ocaml_comment
     tokens = load_sample 'ocaml', 'ocaml'
-    doc = parse @formatter.format(tokens)
+    html = @formatter.format(tokens)
+    doc = parse html
     raw_lines = load_example('ocaml').lines
 
-    assert_equal 6, doc.css('div[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal 6, doc.css('span[id^=L]').size, "Formatting should preserve linecount"
     assert_equal 3, doc.css('span.c').size, "Multiline comment should be split into individual lines with proper style"
 
     (1..3).each do |lineno|
-      line = doc.css("div[id=L#{lineno}]").text.rstrip
+      line = doc.css("span[id=L#{lineno}]").text.rstrip
       original_line = raw_lines[lineno - 1].rstrip
       assert_equal original_line, line,  "Comment text in line #{lineno} should be preserved"
     end
@@ -27,7 +28,7 @@ class HTMLFormatterTest < MiniTest::Test
     tokens = load_sample 'python', 'python'
     doc = parse @formatter.format(tokens)
 
-    assert_equal 12, doc.css('div[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal 12, doc.css('span[id^=L]').size, "Formatting should preserve linecount"
     assert_equal 3, doc.css('span.s').size, "There should be exactly 3 string tokens in the code"
     assert_equal '', doc.css('div#L4').text.rstrip, "Line 4 should be blank"
     assert_equal '', doc.css('div#L5').text.rstrip, "Line 5 should be blank"
@@ -37,9 +38,9 @@ class HTMLFormatterTest < MiniTest::Test
     tokens = load_sample 'swift', 'swift'
     doc = parse @formatter.format(tokens)
 
-    assert_equal 121, doc.css('div[id^=L]').size, "Formatting should preserve linecount"
-    assert_equal "}", doc.css('div#L121').text.rstrip, "Line 121 should have only a closing brace"
-    assert_equal "    }", doc.css('div#L120').text.rstrip, "Line 120 should have a four space indent and closing brace"
+    assert_equal 121, doc.css('span[id^=L]').size, "Formatting should preserve linecount"
+    assert_equal "}", doc.css('span#L121').text.rstrip, "Line 121 should have only a closing brace"
+    assert_equal "    }", doc.css('span#L120').text.rstrip, "Line 120 should have a four space indent and closing brace"
   end
 
   private

--- a/test/fixtures/approvals/markdown_double_braces.approved.txt
+++ b/test/fixtures/approvals/markdown_double_braces.approved.txt
@@ -1,7 +1,7 @@
 <div class="highlight json">
 <table style="border-spacing: 0;"><tbody><tr>
 <td class="gutter gl" style="text-align: right;"><pre class="lineno"><a href="#L1">1</a></pre></td>
-<td class="code"><pre><span id="L1"><span class="p">{</span><span class="err">{x:</span><span class="w"> </span><span class="err">y</span><span class="p">}</span><span class="err">}</span><span class="w">
-</span><span id="L2"></span></span></pre></td>
+<td class="code"><pre><span id="L1"><span class="p">{</span><span class="err">{x:</span><span class="w"> </span><span class="err">y</span><span class="p">}</span><span class="err">}</span>
+</span></pre></td>
 </tr></tbody></table>
 </div>

--- a/test/fixtures/approvals/markdown_with_clojure_code.approved.txt
+++ b/test/fixtures/approvals/markdown_with_clojure_code.approved.txt
@@ -1,0 +1,12 @@
+<p>Check out this code:</p>
+<div class="highlight clojure">
+<table style="border-spacing: 0;"><tbody><tr>
+<td class="gutter gl" style="text-align: right;"><pre class="lineno"><a href="#L1">1</a>
+<a href="#L2">2</a>
+<a href="#L3">3</a></pre></td>
+<td class="code"><pre><span id="L1"><span class="p">(</span><span class="k">defn</span><span class="w"> </span><span class="n">to-rna</span>
+</span><span id="L2"><span class="w">  </span><span class="p">[</span><span class="n">dna-string</span><span class="p">]</span>
+</span><span id="L3"><span class="w">  </span><span class="p">(</span><span class="nf">clojure.string/replace</span><span class="w"> </span><span class="n">dna-string</span><span class="w"> </span><span class="sc">\T</span><span class="w"> </span><span class="sc">\U</span><span class="p">))</span>
+</span></pre></td>
+</tr></tbody></table>
+</div>

--- a/test/fixtures/code_formatting/ocaml
+++ b/test/fixtures/code_formatting/ocaml
@@ -1,0 +1,6 @@
+(* reverse the first list, then prepend it to the second list. (In
+   other words, one by one, move the head of the first list onto the head
+   of the second.) *)
+let rec backward_prepend = function
+| ([], lst) -> ([], lst)
+| (hd::tl, lst) -> backward_prepend (tl, hd::lst)

--- a/test/fixtures/code_formatting/python
+++ b/test/fixtures/code_formatting/python
@@ -1,0 +1,12 @@
+"""
+Implementation of the "word-count" exercise.
+"""
+
+
+def word_count(phrase):
+    book = {}
+    for word in phrase.split():
+        if word not in book:
+            book[word] = 0
+        book[word] += 1
+    return book

--- a/test/fixtures/code_formatting/swift
+++ b/test/fixtures/code_formatting/swift
@@ -6,10 +6,14 @@ struct BlahBlah: YaddaYadda
 
     }
 
-    /* Multiline
-    comment */
+    /* 
+		Multi
+		line
+   		comment 
+	*/
     var foo: String
     {
         return "FooBar"
     }
+// This file should NOT have a newline at the end of it.
 }

--- a/test/fixtures/code_formatting/swift
+++ b/test/fixtures/code_formatting/swift
@@ -1,6 +1,6 @@
 struct BlahBlah: YaddaYadda
 {
-    /// Comment
+    // Comment
     init(_)
     {
 

--- a/test/fixtures/code_formatting/swift
+++ b/test/fixtures/code_formatting/swift
@@ -1,121 +1,15 @@
-//
-//  PhoneNumber.swift
-//  PhoneNumber
-//
-//  Created by Tom Holland on 8/13/16.
-//  Copyright © 2016 Tom Holland. All rights reserved.
-//
-import Foundation
-
-///
-/// Represents a United States Phone Number
-///
-struct PhoneNumber: CustomStringConvertible
+struct BlahBlah: YaddaYadda
 {
-    private let phoneNumber: PhoneNumberComponents?
-
-    init(_ _phoneNumber: String)
+    /// Comment
+    init(_)
     {
-        let trimmedNumber = _phoneNumber
-            .components(separatedBy: CharacterSet(charactersIn: "0123456789").inverted)
-            .joined(separator: "")
 
-        if let components = PhoneNumberComponents(withString: trimmedNumber)
-        {
-            self.phoneNumber = components
-
-        } else {
-
-            self.phoneNumber = PhoneNumberComponents(withString: "0000000000")
-        }
     }
 
-    ///
-    /// The Phone Number's digits without formatting
-    ///
-    var number: String
+    /* Multiline
+    comment */
+    var foo: String
     {
-        return "\(self.phoneNumber!.areaCode)\(self.phoneNumber!.prefix)\(self.phoneNumber!.line)"
-    }
-
-    ///
-    /// The Phone Number's Area Code digits without formatting
-    ///
-    var areaCode: String
-    {
-        return "\(self.phoneNumber!.areaCode)"
-    }
-
-    ///
-    /// The Phone Number digits formatted in standard U.S. format
-    ///
-    /// This is a custom string value for this type
-    ///
-    var description: String
-    {
-        return "(\(self.phoneNumber!.areaCode)) \(self.phoneNumber!.prefix)-\(self.phoneNumber!.line)"
-    }
-}
-
-///
-/// Represents the components of a U.S. Phone Number - area code, prefix and line
-///
-struct PhoneNumberComponents {
-
-    private let number: String
-
-    ///
-    /// Optional initializer will only instantiate with valid input string
-    ///
-    init?(withString _number: String) {
-
-        // The number must be 10 or 11 digits long
-        guard 10...11 ~= _number.characters.count else
-        {
-            return nil
-        }
-
-        if _number.characters.count == 11
-        {
-            // Make sure that the first 2 digits are "11"
-            guard "11" == _number.substring(to: _number.index(_number.startIndex, offsetBy: 2)) else
-            {
-                return nil
-            }
-
-            // First 2 digits are "11" so we need to trim the first "1"
-            self.number = _number.substring(from: _number.index(_number.startIndex, offsetBy: 1))
-
-        } else {
-
-            // Good to go!
-            self.number = _number
-        }
-    }
-
-    ///
-    /// The Phone Number's Area Code component
-    ///
-    var areaCode: String
-    {
-        return self.number.substring(to: self.number.index(self.number.startIndex, offsetBy: 3))
-    }
-
-    ///
-    /// The Phone Number's Prefix component
-    ///
-    var prefix: String
-    {
-        let prefixRange = self.number.index(self.number.startIndex, offsetBy: 3)..<self.number.index(self.number.startIndex, offsetBy: 6)
-
-        return self.number.substring(with: prefixRange)
-    }
-
-    ///
-    /// The Phone Number's Line Number component
-    ///
-    var line: String
-    {
-        return self.number.substring(from: self.number.index(self.number.endIndex, offsetBy: -4))
+        return "FooBar"
     }
 }

--- a/test/fixtures/code_formatting/swift
+++ b/test/fixtures/code_formatting/swift
@@ -1,0 +1,121 @@
+//
+//  PhoneNumber.swift
+//  PhoneNumber
+//
+//  Created by Tom Holland on 8/13/16.
+//  Copyright © 2016 Tom Holland. All rights reserved.
+//
+import Foundation
+
+///
+/// Represents a United States Phone Number
+///
+struct PhoneNumber: CustomStringConvertible
+{
+    private let phoneNumber: PhoneNumberComponents?
+
+    init(_ _phoneNumber: String)
+    {
+        let trimmedNumber = _phoneNumber
+            .components(separatedBy: CharacterSet(charactersIn: "0123456789").inverted)
+            .joined(separator: "")
+
+        if let components = PhoneNumberComponents(withString: trimmedNumber)
+        {
+            self.phoneNumber = components
+
+        } else {
+
+            self.phoneNumber = PhoneNumberComponents(withString: "0000000000")
+        }
+    }
+
+    ///
+    /// The Phone Number's digits without formatting
+    ///
+    var number: String
+    {
+        return "\(self.phoneNumber!.areaCode)\(self.phoneNumber!.prefix)\(self.phoneNumber!.line)"
+    }
+
+    ///
+    /// The Phone Number's Area Code digits without formatting
+    ///
+    var areaCode: String
+    {
+        return "\(self.phoneNumber!.areaCode)"
+    }
+
+    ///
+    /// The Phone Number digits formatted in standard U.S. format
+    ///
+    /// This is a custom string value for this type
+    ///
+    var description: String
+    {
+        return "(\(self.phoneNumber!.areaCode)) \(self.phoneNumber!.prefix)-\(self.phoneNumber!.line)"
+    }
+}
+
+///
+/// Represents the components of a U.S. Phone Number - area code, prefix and line
+///
+struct PhoneNumberComponents {
+
+    private let number: String
+
+    ///
+    /// Optional initializer will only instantiate with valid input string
+    ///
+    init?(withString _number: String) {
+
+        // The number must be 10 or 11 digits long
+        guard 10...11 ~= _number.characters.count else
+        {
+            return nil
+        }
+
+        if _number.characters.count == 11
+        {
+            // Make sure that the first 2 digits are "11"
+            guard "11" == _number.substring(to: _number.index(_number.startIndex, offsetBy: 2)) else
+            {
+                return nil
+            }
+
+            // First 2 digits are "11" so we need to trim the first "1"
+            self.number = _number.substring(from: _number.index(_number.startIndex, offsetBy: 1))
+
+        } else {
+
+            // Good to go!
+            self.number = _number
+        }
+    }
+
+    ///
+    /// The Phone Number's Area Code component
+    ///
+    var areaCode: String
+    {
+        return self.number.substring(to: self.number.index(self.number.startIndex, offsetBy: 3))
+    }
+
+    ///
+    /// The Phone Number's Prefix component
+    ///
+    var prefix: String
+    {
+        let prefixRange = self.number.index(self.number.startIndex, offsetBy: 3)..<self.number.index(self.number.startIndex, offsetBy: 6)
+
+        return self.number.substring(with: prefixRange)
+    }
+
+    ///
+    /// The Phone Number's Line Number component
+    ///
+    var line: String
+    {
+        return self.number.substring(from: self.number.index(self.number.endIndex, offsetBy: -4))
+    }
+}


### PR DESCRIPTION
Replaces #3048 and #3058 after the first one was reverted in  #3056, addresses #3050 and the original #3044.

This changes the formatter to use Rouge's native `token_lines` method instead of roll-your-own, and removes many of its unused options; otherwise the behavior and code is similar to #3048. @Insti provided motivation to rewrite and trim the formatter, some nice refactors and adjusted tests.