### PR TITLE
Replace calls to Xapi.exists? with call to x-api v3

### DIFF
--- a/api/v1/routes/iterations.rb
+++ b/api/v1/routes/iterations.rb
@@ -14,7 +14,7 @@ module ExercismAPI
           halt 401, { error: message }.to_json
         end
 
-        unless Xapi.exists?(language, slug)
+        unless X::Exercise.exists?(language, slug)
           message = "Exercise '#{slug}' in language '#{language}' doesn't exist. "
           message << "Maybe you mispelled it?"
           halt 404, { error: message }.to_json

--- a/api/v1/routes/tracks.rb
+++ b/api/v1/routes/tracks.rb
@@ -6,7 +6,7 @@ module ExercismAPI
       get '/tracks/:id/status' do |id|
         require_key
 
-        unless Xapi.exists?(id)
+        unless X::Exercise.exists?(id)
           message = "Track #{id} not found."
           halt 404, { error: message }.to_json
         end

--- a/lib/exercism/use_cases/attempt.rb
+++ b/lib/exercism/use_cases/attempt.rb
@@ -15,7 +15,7 @@ class Attempt
   # rubocop:enable Metrics/AbcSize
 
   def valid?
-    !!slug && Xapi.exists?(track, slug)
+    !!slug && X::Exercise.exists?(track, slug)
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/lib/exercism/xapi.rb
+++ b/lib/exercism/xapi.rb
@@ -3,10 +3,6 @@ module Xapi
     ENV.fetch('EXERCISES_API_URL') { "http://x.exercism.io" }
   end
 
-  def self.exists?(language, slug=nil)
-    request(*['tracks', language, slug].compact).status != 404
-  end
-
   def self.conn
     Faraday.new(url: exercises_api_url) do |c|
       c.use Faraday::Response::Logger

--- a/test/api/assignments_test.rb
+++ b/test/api/assignments_test.rb
@@ -25,7 +25,7 @@ class AssignmentsApiTest < Minitest::Test
 
   def test_api_accepts_submission_attempt
     Notify.stub(:everyone, nil) do
-      Xapi.stub(:exists?, true) do
+      X::Exercise.stub(:exists?, true) do
         post '/user/assignments', { key: alice.key, solution: { 'ruby/one/code.rb' => 'THE CODE' } }.to_json
       end
     end
@@ -41,7 +41,7 @@ class AssignmentsApiTest < Minitest::Test
 
   def test_api_accepts_submission_attempt_with_multi_file_solution
     Notify.stub(:everyone, nil) do
-      Xapi.stub(:exists?, true) do
+      X::Exercise.stub(:exists?, true) do
         solution = {
           'ruby/one/file1.rb' => 'code 1',
           'ruby/one/file2.rb' => 'code 2',
@@ -61,7 +61,7 @@ class AssignmentsApiTest < Minitest::Test
 
   def test_provides_a_useful_error_message_when_key_is_wrong
     Notify.stub(:everyone, nil) do
-      Xapi.stub(:exists?, true) do
+      X::Exercise.stub(:exists?, true) do
         post '/user/assignments', { key: 'no-such-key', solution: { 'ruby/one/code.rb' => 'THE CODE' } }.to_json
       end
     end
@@ -70,7 +70,7 @@ class AssignmentsApiTest < Minitest::Test
 
   def test_api_accepts_submission_on_completed_exercise
     Notify.stub(:everyone, nil) do
-      Xapi.stub(:exists?, true) do
+      X::Exercise.stub(:exists?, true) do
         post '/user/assignments', { key: alice.key, language: 'ruby', problem: 'one', solution: { 'ruby/one/code.rb' => 'THE CODE' } }.to_json
       end
     end
@@ -87,7 +87,7 @@ class AssignmentsApiTest < Minitest::Test
   def test_api_rejects_duplicates
     Attempt.new(alice, Iteration.new({ 'code.rb' => 'THE CODE' }, 'ruby', 'one')).save
     Notify.stub(:everyone, nil) do
-      Xapi.stub(:exists?, true) do
+      X::Exercise.stub(:exists?, true) do
         post '/user/assignments', { key: alice.key, solution: { 'ruby/one/code.rb' => 'THE CODE' } }.to_json
       end
     end

--- a/test/api/iterations_test.rb
+++ b/test/api/iterations_test.rb
@@ -22,7 +22,7 @@ class IterationsApiTest < Minitest::Test
       comment: '',
     }
 
