### PR TITLE
Fix overlapping test names

### DIFF
--- a/test/exercism/team_stream_filters_test.rb
+++ b/test/exercism/team_stream_filters_test.rb
@@ -1,18 +1,18 @@
 require_relative '../integration_helper'
 
-class TeamStreamTest < Minitest::Test
+class TeamStreamFiltersTest < Minitest::Test
   include DBCleaner
 
   def setup
     super
     Language.instance_variable_set(:"@by_track_id", "go" => "Go", "elixir" => "Elixir")
-    TeamStream.instance_variable_set(:"@ordered_slugs", "go" => %w(clock anagram))
+    Stream.instance_variable_set(:"@ordered_slugs", "go" => %w(clock anagram))
   end
 
   def teardown
     super
     Language.instance_variable_set(:"@by_track_id", nil)
-    TeamStream.instance_variable_set(:"@ordered_slugs", nil)
+    Stream.instance_variable_set(:"@ordered_slugs", nil)
   end
 
   def test_filters

--- a/test/exercism/track_stream_filters_test.rb
+++ b/test/exercism/track_stream_filters_test.rb
@@ -1,6 +1,6 @@
 require_relative '../integration_helper'
 
-class TeamStreamTest < Minitest::Test
+class TrackStreamFiltersTest < Minitest::Test
   include DBCleaner
 
   def setup

--- a/test/exercism/track_stream_test.rb
+++ b/test/exercism/track_stream_test.rb
@@ -1,6 +1,6 @@
 require_relative '../integration_helper'
 
-class TrackStreamTrackTest < Minitest::Test
+class TrackStreamTest < Minitest::Test
   include DBCleaner
 
   def setup


### PR DESCRIPTION
The tests for team streams, track streams, and the filters for both streams all had conflicting
class names, which means that they were reopening the same class. Since some tests had the same
name, some tests were not being run, which was hiding failures.

This fixes both the test names and the failures.

/cc @bernardoamc just for your information. I'm going to merge this so I can work on top of it.