### PR TITLE
Change invite feature to rely on its own table

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -43,6 +43,7 @@ module ExercismWeb
     use Routes::Comments
     use Routes::Tags
     use Routes::Teams
+    use Routes::Invitations
     use Routes::Tracks
     use Routes::Sessions
     use Routes::Styleguide

--- a/app/helpers/notification_count.rb
+++ b/app/helpers/notification_count.rb
@@ -5,9 +5,9 @@ module ExercismWeb
         sql = "SELECT COUNT(note.id) AS tally FROM notifications note INNER JOIN submissions sub ON note.iteration_id=sub.id WHERE note.user_id=#{current_user.id} AND note.read='f'"
 
         notifications_count = ActiveRecord::Base.connection.execute(sql).to_a.first["tally"].to_i
-        unconfirmed_memberships_count = current_user.unconfirmed_team_memberships.count
+        membership_invites_count = current_user.team_membership_invites.count
 
-        notifications_count + unconfirmed_memberships_count
+        notifications_count + membership_invites_count
       end
     end
   end

--- a/app/presenters/inbox.rb
+++ b/app/presenters/inbox.rb
@@ -7,23 +7,23 @@ module ExercismWeb
       end
 
       def count
-        notifications.count + unconfirmed_team_memberships.count
+        notifications.count + team_membership_invites.count
       end
 
       def has_notifications?
         notifications.count > 0
       end
 
-      def has_unconfirmed_team_memberships?
-        unconfirmed_team_memberships.count > 0
+      def has_team_membership_invites?
+        team_membership_invites.count > 0
       end
 
       def notifications
         user.notifications.includes(:iteration, :actor).unread.recent.reject { |note| note.iteration.nil? || note.iteration.user.nil? }
       end
 
-      def unconfirmed_team_memberships
-        user.unconfirmed_team_memberships
+      def team_membership_invites
+        user.team_membership_invites
       end
     end
   end

--- a/app/presenters/profile.rb
+++ b/app/presenters/profile.rb
@@ -50,7 +50,7 @@ module ExercismWeb
       end
 
       def teams
-        user.unconfirmed_teams | user.teams | user.managed_teams
+        user.team_invites | user.teams | user.managed_teams
       end
 
       def has_teams?

--- a/app/routes.rb
+++ b/app/routes.rb
@@ -20,6 +20,7 @@ module ExercismWeb
       Submissions: 'submissions',
       Tags: 'tags',
       Teams: 'teams',
+      Invitations: 'invitations',
       Tracks: 'tracks',
       Styleguide: 'styleguide',
       Subscriptions: 'subscriptions',

--- a/app/routes/invitations.rb
+++ b/app/routes/invitations.rb
@@ -1,0 +1,76 @@
+module ExercismWeb
+  module Routes
+    class Invitations < Core
+      post '/teams/:slug/invitations' do |slug|
+        please_login
+        only_for_team_managers(slug, "You are not allowed to add team members.") do |team|
+          team.invite_with_usernames(params[:usernames], current_user)
+          team.save
+
+          flash[:success] = "Invitation sent to team #{slug}"
+          redirect "/teams/#{slug}/manage"
+        end
+      end
+
+      post '/teams/:slug/invitation/accept' do |slug|
+        please_login
+        only_with_existing_team(slug) do |team|
+          invite = invite_for_user_and_team(current_user, team)
+
+          unless invite.present?
+            flash[:error] = "You don't have a pending invitation to this team."
+            redirect "/"
+          end
+
+          invite.accept!
+          flash[:success] = "You are now a member of team #{slug}."
+          redirect "/teams/#{slug}"
+        end
+      end
+
+      post '/teams/:slug/invitation/refuse' do |slug|
+        please_login
+        only_with_existing_team(slug) do |team|
+          invite = invite_for_user_and_team(current_user, team)
+
+          unless invite.present?
+            flash[:error] = "You don't have a pending invitation to this team."
+            redirect "/"
+          end
+
+          invite.refuse!
+          flash[:success] = "Invite from team #{slug} was refused."
+          redirect "/"
+        end
+      end
+
+      private
+
+      def only_for_team_managers(slug, message)
+        only_with_existing_team(slug) do |team|
+          if team.managed_by?(current_user)
+            yield team
+          else
+            flash[:error] = message
+            redirect "/teams/#{slug}"
+          end
+        end
+      end
+
+      def only_with_existing_team(slug)
+        team = Team.find_by_slug(slug)
+
+        if team
+          yield team
+        else
+          flash[:error] = "We don't know anything about team '#{slug}'"
+          redirect '/'
+        end
+      end
+
+      def invite_for_user_and_team(user, team)
+        TeamMembershipInvite.pending.find_by(user: user, team: team)
+      end
+    end
+  end
+end

