### PR TITLE
Team pagination

### DIFF
--- a/app/routes/teams.rb
+++ b/app/routes/teams.rb
@@ -55,7 +55,7 @@ module ExercismWeb
 
           locals = {
             team: team,
-            stream: TeamStream.new(team, current_user.id, params['page'] || 1),
+            stream: TeamStream.new(team, current_user.id, params['page'] || 1, params['per_page']),
             active: 'stream',
           }
           erb :"teams/stream", locals: locals

--- a/lib/exercism/team_stream.rb
+++ b/lib/exercism/team_stream.rb
@@ -8,11 +8,12 @@ require 'will_paginate/array'
 class TeamStream
   attr_reader :team, :viewer_id, :page, :track_id, :user_id, :username, :slug
   attr_accessor :per_page
-  def initialize(team, viewer_id, page=1)
+
+  def initialize(team, viewer_id, page=1, per_page=50)
     @team = team
     @viewer_id = viewer_id
     @page = page.to_i
-    @per_page = 50
+    @per_page = per_page.to_i
   end
 
   def track_id=(track_id)


### PR DESCRIPTION
@jendiamond && @MrExeter

---

Current URL on exercism.io `<a rel="next"
href="/teams/some-team/streams?page=2">2</a>`

Our URL `<a rel="next"
href="/teams/some-team/streams?per_page=2&amp;page=2">2</a>`

(`per_page=2&amp;`  Is created on the local instance of the page generated
from the test's Given, where we force paginate at 2 activities.
*NOTE:  `&amp;` == &amp;*

It seem as though we probably not seeing the page `visit
"/teams/some-team/streams?page=1"`
```
    with_login(user) do
      visit "/teams/some-team/streams?page=1"
      click_link '2'
      assert_content 'Apple 2 foobar'
    end
```
Running the above test with click_link("2"), click_link("Next") and
click_link("puppy") fails.
```
  1) Error:
TeamAcceptanceTest#test_team_pagination:
Capybara::ElementNotFound: Unable to find link "2"
```
```
1) Error:
TeamAcceptanceTest#test_team_pagination:
Capybara::ElementNotFound: Unable to find link "Next"
```

We also tried all links with:
```
    with_login(user) do
      visit "/teams/some-team/streams?page=2"
      click_link '2'
      assert_content("Apple 2 foobar")
    end
```

and
```
    with_login(user) do
      visit "/teams/some-team/streams?page=1"
      click_on '2'
      assert_content 'Apple 2 foobar'
    end
```

We realized that we need `visit "/teams/some-team/streams?page=1"` to have
`?page=2` for the pagination work.

Now the clink_link seems to be working.

```
TeamAcceptanceTest#test_team_pagination
[/vagrant/exercism.io/test/acceptance/team_test.rb:91]:
Expected to find text "Apple 2 foobar" in "Toggle navigation Exercism.io
Dashboard Languages Donate foobar Profile Account API Key Recently Viewed Log
Out Activity Members Manage All 3 3 3 3 foobar 3 3 Some Team Apple0 foobar 1
iteration · 0 comments just now mark as read ← Previous 1 2 Next → Beta About
Contribute to Exercism Help How it Works (New Devs) How it Works (Experienced
Devs) The Command-Line Client GitHub Twitter Newsletter Sponsors Heroku
Bugsnag Rackspace Shopify © 2016 Katrina Owen".
```

Are we only creating one page so we can't see the expectation?

---

### We realized that theActivities are being listed in descending order not ascending as we thought.  We were looking for Apple2 and we needed to look for Apple0.

```
    with_login(user) do
      visit "/teams/some-team/streams?per_page=2"
      click_link '2'
      assert_content 'Apple0 foobar'
    end
  end
```

## All tests pass! Success at last!
349 runs, 918 assertions, 0 failures, 0 errors, 0 skips
