### PR TITLE
Adds user filter on track stream

### DIFF
--- a/app/routes/tracks.rb
+++ b/app/routes/tracks.rb
@@ -1,12 +1,18 @@
 module ExercismWeb
   module Routes
     class Tracks < Core
+      get '/tracks/:id/my_solutions' do |id|
+        please_login
+        page = params[:page] || 1
+        stream = TrackStream.new(current_user, id, nil, page, true)
+        session[:inbox] = id
+        erb :"track_stream/index", locals: { stream: stream }
+      end
+
       get '/tracks/:id/exercises/?:slug?' do |id, slug|
         please_login
-
         page = params[:page] || 1
         stream = TrackStream.new(current_user, id, slug, page)
-
         session[:inbox] = id
         session[:inbox_slug] = slug
 

--- a/test/exercism/track_stream_filters_test.rb
+++ b/test/exercism/track_stream_filters_test.rb
@@ -86,6 +86,18 @@ class TeamStreamTest < Minitest::Test
     assert_equal 1, item3.total
     assert_equal 1, item3.unread
     refute item3.active?
+
+    filter = TrackStream::ViewerFilter.new(bob.id, 'go', true)
+    assert_equal 1, filter.items.size
+
+
+    item = filter.items.first
+
+
+    assert_equal 'My Solutions', item.text
+    assert_equal '/tracks/go/my_solutions', item.url
+    assert_equal 2, item.total
+    assert item.active?
   end
 
   private


### PR DESCRIPTION
Currently on tracks, filters for language and language/problem exists and do not have option of filtering user's solutions/exercises.

This PR adds a filter on tracks where user can filter out only his/her solutions for a particular language track. The filtered results doesn't include archived exercises.

Below is the screen shot. 
![screenshot from 2016-09-20 10-57-07](https://cloud.githubusercontent.com/assets/8723247/18736332/766a4340-80c9-11e6-99a2-df432e202234.png)

Please let me know the feedback on this.