--- a/app/views/account/show.erb
+++ b/app/views/account/show.erb
@@ -37,17 +37,15 @@
       <ul class="nav nav-stacked nav-bordered" style="max-width: 400px">
         <% profile.teams.each do |team| %>
           <li>
-            <% if team.unconfirmed_members.include?(profile.user) %>
+            <% if team.member_invites.include?(profile.user) %>
               <ul class="list-inline" style="padding:10px 20px;">
                 <li>
-                  <form action="<%= "/teams/#{team.slug}/confirm" %>" method="post">
-                    <input type="hidden" name="_method" value="put" />
+                  <form action="<%= "/teams/#{team.slug}/invitation/accept" %>" method="post">
                     <input type="submit" name="update" value="Accept" class="btn btn-xs btn-success"/>
                   </form>
                 </li>
                 <li>
-                  <form action="<%= "/teams/#{team.slug}/leave" %>" method="post">
-                    <input type="hidden" name="_method" value="put" />
+                  <form action="<%= "/teams/#{team.slug}/invitation/refuse" %>" method="post">
                     <input type="submit" name="update" value="Decline" class="btn btn-xs btn-danger"/>
                   </form>
                 </li>

--- a/app/views/dashboard.erb
+++ b/app/views/dashboard.erb
@@ -100,7 +100,7 @@
                             <%= team.name %>
                           </td>
                           <td width="40%">
-                            <%= team.confirmed_members.size %> <%= 'member'.pluralize(team.confirmed_members.size) %>
+                            <%= team.members.size %> <%= 'member'.pluralize(team.members.size) %>
                           </td>
                         </tr>
                       </table>

--- a/app/views/notifications/index.erb
+++ b/app/views/notifications/index.erb
@@ -14,24 +14,22 @@
 
   <div class="row">
     <div class="col-xs-8">
-      <% if inbox.has_unconfirmed_team_memberships? %>
+      <% if inbox.has_team_membership_invites? %>
         <ul style="list-style-type: none; margin: 0;">
-          <% inbox.unconfirmed_team_memberships.each do |team_membership| %>
+          <% inbox.team_membership_invites.each do |invite| %>
           <li class="alert-row">
             <span style="padding-right: 15px;" class="fa fa-bell-o alert-icon"></span>
-            <% if team_membership.inviter.present? %>
-              <%= gravatar_tag team_membership.inviter.avatar_url, size: 20 %>
-              <a href="<%= team_membership.inviter.username %>"><%= team_membership.inviter.username %></a> would like you to join the team <%= team_membership.team.name %>.
+            <% if invite.inviter.present? %>
+              <%= gravatar_tag invite.inviter.avatar_url, size: 20 %>
+              <a href="<%= invite.inviter.username %>"><%= invite.inviter.username %></a> would like you to join the team <%= invite.team.name %>.
             <% else %>
-              You are invited to join the team <%= team_membership.team.name %>.
+              You are invited to join the team <%= invite.team.name %>.
             <% end %>
-            <form action="<%= "/teams/#{team_membership.team.slug}/leave" %>" method="post" class="inline">
-              <input type="hidden" name="_method" value="put" />
+            <form action="<%= "/teams/#{invite.team.slug}/invitation/refuse" %>" method="post" class="inline">
               <input type="submit" name="update" value="Decline" class="btn btn-xs btn-danger pull-right"/>
             </form>
 
