### PR TITLE
Add migration for watermarks

### DIFF
--- a/db/migrate/201610012033_create_watermarks.rb
+++ b/db/migrate/201610012033_create_watermarks.rb
@@ -1,0 +1,12 @@
+class CreateWatermarks < ActiveRecord::Migration
+  def change
+    create_table :watermarks do |t|
+      t.integer   :user_id, null: false
+      t.string    :track_id, null: false
+      t.string    :slug, null: false
+      t.timestamp :at, null: false
+    end
+    add_index :watermarks, [:user_id, :track_id, :slug], unique: true, name: "index_watermarks_on_user_track_slug"
+    add_index :watermarks, :user_id
+  end
+end


### PR DESCRIPTION
This adds a database migration which we will need in order to add a _watermarks_ feature that will let us implement "mark all as read" in the activity streams with fewer rows in the database.

I'm adding the migration separately so that it can be run in production before we have any code that depends on it.

See #3130 for more details.