### PR TITLE
change 'Edit Nitpick' to 'Edit Comment'

### DIFF
--- a/app/views/submissions/edit_nit.erb
+++ b/app/views/submissions/edit_nit.erb
@@ -1,6 +1,6 @@
 <div class="container">
   <section class="page-header">
-    <h1>Edit Nitpick</h1>
+    <h1>Edit Comment</h1>
   </section>
   <section>
     <form class="inline" action="/submissions/<%= submission.key %>/nits/<%= nit.id %>" method='POST'>

--- a/test/acceptance/nits_test.rb
+++ b/test/acceptance/nits_test.rb
@@ -19,7 +19,7 @@ class NitsTest < AcceptanceTestCase
 
     with_login(@user) do
       visit "/submissions/#{submission.key}/nits/#{nit.id}/edit"
-      assert_content "Edit Nitpick"
+      assert_content "Edit Comment"
     end
   end
 end


### PR DESCRIPTION
When using the site this evening, I noticed that when I went to edit a comment, it had the old wording to edit a "Nitpick". This seems an artifact of the old naming, so here's a PR to change it and make things more consistent.