-            <form action="<%= "/teams/#{team_membership.team.slug}/confirm" %>" method="post" class="inline">
-              <input type="hidden" name="_method" value="put"/>
+            <form action="<%= "/teams/#{invite.team.slug}/invitation/accept" %>" method="post" class="inline">
               <input type="submit" name="update" value="Accept" class="btn btn-xs btn-success pull-right" style="margin-right: 5px" />
             </form>
           </li>

--- a/app/views/teams/directory.erb
+++ b/app/views/teams/directory.erb
@@ -2,7 +2,7 @@
   <br>
   <%= erb :"teams/_tabs", locals: {active: active, team: team} %>
 
-  <h3><%= h(team.name) %> (<%= team.confirmed_members.size %> <%= 'member'.pluralize(team.confirmed_members.size) %>)</h3>
+  <h3><%= h(team.name) %> (<%= team.members.size %> <%= 'member'.pluralize(team.members.size) %>)</h3>
 
   <% if team.description.present? %>
     <h4><%= team.description %></h4>
@@ -10,7 +10,7 @@
 
   <p>Click on a team member's name to go to their profile.</p>
 
-  <% team.confirmed_members.each_slice(3) do |row| %>
+  <% team.members.each_slice(3) do |row| %>
     <div class="row">
       <% row.each do |member| %>
         <div class="col-md-4" id="<%= member.username %>">

--- a/app/views/teams/list.erb
+++ b/app/views/teams/list.erb
@@ -31,7 +31,7 @@
         <li class="team-info">
           <div class="row">
             <a href="/teams/<%= team.slug %>" class="list-group-item">
-              <h3><%= h(team.name) %> (<%= team.confirmed_members.size %> <%= 'member'.pluralize(team.confirmed_members.size) %>)</h3>
+              <h3><%= h(team.name) %> (<%= team.members.size %> <%= 'member'.pluralize(team.members.size) %>)</h3>
 
               <% if team.description.present? %>
                 <h4><%= team.description %></h4>

--- a/app/views/teams/manage.erb
+++ b/app/views/teams/manage.erb
@@ -107,7 +107,7 @@
 
   <div id="members">
     <h3>Members</h3>
-    <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}/members" %>" method="post">
+    <form accept-charset="UTF-8" action="<%= "/teams/#{team.slug}/invitations" %>" method="post">
       <div class="row">
         <div class="control-group col-md-8">
           <label  class="control-label" for="usernames">Usernames (comma-separated list)</label>
@@ -122,7 +122,7 @@
     <br/>
 
     <div class="row">
-      <% team.confirmed_members.each do |member| %>
+      <% team.members.each do |member| %>
         <div class="col-sm-3">
           <a href="#" data-username="<%= member.username %>" data-team="<%= team.slug %>"
           class="btn btn-xs btn-danger member_delete" style="margin: 10px 10px 10px 0">X</a>
@@ -132,17 +132,19 @@
       <% end %>
     </div>
 
-    <div class="row">
-      <h4>Unconfirmed members</h4>
-      <% team.unconfirmed_members.each do |member| %>
-        <div class="col-sm-3">
-          <a href="#" data-username="<%= member.username %>" data-team="<%= team.slug %>"
-          class="btn btn-xs btn-danger member_delete" style="margin: 10px 10px 10px 0">X</a>
-          <%= gravatar_tag member.avatar_url, size: 20 %>
-          <a href="/<%= member.username %>"><%= member.username %></a>
-        </div>
-      <% end %>
-    </div>
+    <% if team.member_invites.exists? %>
+      <div class="row">
+        <h4>Invited members</h4>
+        <% team.member_invites.each do |member| %>
+          <div class="col-sm-3">
+            <a href="#" data-username="<%= member.username %>" data-team="<%= team.slug %>"
+            class="btn btn-xs btn-danger member_delete" style="margin: 10px 10px 10px 0">X</a>
+            <%= gravatar_tag member.avatar_url, size: 20 %>
+            <a href="/<%= member.username %>"><%= member.username %></a>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
 
   </div>
 </div>