-    Xapi.stub(:exists?, true) do
+    X::Exercise.stub(:exists?, true) do
       post '/user/assignments', submission.to_json
     end
 
@@ -31,7 +31,7 @@ class IterationsApiTest < Minitest::Test
     submission[:comment] = 'Awesome code!'
     submission[:solution] = { 'code.rb' => 'CODE2' }
 
-    Xapi.stub(:exists?, true) do
+    X::Exercise.stub(:exists?, true) do
       post '/user/assignments', submission.to_json
     end
 
@@ -79,7 +79,7 @@ class IterationsApiTest < Minitest::Test
       Hack::UpdatesUserExercise.new(*args).update
     end
 
-    Xapi.stub(:exists?, true) do
+    X::Exercise.stub(:exists?, true) do
       get '/iterations/latest', key: @alice.key
     end
 
@@ -89,7 +89,7 @@ class IterationsApiTest < Minitest::Test
   end
 
   def test_skip_problem
-    Xapi.stub(:exists?, true) do
+    X::Exercise.stub(:exists?, true) do
       post '/iterations/ruby/one/skip', key: @alice.key
     end
 
@@ -101,7 +101,7 @@ class IterationsApiTest < Minitest::Test
   end
 
   def test_skip_non_existent_problem
-    Xapi.stub(:exists?, false) do
+    X::Exercise.stub(:exists?, false) do
       post '/iterations/ruby/not-found/skip', key: @alice.key
     end
 
@@ -113,7 +113,7 @@ class IterationsApiTest < Minitest::Test
   end
 
   def test_skip_problem_as_guest
-    Xapi.stub(:exists?, true) do
+    X::Exercise.stub(:exists?, true) do
       post '/iterations/ruby/one/skip', key: 'invalid-api-key'
     end
 
@@ -131,12 +131,12 @@ class IterationsApiTest < Minitest::Test
       "dir" => "/path/to/exercism/dir",
     }
 
-    Xapi.stub(:exists?, true) do
+    X::Exercise.stub(:exists?, true) do
       post '/user/assignments', submission.to_json
     end
 
     submission = Submission.first
-    assert_equal "go", submission.language
+    assert_equal "go", submission.track_id
     assert_equal "binary", submission.slug
     expected = { "binary.go" => "Hello, World!" }
     assert_equal expected, submission.solution
@@ -150,7 +150,7 @@ class IterationsApiTest < Minitest::Test
       "dir" => "/path/to/exercism/dir",
     }
 
-    Xapi.stub(:exists?, true) do
+    X::Exercise.stub(:exists?, true) do
       post '/user/assignments', submission.to_json
     end
 
@@ -158,6 +158,6 @@ class IterationsApiTest < Minitest::Test
     assert_equal "binary", submission.slug
     expected = { "binary.go" => "Hello, World!" }
     assert_equal expected, submission.solution
-    assert_equal "go", submission.language
+    assert_equal "go", submission.track_id
   end
 end

--- a/test/exercism/use_cases/attempt_test.rb
+++ b/test/exercism/use_cases/attempt_test.rb
@@ -10,11 +10,11 @@ class AttemptTest < Minitest::Test
   end
 
   def test_validity
-    Xapi.stub(:exists?, true) do
+    X::Exercise.stub(:exists?, true) do
       assert Attempt.new(user, Iteration.new({ 'two.py' => 'CODE' }, 'python', 'two')).valid?
     end
 
