### PR TITLE
Update Compass instructions for compiling the csss to production

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -305,7 +305,7 @@ bundle exec compass watch
 Before committing, tell `compass` to compile the stylesheets for production use.
 
 ```bash
-bundle exec compass compile --production
+bundle exec compass compile -e production --force
 ```
 
 For CSS we are using Sass (with `.scss`). Feel free to use [Bootstrap 3](http://getbootstrap.com) components and mixins. Or if you want to use even more mixins you can use [Compass](http://compass-style.org/reference/compass/). Structurewise we try to separate components, mixins and layouts. Where layouts should be a single page (using an HTML id as a selector) and components should be reusable partials, which can look different by layout.


### PR DESCRIPTION
@kytrinyx 

I have notice that the documentation for compiling the css to production is outdated.

for references [compass-production](http://compass-style.org/help/tutorials/production-css/)