--- a/db/migrate/201608152201_create_team_membership_invites_table.rb
+++ b/db/migrate/201608152201_create_team_membership_invites_table.rb
@@ -1,0 +1,17 @@
+class CreateTeamMembershipInvitesTable < ActiveRecord::Migration
+  def up
+    create_table :team_membership_invites do |t|
+      t.integer :team_id, null: false
+      t.integer :user_id, null: false
+      t.integer :inviter_id
+      t.boolean :refused, null: false, default: false
+      t.timestamps null: false
+    end
+
+    add_index :team_membership_invites, [:team_id, :user_id]
+  end
+
+  def down
+    drop_table :team_membership_invites
+  end
+end

--- a/lib/exercism/team_membership.rb
+++ b/lib/exercism/team_membership.rb
@@ -4,18 +4,7 @@ class TeamMembership < ActiveRecord::Base
   belongs_to :inviter, class_name: 'User', foreign_key: :inviter_id
 
   validates :user, uniqueness: { scope: :team }
-  scope :confirmed, -> { where(confirmed: true) }
   scope :for_team, -> (team_id) { where(team_id: team_id) }
-
-  before_create do
-    self.confirmed = false if confirmed.nil?
-    true
-  end
-
-  def confirm!
-    self.confirmed = true
-    save
-  end
 
   def self.destroy_for_team(id)
     for_team(id).map(&:destroy)

--- a/lib/exercism/team_membership_invite.rb
+++ b/lib/exercism/team_membership_invite.rb
@@ -1,0 +1,27 @@
+class TeamMembershipInvite < ActiveRecord::Base
+  belongs_to :team
+  belongs_to :user
+  belongs_to :inviter, class_name: 'User', foreign_key: :inviter_id
+
+  scope :for_team, -> (team_id) { where(team_id: team_id) }
+  scope :refused, -> { where(refused: true) }
+  scope :pending, -> { where(refused: false) }
+
+  def accept!
+    ActiveRecord::Base.transaction do
+      TeamMembership.create!(
+        team_id: team_id,
+        user_id: user_id,
+        inviter_id: inviter_id,
+        confirmed: true
+      )
+
+      destroy
+    end
+  end
+
+  def refuse!
+    self.refused = true
+    save
+  end
+end

--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -13,11 +13,11 @@ class User < ActiveRecord::Base
 
   has_many :management_contracts, class_name: "TeamManager"
   has_many :managed_teams, through: :management_contracts, source: :team
-  has_many :team_memberships, -> { where confirmed: true }, class_name: "TeamMembership", dependent: :destroy
+  has_many :team_memberships, -> { where confirmed: true }, dependent: :destroy
+  has_many :team_membership_invites, -> { where refused: false }, dependent: :destroy
   has_many :teams, through: :team_memberships
-  has_many :inviters, through: :team_memberships, class_name: "User", foreign_key: :inviter_id
-  has_many :unconfirmed_team_memberships, -> { where confirmed: false }, class_name: "TeamMembership", dependent: :destroy
-  has_many :unconfirmed_teams, through: :unconfirmed_team_memberships, source: :team
+  has_many :team_invites, through: :team_membership_invites, source: :team
+  has_many :inviters, through: :team_membership_invites, class_name: "User", foreign_key: :inviter_id
 
   before_save do
     self.key ||= Exercism.uuid
@@ -139,6 +139,10 @@ class User < ActiveRecord::Base
       avatar_url: avatar_url,
       github_id: github_id,
     }
+  end
+
+  def team_membership_invites_for(team)
+    team_membership_invites.find_by(team_id: team)
   end
 
   private

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -272,5 +272,21 @@ namespace :data do
         end
       end
     end
