### PR TITLE
Partition Inactive Languages to Inactive & Planned

### DIFF
--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -6,8 +6,9 @@ module ExercismWeb
       get '/languages' do
         tracks = X::Track.all
         active, inactive = tracks.partition(&:active?)
+        planned, inactive = inactive.partition(&:planned?)
         inactive.sort! { |a, b| b.problems.count <=> a.problems.count }
-        erb :"languages/index", locals: { active: active, inactive: inactive }
+        erb :"languages/index", locals: { active: active, inactive: inactive, planned: planned }
       end
 
       get '/repositories' do

--- a/app/views/languages/index.erb
+++ b/app/views/languages/index.erb
@@ -17,7 +17,7 @@
     <% inactive.each_slice(6) do |tracks| %>
       <div class="row">
         <% tracks.each do |t| %>
-          <%= erb :'languages/_block', locals: { track: t }  if t.problems.any? %>
+          <%= erb :'languages/_block', locals: { track: t } %>
         <% end %>
       </div>
     <% end %>
@@ -25,10 +25,10 @@
     <section class="page-header">
       <h3>Planned</h3>
     </section>
-    <% inactive.each_slice(6) do |tracks| %>
+    <% planned.each_slice(6) do |tracks| %>
       <div class="row">
         <% tracks.each do |t| %>
-          <%= erb :'languages/_block', locals: { track: t } if t.planned? %>
+          <%= erb :'languages/_block', locals: { track: t } %>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
Currently, the Upcoming & Planned section languages come from an array
called inactive. Due to them being intermingled, it causes some issues
on the Languages index page in Planned.

![Before changes](https://cloud.githubusercontent.com/assets/5634381/18018375/19ea3bd0-6b9c-11e6-85ed-850c5a96b6f2.png)

This partitions the two out and simplifies the view page.

![After Changes](https://cloud.githubusercontent.com/assets/5634381/18018379/295fc184-6b9c-11e6-8087-b219e0c888bb.png)

I'm happy to hear any recommendations on a better way to implement this. Also, if this is the way to go, then maybe `inactive` needs a new name since it's no longer accurate?
