### PR TITLE
Change choco update to choco upgrade

### DIFF
--- a/docs/maintaining-a-track.md
+++ b/docs/maintaining-a-track.md
@@ -1,0 +1,79 @@
+# Maintaining an Exercism Language Track
+
+* [Philosophy](#philosophy)
+
+  * [Be Kind](#be-kind)
+  * [Be Responsive](#be-responsive)
+  * [Empower New Contributors](#empower-new-contributors)
+  * [Recognize Great Contributions](#recognize-great-contributions)
+  * [Improve the Learning Experience](#improve-the-learning-experience)
+  * [Collaborate](#collaborate)
+
+* [Day-to-Day Tactics](#day-to-day-tactics)
+
+  * [Watch Key Repositories](#watch-key-repositories)
+  * [Perform Common Tasks](#perform-common-tasks)
+
+## Philosophy
+
+### Be Kind
+
+First and foremost, strive always to be kind, humble and show gratitude for the work being contributed.
+
+**_Kind_ is not the same thing as _nice_.** Being kind does not mean being a pushover.
+Doing the right thing is not always the thing that pleases the most people.
+
+### Be Responsive
+
+Even if you do not have an answer immediately, respond quickly. This lets the person on the other end know that they've been heard. If it takes a long time to figure out what to do, be honest about what's going on.
+
+### Empower New Contributors
+
+As a maintainer, your most important task is to make it as easy as possible for people to successfully contribute. The exact details will vary, but often this means things like:
+
+- documenting or scripting the necessary steps to get started with the codebase
+- helping people understand how to use the tools successfully (including git and GitHub)
+- writing detailed issues about work that needs to be done so that someone without knowledge of the project can easily find something to work on
+- improving the tooling to reduce friction
+- answering questions
+- reviewing pull requests
+
+### Recognize Great Contributions
+
+When someone has done great work, thank them. If they do great work consistently over time, invite them to become maintainers.
+
+### Improve the Learning Experience
+
+The exercises often start out as an experiment. As people do the exercises we learn a lot about what's interesting, tough, boring, challenging, fun, tricky, confusing, or useful.
+
+Over time we try to:
+
+- improve the problem descriptions in [exercism/x-common](github.com/exercism/x-common)
+- add missing edge cases in the test suites
+- reorder tests to allow a more incremental approach to solving the problem
+- improve the test suites to avoid pushing people towards specific solutions
+- reorder exercises to provide a gentler learning curve on the site
+- deprecate exercises that don't provide enough value
+
+### Collaborate
+
+Maintaining a track is so much more fun and interesting when there are several people actively involved in the process.
+
+Even with full push access, **create pull requests**. This notifies the other maintainers about the change.
+As a general rule, don't merge your own pull requests, unless they are utterly trivial.
+
+## Day-to-Day Tactics
+
+### Watch Key Repositories
+
+This will notify you of all new issues, pull requests, and comments.
+
+In addition to the language track repository itself, you may also want to watch:
+
+- the [exercism/x-common](http://github.com/exercism/x-common) repository which contains all of the exercise descriptions and metadata. Many discussions about improvements to the exercises happen here.
+- the [exercism/discussions](http://github.com/exercism/discussions) repository where a lot of high-level discussions about Exercism itself happen (roadmap, direction, ideas, conundrums).
+
+### Perform Common Tasks
+
+- Triage issues [TODO: link to documentation]
+- Review pull requests [TODO: link to documentation]

--- a/x/docs/md/cli/windows.md
+++ b/x/docs/md/cli/windows.md
@@ -45,7 +45,7 @@ cinst exercism-io-cli
 5. Proceed to [Running exercism](#run-exercism) to test the exercism install
 6. If at anytime you need to update the exercism CLI to a newer version you can open up a command line (step 1) and type in the following:
 
-        choco update exercism-io-cli
+        choco upgrade exercism-io-cli
 
 ### Running exercism <a name="run-exercism"></a>
 1. Open a command line interface (CLI) by clicking on "Start", typing "cmd" into the search bar and pressing enter


### PR DESCRIPTION
DEPRECATION NOTICE - choco update is deprecated and will be removed or
 replaced in version 1.0.0 with something that performs the functions
 of updating package indexes. Please use `choco upgrade` instead.