+
+    desc "migrate unconfirmed memberships to membership_invites"
+    task :migrate_unconfirmed_memberships do
+      require 'active_record'
+      require 'db/connection'
+      DB::Connection.establish
+
+      sql = <<-SQL
+        INSERT INTO team_membership_invites(team_id, user_id, inviter_id, created_at, updated_at)
+        SELECT team_id, user_id, inviter_id, created_at, updated_at
+        FROM team_memberships
+        WHERE confirmed is FALSE
+      SQL
+
+      ActiveRecord::Base.connection.execute(sql)
+    end
   end
 end

--- a/test/app/invitations_test.rb
+++ b/test/app/invitations_test.rb
@@ -1,0 +1,132 @@
+require_relative '../app_helper'
+require 'mocha/setup'
+
+class InvitationsTest < Minitest::Test
+  include Rack::Test::Methods
+  include AppTestHelper
+  include DBCleaner
+
+  def app
+    ExercismWeb::App
+  end
+
+  def alice_attributes
+    {
+      username: 'alice',
+      github_id: 1,
+      email: "alice@example.com",
+    }
+  end
+
+  def bob_attributes
+    {
+      username: 'bob',
+      github_id: 2,
+      track_mentor: ['ruby'],
+      email: "bob@example.com",
+    }
+  end
+
+  def charlie_attributes
+    {
+      username: 'charlie',
+      github_id: 3,
+      track_mentor: ['ruby'],
+      email: "charlie@example.com",
+    }
+  end
+
+  attr_reader :alice, :bob, :charlie
+  def setup
+    super
+    @alice = User.create(alice_attributes)
+    @bob = User.create(bob_attributes)
+    @charlie = User.create(charlie_attributes)
+  end
+
+  def assert_response_status(expected_status)
+    assert_equal expected_status, last_response.status
+  end
+
+  def test_user_must_be_logged_in
+    [
+      [:post, '/teams/abc/invitations'],
+      [:post, '/teams/abc/invitation/accept'],
+      [:post, '/teams/abc/invitation/refuse'],
+    ].each do |verb, endpoint|
+      send verb, endpoint
+      assert_equal 302, last_response.status
+      location = "http://example.org/please-login?return_path=#{endpoint}"
+      assert_equal location, last_response.location, "Wrong redirect for #{verb.to_s.upcase} #{endpoint}"
+    end
+  end
+
+  def test_user_must_be_manager
+    team = Team.by(alice).defined_with(slug: 'abc', usernames: bob.username)
+    team.save
+    TeamMembershipInvite.pending.find_by(user: bob, team: team).accept!
+
+    verb, path, action = [:post, '/teams/abc/invitations', "invite members"]
+    location = "http://example.org/teams/abc"
+
+    send verb, path, {}, login(bob)
+    assert_equal 302, last_response.status, "No redirect for #{verb.to_s.upcase} #{path}"
+    assert_equal location, last_response.location, "Only a manager may #{action}. (#{verb.to_s.upcase} #{path})"
+  end
+
+  def test_invitation
+    team = Team.by(alice).defined_with(slug: 'members')
+    team.save
+
+    refute TeamMembershipInvite.exists?
+
+    post "/teams/#{team.slug}/invitations", { usernames: "#{bob.username}, #{charlie.username}" }, login(alice)
+
+    assert_equal 1, bob.reload.team_membership_invites.count
+    assert_equal 1, charlie.reload.team_membership_invites.count
+
+    refute team.includes?(bob)
+    refute team.includes?(charlie)
+  end
+
+  def test_only_managers_can_invite_members
+    team = Team.by(alice).defined_with(slug: 'members', usernames: bob.username)
+    team.save
+
+    post "/teams/#{team.slug}/invitations", { usernames: charlie.username }, login(bob)
+
+    team.reload
+
+    assert_response_status(302)
+    refute team.includes?(charlie)
+  end
+
+  def test_accept_invitation
+    team_name = 'abc'
+    post '/teams/new', { team: { slug: team_name, usernames: bob.username } }, login(alice)
+
+    assert_equal 1, bob.team_membership_invites.count, "Bob should have membership invite for the team."
+    assert_equal 0, bob.team_memberships.count, "Bob should not have a membership for the team."
+
+    post "/teams/abc/invitation/accept", { usernames: bob.username }, login(bob)
+
+    assert_equal 0, bob.reload.team_membership_invites.count, "Bob should not have a membership invite."
+    assert_equal 1, bob.reload.team_memberships.count, "Bob should have a membership."
+  end
+
+  def test_refuse_invitation
+    team_name = 'abc'
+    post '/teams/new', { team: { slug: team_name, usernames: bob.username } }, login(alice)
+
+    assert_equal 1, bob.team_membership_invites.count, "Bob should have a membership invite for the team."
+    assert_equal 0, bob.team_memberships.count, "Bob should not have a membership for the team."
+
+    post "/teams/abc/invitation/refuse", { usernames: bob.username }, login(bob)
+
+    bob_invitations = TeamMembershipInvite.where(user: bob)
+
+    assert_equal 1, bob_invitations.count, "Bob should still have membership invite record."
+    assert bob_invitations.last.refused?, "Bob membership invite should be refused."
+    assert_equal 0, bob.reload.team_memberships.count, "Bob should not have a membership."
+  end
+end