-    Xapi.stub(:exists?, false) do
+    X::Exercise.stub(:exists?, false) do
       refute Attempt.new(user, Iteration.new({ 'two.py' => 'CODE' }, 'python', 'two')).valid?
     end
   end
@@ -22,7 +22,7 @@ class AttemptTest < Minitest::Test
   def test_saving_with_comments_creates_a_new_comment
     iteration = Iteration.new({ 'two.py' => 'CODE' }, 'python', 'two', comment: "hello world")
 
-    Xapi.stub(:exists?, true) do
+    X::Exercise.stub(:exists?, true) do
       attempt = Attempt.new(user, iteration).save
 
       assert_equal 1, Comment.count
@@ -35,7 +35,7 @@ class AttemptTest < Minitest::Test
 
   def test_saving_without_comments_does_not_create_the_comment
     save_attempt = lambda do |i|
-      Xapi.stub(:exists?, true) do
+      X::Exercise.stub(:exists?, true) do
         Attempt.new(user, i).save
       end
     end

--- a/test/x/exercise_test.rb
+++ b/test/x/exercise_test.rb
@@ -4,13 +4,24 @@ require_relative '../../x/exercise'
 
 module X
   class ExerciseTest < Minitest::Test
-    def test_exists_gets_passed_a_track_id
-      <<-NEED_HELP
-        I would like to test the exists? method by checking that request is
-        called when the method is called. I however am not sure how to mock out
-        method from a module and expect that it was called. Any insight into
-        how to do that?
-      NEED_HELP
+    def test_exists_returns_true
+      response = Minitest::Mock.new
+      response.expect(:status, 200, [])
+
+      X::Xapi.stub(:request, response) do
+        result = X::Exercise.exists?('valid_track_id')
+        assert_equal(true, result)
+      end
+    end
+
+    def test_exists_returns_false
+      response = Minitest::Mock.new
+      response.expect(:status, 404, [])
+
+      X::Xapi.stub(:request, response) do
+        result = X::Exercise.exists?('invalid_track_id')
+        assert_equal(false, result)
+      end
     end
   end
 end

--- a/test/x/exercise_test.rb
+++ b/test/x/exercise_test.rb
@@ -1,0 +1,16 @@
+require_relative '../test_helper'
+require_relative '../x_helper'
+require_relative '../../x/exercise'
+
+module X
+  class ExerciseTest < Minitest::Test
+    def test_exists_gets_passed_a_track_id
+      <<-NEED_HELP
+        I would like to test the exists? method by checking that request is
+        called when the method is called. I however am not sure how to mock out
+        method from a module and expect that it was called. Any insight into
+        how to do that?
+      NEED_HELP
+    end
+  end
+end

--- a/x/exercise.rb
+++ b/x/exercise.rb
@@ -12,5 +12,9 @@ module X
         instance_variable_set(:"@#{name}", attrs[name.to_s])
       end
     end
+
+    def self.exists?(track_id, slug=nil)
+      request(*['tracks', track_id, slug].compact).status != 404
+    end
   end
 end

--- a/x/exercise.rb
+++ b/x/exercise.rb
@@ -14,7 +14,7 @@ module X
     end
 
     def self.exists?(track_id, slug=nil)
-      request(*['tracks', track_id, slug].compact).status != 404
+      X::Xapi.request(*['tracks', track_id, slug].compact).status != 404
     end
   end
 end


### PR DESCRIPTION
This closes #2637 and exercism/todo#167

#### Issue Summary
> I think it would make sense to implement this as X::Exercise.exists?, which would rely on X::Xapi, which calls v3.

#### Solution
The following changes were made:
  - Use `X::Exercise` for the Iterations class
  - Use `X::Exercise` for the Tracks class
  - Use `X::Exercise` for the Attempt class
  - Migrate the `exists?` class from `X::Xapi` to `X::Exercise`

There was a small comment on the original implementation for this PR that I also wanted to address however I did not know (yet) on how to implement the test. I left a docstring comment on the test in hopes that somebody will be able to point me to the right direction 😄 
