### PR TITLE
Separating out language sections into separate routes

### DIFF
--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -70,6 +70,10 @@ module ExercismWeb
         status 404
         erb :"languages/not_found", locals: { track_id: topic }
       end
+
+      def active(topic, selected_topic)
+        'active' if topic == selected_topic
+      end
     end
   end
 end

--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -45,12 +45,12 @@ module ExercismWeb
       end
 
       get '/languages/:track_id/:topic' do |track_id, topic|
+        return language_not_found(topic) unless TOPICS.include?(topic.to_sym)
+
         _, body = X::Xapi.get('tracks', track_id)
         parsed_body = JSON.parse(body)
         if parsed_body['error'] == "No track '#{track_id}'"
-          erb :"languages/not_found", locals: { track_id: track_id }
-        elsif !TOPICS.include?(topic.to_sym)
-          erb :"languages/not_found", locals: { track_id: topic }
+          language_not_found(track_id)
         else
           track = X::Track.new(parsed_body['track'])
           erb :"languages/language", locals: {

--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -45,7 +45,7 @@ module ExercismWeb
       end
 
       get '/languages/:track_id/:topic' do |track_id, topic|
-        return language_not_found(topic) unless TOPICS.include?(topic.to_sym)
+        return topic_not_found(topic) unless TOPICS.include?(topic.to_sym)
 
         _, body = X::Xapi.get('tracks', track_id)
         parsed_body = JSON.parse(body)
@@ -64,6 +64,11 @@ module ExercismWeb
       def language_not_found(track_id)
         status 404
         erb :"languages/not_found", locals: { track_id: track_id }
+      end
+
+      def topic_not_found(topic)
+        status 404
+        erb :"languages/not_found", locals: { track_id: topic }
       end
     end
   end

--- a/app/views/languages/_about.erb
+++ b/app/views/languages/_about.erb
@@ -1,0 +1,24 @@
+<div class="tab-pane <%='active' if track.active? %>" id="about">
+  <%= md track.docs.about %>
+
+  <h3>Try It!</h3>
+  <p>
+    If you've downloaded the <a href='/cli'>command-line client</a> and have <%= track.language %> installed
+    on your machine, then go ahead and fetch the first problem.
+  </p>
+  <%= syntax track.fetch_cmd, "plain" %>
+
+  <p>
+    In order to be able to submit your solution, you'll need to configure the client with your
+    <a href="/account/key">Exercism API key</a>.
+  </p>
+
+  <%= syntax "exercism configure --key=YOUR_EXERCISM_KEY", "plain" %>
+
+  <p>
+    When you've written a solution, submit it to the site.
+    You'll have to configure the command-line client with your exercism API key before you can submit.
+  </p>
+
+  <%= syntax "exercism submit PATH_TO_FILE", "plain" %>
+</div>

--- a/app/views/languages/_contribute.erb
+++ b/app/views/languages/_contribute.erb
@@ -1,0 +1,25 @@
+<div class="tab-pane <%='active' if track.active? %>" id="contribute">
+  <h5>Help Us Improve the <%= track.language %> Track!</h5>
+
+  <p>
+    Did you find a typo in the README? Is the test suite missing an edge case?
+    We want to know about it.
+  </p>
+
+  <p>
+    We always welcome GitHub issues and pull requests. See the
+    <a href="<%= track.repository %>"><%= track.language %> repository</a>
+    for more information.
+  </p>
+
+  <h5>Help Add More <%= track.language %> Exercises</h5>
+  <p>
+  The easiest way to add new exercises is to translate existing exercises from other language tracks on Exercism.
+  Here's the <a href="/languages/<%= track.id %>/contribute">full list of unimplemented exercises in <%= track.language %></a>,
+  along with links to all the existing implementations.
+  </p>
+
+  <p>
+  If you have an idea for a completely new exercise, you can follow <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#implementing-a-completely-new-exercise">this guide</a> to add it to the site.
+  </p>
+</div>

--- a/app/views/languages/_exercises.erb
+++ b/app/views/languages/_exercises.erb
@@ -1,0 +1,44 @@
+<div class="tab-pane <%='active' if track.active? %>" id="exercises">
+  <p>
+    When you're logged in, you can say <code>exercism fetch <%= track.id %></code> to get
+    the next available exercise on the track.
+  </p>
+
+  <p>
+    Every time you submit a solution to an exercise, you will get the next in line the next time
+    you fetch.
+  </p>
+
+  <p>
+    If you want to try a specific exercise, you can always fetch it directly (commands
+    are listed below).
+  </p>
+
+  <p>
+    The exercises are ordered roughly in order of difficulty, but it's a bit haphazard.
+  </p>
+
+  <h3>Available Exercises</h3>
+
+  <% track.problems.each do |problem| %>
+    <h5>
+      <button class="btn btn-default" data-toggle="collapse" data-target="#<%= problem.slug %>" aria-expanded="false" aria-controls="<%= problem.slug %>">
+        <%= problem.name %>
+        <b class="caret fuchsia"></b>
+      </button>
+    </h5>
+
+    <div class="collapse" id="<%= problem.slug %>">
+      <p><%= problem.blurb %></p>
+
+      <p>
+        <a href="/exercises/<%= track.id %>/<%= problem.slug %>/readme">README</a>
+        |
+        <a href="/exercises/<%= track.id %>/<%= problem.slug %>/test-suite">Test Suite</a>
+      </p>
+
+      <h6>Fetch it!</h6>
+      <%= syntax track.fetch_cmd(problem), 'shell' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/languages/_help.erb
+++ b/app/views/languages/_help.erb
@@ -1,0 +1,8 @@
+<div class="tab-pane <%='active' if track.active? %>" id="help">
+  <p>
+    If you're having trouble <a href="https://gitter.im/exercism/support">jump in the support chat</a>,
+    or submit a <a href="https://github.com/exercism/exercism.io/issues">GitHub issue</a> and
+    explain what's going on. We'll do our best to get you unstuck.
+  </p>
+</div>
+

--- a/app/views/languages/_installing.erb
+++ b/app/views/languages/_installing.erb
@@ -1,0 +1,3 @@
+<div class="tab-pane <%='active' if track.active? %>" id="installing">
+  <%= md track.docs.installation %>
+</div>

--- a/app/views/languages/_learning.erb
+++ b/app/views/languages/_learning.erb
@@ -1,0 +1,3 @@
+<div class="tab-pane <%='active' if track.active? %>" id="learning">
+  <%= md track.docs.learning %>
+</div>

--- a/app/views/languages/_resources.erb
+++ b/app/views/languages/_resources.erb
@@ -1,0 +1,3 @@
+<div class="tab-pane <%='active' if track.active? %>" id="resources">
+  <%= md track.docs.resources %>
+</div>

--- a/app/views/languages/_tests.erb
+++ b/app/views/languages/_tests.erb
@@ -1,0 +1,3 @@
+<div class="tab-pane <%='active' if track.active? %>" id="tests">
+  <%= md track.docs.tests %>
+</div>

--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -18,43 +18,43 @@
           </li>
         <% end %>
 
-        <li class="<%= 'active' if topic == "about" %>">
+        <li class="<%= active(topic, 'about') %>">
           <a href="<%="/languages/#{track.id}/about"%>">
             About the <%= track.language %> Track
           </a>
         </li>
 
-        <li class="<%= 'active' if topic == "exercises" %>">
+        <li class="<%= active(topic, 'exercises') %>">
           <a href="<%="/languages/#{track.id}/exercises"%>">
             Available Exercises
           </a>
         </li>
 
-        <li class="<%= 'active' if topic == "installing" %>">
+        <li class="<%= active(topic, 'installing') %>">
           <a href="<%="/languages/#{track.id}/installing"%>">
             Installing <%= track.language %>
           </a>
         </li>
 
-        <li class="<%= 'active' if topic == "tests" %>">
+        <li class="<%= active(topic, 'tests') %>">
           <a href="<%="/languages/#{track.id}/tests"%>">
             Running the Tests
           </a>
         </li>
 
-        <li class="<%= 'active' if topic == "learning" %>">
+        <li class="<%= active(topic, 'learning') %>">
           <a href="<%="/languages/#{track.id}/learning"%>">
             Learning <%= track.language %>
           </a>
         </li>
 
-        <li class="<%= 'active' if topic == "resources" %>">
+        <li class="<%= active(topic, 'resources') %>">
           <a href="<%="/languages/#{track.id}/resources"%>">
             Useful <%= track.language %> Resources
           </a>
         </li>
 
-        <li class="<%= 'active' if topic == "help" %>">
+        <li class="<%= active(topic, 'help') %>">
           <a href="<%="/languages/#{track.id}/help"%>">
             Getting Help
           </a>

--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -18,35 +18,52 @@
           </li>
         <% end %>
 
-        <li class="<%= 'active' if track.active? %>">
-          <a data-toggle="tab" href="#about">About the <%= track.language %> Track</a>
+        <li class="<%= 'active' if topic == "about" %>">
+          <a href="<%="/languages/#{track.id}/about"%>">
+            About the <%= track.language %> Track
+          </a>
+        </li>
+
+        <li class="<%= 'active' if topic == "exercises" %>">
+          <a href="<%="/languages/#{track.id}/exercises"%>">
+            Available Exercises
+          </a>
+        </li>
+
+        <li class="<%= 'active' if topic == "installing" %>">
+          <a href="<%="/languages/#{track.id}/installing"%>">
+            Installing <%= track.language %>
+          </a>
+        </li>
+
+        <li class="<%= 'active' if topic == "tests" %>">
+          <a href="<%="/languages/#{track.id}/tests"%>">
+            Running the Tests
+          </a>
+        </li>
+
+        <li class="<%= 'active' if topic == "learning" %>">
+          <a href="<%="/languages/#{track.id}/learning"%>">
+            Learning <%= track.language %>
+          </a>
+        </li>
+
+        <li class="<%= 'active' if topic == "resources" %>">
+          <a href="<%="/languages/#{track.id}/resources"%>">
+            Useful <%= track.language %> Resources
+          </a>
+        </li>
+
+        <li class="<%= 'active' if topic == "help" %>">
+          <a href="<%="/languages/#{track.id}/help"%>">
+            Getting Help
+          </a>
         </li>
 
         <li>
-          <a data-toggle="tab" href="#exercises">Available Exercises</a>
-        </li>
-
-        <li>
-          <a data-toggle="tab" href="#installing">Installing <%= track.language %></a>
-        </li>
-        <li>
-          <a data-toggle="tab" href="#tests">Running the Tests</a>
-        </li>
-
-        <li>
-          <a data-toggle="tab" href="#learning">Learning <%= track.language %></a>
-        </li>
-
-        <li>
-          <a data-toggle="tab" href="#resources">Useful <%= track.language %> Resources</a>
-        </li>
-
-        <li>
-          <a data-toggle="tab" href="#help">Getting Help</a>
-        </li>
-
-        <li>
-        <a data-toggle="tab" href="#contribute">Contributing to <%= track.language %> on Exercism</a>
+          <a href="<%="/languages/#{track.id}/contribute"%>">
+            Contributing to <%= track.language %> on Exercism
+          </a>
         </li>
       </ul>
 
@@ -60,111 +77,8 @@
         </div>
       <% end %>
 
-      <div class="tab-pane <%='active' if track.active? %>" id="about">
-        <%= md track.docs.about %>
+      <%= erb :"languages/_#{topic}", locals: { track: track } %>
 
-        <h3>Try It!</h3>
-        <p>
-          If you've downloaded the <a href='/cli'>command-line client</a> and have <%= track.language %> installed
-          on your machine, then go ahead and fetch the first problem.
-        </p>
-        <%= syntax track.fetch_cmd, "plain" %>
-
-        <p>
-          In order to be able to submit your solution, you'll need to configure the client with your
-          <a href="/account/key">Exercism API key</a>.
-        </p>
-
-        <%= syntax "exercism configure --key=YOUR_EXERCISM_KEY", "plain" %>
-
-        <p>
-          When you've written a solution, submit it to the site.
-          You'll have to configure the command-line client with your exercism API key before you can submit.
-        </p>
-
-        <%= syntax "exercism submit PATH_TO_FILE", "plain" %>
-      </div>
-
-      <div class="tab-pane" id="exercises">
-        <p>
-          When you're logged in, you can say <code>exercism fetch <%= track.id %></code> to get
-          the next available exercise on the track.
-        </p>
-
-        <p>
-          Every time you submit a solution to an exercise, you will get the next in line the next time
-          you fetch.
-        </p>
-
-        <p>
-          If you want to try a specific exercise, you can always fetch it directly (commands
-          are listed below).
-        </p>
-
-        <p>
-          The exercises are ordered roughly in order of difficulty, but it's a bit haphazard.
-        </p>
-
-        <h3>Available Exercises</h3>
-        <ul class="available_exercises_listing">
-        <% track.problems.each do |problem| %>
-          <li>
-            <a href="/exercises/<%= track.id %>/<%= problem.slug %>"><%= problem.name %></a>
-            <span class="tagline"><%= problem.blurb %></span>
-          </li>
-        <% end %>
-        </ul>
-      </div>
-
-      <div class="tab-pane" id="tests">
-        <%= md track.docs.tests %>
-      </div>
-
-      <div class="tab-pane" id="installing">
-        <%= md track.docs.installation %>
-      </div>
-
-      <div class="tab-pane" id="learning">
-        <%= md track.docs.learning %>
-      </div>
-
-      <div class="tab-pane" id="resources">
-        <%= md track.docs.resources %>
-      </div>
-
-      <div class="tab-pane" id="help">
-        <p>
-          If you're having trouble <a href="https://gitter.im/exercism/support">jump in the support chat</a>,
-          or submit a <a href="https://github.com/exercism/exercism.io/issues">GitHub issue</a> and
-          explain what's going on. We'll do our best to get you unstuck.
-        </p>
-      </div>
-
-      <div class="tab-pane" id="contribute">
-        <h5>Help Us Improve the <%= track.language %> Track!</h5>
-
-        <p>
-          Did you find a typo in the README? Is the test suite missing an edge case?
-          We want to know about it.
-        </p>
-
-        <p>
-          We always welcome GitHub issues and pull requests. See the
-          <a href="<%= track.repository %>"><%= track.language %> repository</a>
-          for more information.
-        </p>
-
-        <h5>Help Add More <%= track.language %> Exercises</h5>
-        <p>
-        The easiest way to add new exercises is to translate existing exercises from other language tracks on Exercism.
-        Here's the <a href="/languages/<%= track.id %>/contribute">full list of unimplemented exercises in <%= track.language %></a>,
-        along with links to all the existing implementations.
-        </p>
-
-        <p>
-        If you have an idea for a completely new exercise, you can follow <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#implementing-a-completely-new-exercise">this guide</a> to add it to the site.
-        </p>
-      </div>
     </div>
   </div>
 

--- a/app/views/languages/repositories.erb
+++ b/app/views/languages/repositories.erb
@@ -7,7 +7,7 @@
     </p>
     <p> Exercism is a project comprised of several repositories and these can be divided basically into:
     </p>
-    <h2> Basic components </h2>
+    <h2> Basic Components </h2>
     <ul>
       <li><strong><a href="https://github.com/exercism/exercism.io">The website</a></strong>: Holds the code that people submit. Browse and review solutions, and have conversations.</li>
       <li><strong><a href="https://github.com/exercism/cli">Command line interface</a></strong>: Use to fetch exercises and submit solutions.</li>

--- a/test/app/languages_test.rb
+++ b/test/app/languages_test.rb
@@ -9,6 +9,59 @@ class LanguagesRoutesTest < Minitest::Test
     ExercismWeb::App
   end
 
+  def test_route_languages
+    fixture = './test/fixtures/xapi_v3_tracks.json'
+    X::Xapi.stub(:get, [200, File.read(fixture)]) do
+      get '/languages'
+      assert_equal 200, last_response.status
+      assert_match 'Animal', last_response.body
+      assert_match 'Fake', last_response.body
+      assert_match 'Fancy Stones', last_response.body
+      assert_match 'Fruit', last_response.body
+      assert_match 'Shoes & Boots', last_response.body
+    end
+  end
+
+  def test_route_repositories
+    fixture = './test/fixtures/xapi_v3_tracks.json'
+    X::Xapi.stub(:get, [200, File.read(fixture)]) do
+      get '/repositories'
+      assert_equal 200, last_response.status
+      assert_match 'Exercism Repositories', last_response.body
+      assert_match 'Basic Components', last_response.body
+      assert_match 'Exercises', last_response.body
+      assert_match 'Interesting Tools', last_response.body
+      assert_match 'Language tracks you can contribute to', last_response.body
+      assert_match 'In Progress', last_response.body
+      assert_match 'Planned', last_response.body
+    end
+  end
+
+  def test_route_languages_invalid_track
+    fixture = './test/fixtures/xapi_v3_tracks_error.json'
+    X::Xapi.stub(:get, [200, File.read(fixture)]) do
+      get '/languages/invalid_track'
+      assert_equal 200, last_response.status
+      assert_match "It doesn't look like we have <b>invalid_track</b> yet", last_response.body
+    end
+  end
+
+  def test_route_languages_valid_track
+    fixture = './test/fixtures/xapi_v3_track.json'
+    X::Xapi.stub(:get, [200, File.read(fixture)]) do
+      get '/languages/animal'
+      assert_equal 200, last_response.status
+      assert_match "About the Animal Track", last_response.body
+      assert_match "Available Exercises", last_response.body
+      assert_match "Installing Animal", last_response.body
+      assert_match "Running the Tests", last_response.body
+      assert_match "Learning Animal", last_response.body
+      assert_match "Useful Animal Resources", last_response.body
+      assert_match "Getting Help", last_response.body
+      assert_match "Contributing to Animal on Exercism", last_response.body
+    end
+  end
+
   def test_route_contribute
     fixture = './test/fixtures/xapi_v3_todos.json'
     X::Xapi.stub(:get, [200, File.read(fixture)]) do
@@ -36,4 +89,34 @@ class LanguagesRoutesTest < Minitest::Test
     end
   end
 
+  def test_route_valid_track_with_invalid_topic
+    get '/languages/valid_track/invalid_topic'
+    assert_equal 404, last_response.status
+    assert_match "It doesn't look like we have <b>invalid_topic</b> yet", last_response.body
+  end
+
+  def test_route_invalid_track_with_valid_topic
+    fixture = './test/fixtures/xapi_v3_tracks_error.json'
+    X::Xapi.stub(:get, [404, File.read(fixture)]) do
+      get '/languages/invalid_track/about'
+      assert_equal 404, last_response.status
+      assert_match "It doesn't look like we have <b>invalid_track</b> yet", last_response.body
+    end
+  end
+
+  def test_route_valid_track_with_valid_topic
+    fixture = './test/fixtures/xapi_v3_track.json'
+    X::Xapi.stub(:get, [200, File.read(fixture)]) do
+      get '/languages/animal/about'
+      assert_equal 200, last_response.status
+      assert_match "About the Animal Track", last_response.body
+      assert_match "Available Exercises", last_response.body
+      assert_match "Installing Animal", last_response.body
+      assert_match "Running the Tests", last_response.body
+      assert_match "Learning Animal", last_response.body
+      assert_match "Useful Animal Resources", last_response.body
+      assert_match "Getting Help", last_response.body
+      assert_match "Contributing to Animal on Exercism", last_response.body
+    end
+  end
 end

--- a/test/fixtures/xapi_v3_track.json
+++ b/test/fixtures/xapi_v3_track.json
@@ -1,0 +1,26 @@
+{
+  "error": "",
+  "track": {
+    "id": "animal",
+    "language": "Animal",
+    "repository": "https://github.com/exercism/xanimal",
+    "checklist_issue": 1,
+    "gitter": null,
+    "todo": ["apple", "banana", "cherry", "one", "three", "two"],
+    "active": true,
+    "implemented": true,
+    "doc_format": "md",
+    "docs": {
+      "about": "",
+      "installation": "",
+      "tests": "",
+      "learning": "",
+      "resources": ""
+    },
+    "problems": [{
+      "slug": "dog",
+      "name": "Dog",
+      "blurb": "This is dog."
+    }]
+  }
+}

--- a/test/fixtures/xapi_v3_tracks_error.json
+++ b/test/fixtures/xapi_v3_tracks_error.json
@@ -1,0 +1,3 @@
+{
+  "error": "No track 'invalid_track'"
+}


### PR DESCRIPTION
Addresses https://github.com/exercism/exercism.io/issues/3035

### Problem:

Right now if you go to exercism.io/languages/:track_id there is a menu
in the sidebar. E.g. http://exercism.io/languages/ruby

Each of these is a section in the same page, and we can't link directly
to them. Also, they break the back button in some browsers. If you click
into one, you can't use the back button to get to the previous place.

I think that it would be useful to have actual endpoints and urls for
each of these.

### Proposal:

In order to separate out the sections into urls, I decided to create new
partials for each section. The following were created:
  - about
  - contribute
  - exercises
  - help
  - installing
  - learning
  - resources
  - tests

A new route was introduced in order to render the section. This route
will take in the `:track_id` and a new parameter called `:topic`. The
topic will correspond to the section that it will load. A check was also
added to the route to make sure to render the `not_found` page if an
invalid section was added.

This change also removes the anchors from the `languages/languages.rb`
file and now loads the partials that were created