### PR TITLE
Make headers in markdown linkable.

### DIFF
--- a/lib/exercism/markdown.rb
+++ b/lib/exercism/markdown.rb
@@ -37,12 +37,18 @@ end
 module ExercismLib
   class Markdown < Redcarpet::Render::XHTML
     def self.render(content)
-      markdown = Redcarpet::Markdown.new(new, options)
+      markdown = Redcarpet::Markdown.new(new(options), extensions)
       markdown.render(content)
     end
 
-    # rubocop:disable Metrics/MethodLength
     def self.options
+      {
+        with_toc_data: true,
+      }
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def self.extensions
       {
         fenced_code_blocks: true,
         no_intra_emphasis: true,

--- a/test/exercism/markdown_test.rb
+++ b/test/exercism/markdown_test.rb
@@ -23,11 +23,10 @@ class MarkdownTest < Minitest::Test
     assert_equal expected, ExercismLib::Markdown.render(markdown)
   end
 
-  def test_lists_without_blank_lines
-    markdown = "foo bar baz\n* one two three\n* cats dogs and frogs"
-    expected = "<p>foo bar baz</p>\n\n<ul>\n<li>one two three</li>\n" \
-               "<li>cats dogs and frogs</li>\n</ul>\n"
-    assert_equal expected, ExercismLib::Markdown.render(markdown)
+  def test_includes_ids_with_headers_so_they_are_linkable
+     markdown = "toc: [Header](#header)\n# Header\n"
+     expected = "<p>toc: <a href=\"#header\">Header</a></p>\n\n<h1 id=\"header\">Header</h1>\n"
+     assert_equal expected, ExercismLib::Markdown.render(markdown)
   end
 
   def test_mention_works_multiple_times


### PR DESCRIPTION
- "options" are parameters for the Redcarpet renderer, while
  "extensions" enable features in the parser.
- Remove duplicate test.