--- a/test/exercism/team_membership_invite_test.rb
+++ b/test/exercism/team_membership_invite_test.rb
@@ -1,0 +1,40 @@
+require_relative '../integration_helper'
+
+class TeamMembershipInviteTest < Minitest::Test
+  include DBCleaner
+
+  attr_reader :alice, :bob
+  def setup
+    super
+    @alice = User.create(username: 'alice')
+    @bob = User.create(username: 'bob')
+  end
+
+  def test_accept_creates_membership_and_destroys_itself
+    team = Team.by(alice).defined_with(slug: 'purple')
+    team.save
+
+    membership_invite = TeamMembershipInvite.new(team: team, user: bob, inviter: alice)
+    membership_invite.save
+
+    assert_equal 0, TeamMembership.count
+    assert_equal 1, TeamMembershipInvite.count
+
+    membership_invite.accept!
+
+    assert_equal 1, TeamMembership.count
+    assert_equal 0, TeamMembershipInvite.count
+  end
+
+  def test_refuse_changes_invite_status
+    team = Team.by(alice).defined_with(slug: 'purple')
+    team.save
+
+    membership_invite = TeamMembershipInvite.new(team: team, user: bob, inviter: alice)
+    membership_invite.save
+
+    refute membership_invite.refused?
+    membership_invite.refuse!
+    assert membership_invite.refused?
+  end
+end

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -94,15 +94,15 @@ class UserTest < Minitest::Test
 
     team.save
     other_team.save
-    TeamMembership.where(user: bob).first.confirm!
+    TeamMembershipInvite.where(user: bob).first.accept!
 
     assert TeamMembership.exists?(team: team, user: bob, inviter: alice), 'Confirmed TeamMembership for bob was created.'
-    assert TeamMembership.exists?(team: other_team, user: bob, inviter: alice), 'Unconfirmed TeamMembership for charlie was created.'
+    assert TeamMembershipInvite.exists?(team: other_team, user: bob, inviter: alice), 'TeamMembershipInvite for bob was created.'
 
     bob.destroy
 
     refute TeamMembership.exists?(team: team, user: bob, inviter: alice), 'Confirmed TeamMembership was deleted.'
-    refute TeamMembership.exists?(team: other_team, user: bob, inviter: alice), 'Unconfirmed TeamMembership was deleted.'
+    refute TeamMembershipInvite.exists?(team: other_team, user: bob, inviter: alice), 'TeamMembershipInvite was deleted.'
   end
 
   def test_increment_adds_to_table


### PR DESCRIPTION
This change is part of a [bigger plan](https://github.com/exercism/exercism.io/issues/2944) that involves allowing users to request membership for a team.

Although this PR has several changes, it all boils down to use the new table/model instead of relying on the `confirmed` column of the `team_memberships` table.