### PR TITLE
Fix anchor tag issues

### DIFF
--- a/x/docs/md/cli/mac.md
+++ b/x/docs/md/cli/mac.md
@@ -6,7 +6,7 @@
 Homebrew is a package manager for OS X which installs the stuff that Apple
 didn't.
 
-Find out if you have homebrew installed via the terminal.
+Find out if you have homebrew via the terminal.
 
 You can open a terminal using Spotlight by pressing <command><spacebar> and
 then type 'terminal' in the space provided.
@@ -25,7 +25,9 @@ Homebrew/homebrew-core (git revision 3b4c; last commit 2016-05-09)
 Install the CLI via homebrew in the following section.  Otherwise see
 "[Installing Without Homebrew](#installing-without-homebrew)".
 
-### Installing With Homebrew <a name="installing-with-homebrew"></a>
+
+<a name="installing-with-homebrew"></a>
+### Installing With Homebrew 
 
 Install the CLI via [homebrew](http://brew.sh/) with the following command:
 
@@ -44,7 +46,9 @@ If there was a problem you will get an error message saying _command not found_.
 If everything is fine, you're done installing the CLI, and you can move on to the next step,
 which is configuring the CLI.
 
-### Installing Without Homebrew <a name="installing-without-homebrew"></a>
+
+<a name="installing-without-homebrew"></a>
+### Installing Without Homebrew 
 
 This is described in detail in [this video tutorial](https://www.youtube.com/watch?v=TCT4eHGwfaE).
 

--- a/x/docs/md/cli/windows.md
+++ b/x/docs/md/cli/windows.md
@@ -3,7 +3,8 @@ There are two options for installing the Exercism CLI on Windows.
 1. [Manual Installation](#manual)
 1. [Using the Chocolatey Package Manager for Windows](#chocolatey)
 
-## Manual Installation <a name="manual"></a>
+<a name="manual"></a>
+## Manual Installation 
 What follows are instructions that work for installing exercism on Windows 7 or Windows 8.
 Instructions for other versions of Windows may differ slightly, but the principle will be the same.
 
@@ -72,7 +73,8 @@ The following instructions will append the location of the exercism.exe file to 
 1. In the resulting window type in "exercism" and press Enter
 1. If all is well you should be shown information on how to use exercism
 
-## Using the Chocolatey Package Manager for Windows <a name="chocolatey"></a>
+<a name="chocolatey"></a>
+## Using the Chocolatey Package Manager for Windows 
 **NOTE:** You can find more information about using Chocolatey at the [Chocolatey site](https://chocolatey.org/).
 
 ### Using PowerShell


### PR DESCRIPTION
Moved anchor tags above headings to fix display issues.
Before:
![chocprob1](https://cloud.githubusercontent.com/assets/540264/17995219/4da97ace-6ba3-11e6-9ca5-d8c9c0292190.png)

After:
![chocprob2](https://cloud.githubusercontent.com/assets/540264/17995222/5a308da0-6ba3-11e6-9ea8-2a15b919c2b3.png)

As noted in https://github.com/exercism/exercism.io/issues/3078, the fix doesn't completely fix display issues. I'm working on the main issue for the CLI - https://github.com/exercism/exercism.io/issues/2535 and hope to have a pull request if not within hours, by early next week which has more major changes to the copy and layout.
This fix should resolve #3078