### PR TITLE
Make the list of language track repositories more scannable.

### DIFF
--- a/app/views/languages/_repo.erb
+++ b/app/views/languages/_repo.erb
@@ -1,14 +1,32 @@
-<div class="track_link col-xs-4 col-sm-4 col-md-2 col-lg-2 text-center">
-  <a href="<%= track.repository%>">
-    <p>
-      <%= track_icon(track.id) %>
-    </p>
-    <p>
-      <%= track.language %>
-    </p>
-  </a>
-  <% unless track.active %>
-    <p><a href="https://github.com/exercism/x<%= track.id %>/issues/<%= track.checklist_issue %>">Launch checklist</a>
-    </p>
+<table class="table table-bordered table-striped">
+  <col width="5%" />
+  <col width="20%" />
+  <% if active %>
+    <col width="75%" />
+  <% else %>
+    <col width="55%" />
+    <col width="20%" />
   <% end %>
-</div>
+  <thead>
+    <tr>
+      <th>Icon</th>
+      <th>Language</th>
+      <th>Repository</th>
+      <% unless active %>
+        <th>Checklist</th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% tracks.each do |track| %>
+      <tr>
+        <td><%= track_icon(track.id) %></td>
+        <td><a href="http://exercism.io/languages/<%= track.id %>" target='_blank'><%= track.language %></a></td>
+        <td><a href="<%= track.repository%>" target='_blank'><%= track.repository%></a></td>
+        <% unless active %>
+          <td><a href="https://github.com/exercism/x<%= track.id %>/issues/<%= track.checklist_issue %>" target='_blank'>Launch checklist</a></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/languages/repositories.erb
+++ b/app/views/languages/repositories.erb
@@ -27,33 +27,15 @@
   <section class="page-header">
     <h3>Language tracks you can contribute to</h3>
   </section>
-  <% active.each_slice(6) do |tracks| %>
-    <div class="row">
-      <% tracks.each do |t| %>
-        <%= erb :'languages/_repo', locals: { track: t } %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= erb :'languages/_repo', locals: { tracks: active, active: true } %>
   <section class="page-header">
     <h3>In Progress</h3>
     <p>Help contribute to inactive languages by adding more exercises, and helping to review code. To see what still needs to be done, view the launch checklist.</p>
   </section>
-  <% upcoming.each_slice(6) do |tracks| %>
-    <div class="row">
-      <% tracks.each do |t| %>
-        <%= erb :'languages/_repo', locals: { track: t } %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= erb :'languages/_repo', locals: { tracks: upcoming, active: false } %>
   <section class="page-header">
     <h3>Planned</h3>
     <p> People have requested these languages, but we need exercises before we can launch the track. Check out the launch checklist for an idea of what needs to be done.</p>
   </section>
-  <% planned.each_slice(6) do |tracks| %>
-    <div class="row">
-      <% tracks.each do |t| %>
-        <%= erb :'languages/_repo', locals: { track: t } %>
-      <% end %>
-    </div>
-  <% end %>
+  <%= erb :'languages/_repo', locals: { tracks: planned, active: false } %>
 </div>


### PR DESCRIPTION
* Fixes https://github.com/exercism/exercism.io/issues/3101
* List of language track repositories are now in tabular format.
* Updated all the 3 sections: `Language tracks`, `In Progress` & `Planned`.

@kytrinyx please find below screenshots of Before/After fix.

- Before Fix (Lists in grid)

![language_tracks_in_grid](https://cloud.githubusercontent.com/assets/16205473/18467027/e890adc0-79bb-11e6-815b-597d5d2839ca.png)

![in_progress_in_grid](https://cloud.githubusercontent.com/assets/16205473/18467044/fb2077ea-79bb-11e6-85d9-a77606020509.png)


- After Fix (Lists in table)

![language_tracks_in_table](https://cloud.githubusercontent.com/assets/16205473/18467089/24fc5a98-79bc-11e6-9f01-ef5d468258c1.png)

![in_progress_in_table](https://cloud.githubusercontent.com/assets/16205473/18467096/3261cccc-79bc-11e6-8bd2-e9868d5e7fc6.png)


