### PR TITLE
Refactor stream filters

### DIFF
--- a/lib/exercism/team_stream_filters.rb
+++ b/lib/exercism/team_stream_filters.rb
@@ -73,8 +73,8 @@ class TeamStream
     def views_sql
       <<-SQL
       SELECT 'team_stream' AS id, COUNT(1) AS total
-      FROM views
-      INNER JOIN user_exercises ex
+      FROM user_exercises ex
+      INNER JOIN views
         ON ex.id=views.exercise_id
       WHERE ex.archived='f'
         AND ex.iteration_count > 0
@@ -103,28 +103,28 @@ class TeamStream
 
     def sql
       <<-SQL
-      SELECT language AS id, COUNT(id) AS total
-      FROM user_exercises
-      WHERE archived='f'
-        AND iteration_count > 0
-        AND user_id IN (#{user_ids_param})
-      GROUP BY language
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+        GROUP BY ex.language
       SQL
     end
 
     # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-      SELECT ex.language AS id, COUNT(views.id) AS total
-      FROM views
-      INNER JOIN user_exercises ex
-        ON ex.id=views.exercise_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-        AND views.user_id=#{viewer_id}
-        AND views.last_viewed_at > ex.last_activity_at
-      GROUP BY ex.language
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND views.user_id=#{viewer_id}
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY ex.language
       SQL
     end
     # rubocop:enable Metrics/MethodLength
@@ -151,30 +151,30 @@ class TeamStream
 
     def sql
       <<-SQL
-      SELECT slug AS id, COUNT(id) AS total
-      FROM user_exercises
-      WHERE archived='f'
-        AND iteration_count > 0
-        AND user_id IN (#{user_ids_param})
-        AND language='#{current_id}'
-      GROUP BY slug
+        SELECT ex.slug AS id, COUNT(id) AS total
+        FROM user_exercises ex
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND ex.language='#{current_id}'
+        GROUP BY ex.slug
       SQL
     end
 
     # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-      SELECT ex.slug AS id, COUNT(views.id) AS total
-      FROM views
-      INNER JOIN user_exercises ex
-        ON ex.id=views.exercise_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-        AND ex.language='#{current_id}'
-        AND views.user_id=#{viewer_id}
-        AND views.last_viewed_at > ex.last_activity_at
-      GROUP BY ex.slug
+        SELECT ex.slug AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND ex.language='#{current_id}'
+          AND views.user_id=#{viewer_id}
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY ex.slug
       SQL
     end
     # rubocop:enable Metrics/MethodLength
@@ -201,32 +201,32 @@ class TeamStream
 
     def sql
       <<-SQL
-      SELECT u.username AS id, COUNT(ex.id) AS total
-      FROM users u
-      INNER JOIN user_exercises ex
-        ON u.id=ex.user_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-      GROUP BY u.username
+        SELECT u.username AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN users u
+          ON u.id=ex.user_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+        GROUP BY u.username
       SQL
     end
 
     # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-      SELECT u.username AS id, COUNT(views.id) AS total
-      FROM views
-      INNER JOIN user_exercises ex
-        ON ex.id=views.exercise_id
-      INNER JOIN users u
-        ON u.id=ex.user_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-        AND views.user_id=#{viewer_id}
-        AND views.last_viewed_at > ex.last_activity_at
-      GROUP BY u.username
+        SELECT u.username AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN users u
+          ON u.id=ex.user_id
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND views.user_id=#{viewer_id}
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY u.username
       SQL
     end
     # rubocop:enable Metrics/MethodLength
@@ -249,28 +249,28 @@ class TeamStream
 
     def sql
       <<-SQL
-        SELECT language AS id, COUNT(id) AS total
-        FROM user_exercises
-        WHERE archived='f'
-          AND iteration_count > 0
-          AND user_id IN (#{user_ids_param})
-        GROUP BY language
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+        GROUP BY ex.language
       SQL
     end
 
     # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-      SELECT ex.language AS id, COUNT(views.id) AS total
-      FROM views
-      INNER JOIN user_exercises ex
-        ON ex.id=views.exercise_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-        AND views.user_id=#{viewer_id}
-        AND views.last_viewed_at > ex.last_activity_at
-      GROUP BY ex.language
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND views.user_id=#{viewer_id}
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY ex.language
       SQL
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/exercism/track_stream_filters.rb
+++ b/lib/exercism/track_stream_filters.rb
@@ -9,7 +9,6 @@ class TrackStream
         item.unread = unread(item)
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
@@ -30,59 +29,6 @@ class TrackStream
 
     def execute(query)
       ActiveRecord::Base.connection.execute(query).to_a
-    end
-  end
-
-  class ViewerFilter < Filter
-    private
-
-    attr_reader :track_id, :viewer_id, :only_mine
-    def initialize(viewer_id, track_id, only_mine)
-      @viewer_id = viewer_id
-      @track_id = track_id
-      @only_mine = only_mine
-    end
-
-    # rubocop:disable Metrics/MethodLength
-    def items_sql
-      <<-SQL
-      SELECT u.username AS id, COUNT(ex.id) AS total
-      FROM users u
-      INNER JOIN user_exercises ex
-        ON u.id=ex.user_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id = #{viewer_id}
-        AND ex.language='#{track_id}'
-      GROUP BY u.username
-      SQL
-    end
-
-    def views_sql
-      <<-SQL
-        SELECT u.username AS id, COUNT(views.id) AS total
-        FROM users u
-        INNER JOIN user_exercises ex
-          ON u.id=ex.user_id
-        INNER JOIN views
-          ON views.user_id=u.id
-          AND views.exercise_id=ex.id
-        WHERE ex.archived='f'
-          AND ex.iteration_count > 0
-          AND ex.user_id=#{viewer_id}
-          AND ex.language='#{track_id}'
-          AND views.last_viewed_at > ex.last_activity_at
-        GROUP BY u.username
-      SQL
-    end
-    # rubocop:enable Metrics/MethodLength
-
-    def item(username, total)
-      Stream::FilterItem.new(username, 'My Solutions', url, only_mine, total.to_i)
-    end
-
-    def url
-      "/tracks/%s/my_solutions" % [track_id]
     end
   end
 
@@ -115,17 +61,17 @@ class TrackStream
 
     def views_sql
       <<-SQL
-        SELECT ex.language AS id, COUNT(views.id) AS total
-        FROM views
-        INNER JOIN user_exercises ex
-          ON ex.id=views.exercise_id
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
         INNER JOIN acls
           ON ex.language=acls.language
           AND ex.slug=acls.slug
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+          AND acls.user_id=views.user_id
         WHERE acls.user_id=#{viewer_id}
           AND ex.archived='f'
           AND ex.iteration_count > 0
-          AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
         GROUP BY ex.language
       SQL
@@ -175,23 +121,21 @@ class TrackStream
         GROUP BY ex.slug
       SQL
     end
-    # rubocop:enable Metrics/MethodLength
 
-    # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-        SELECT ex.slug AS id, COUNT(views.id) AS total
-        FROM views
-        INNER JOIN user_exercises ex
-          ON ex.id=views.exercise_id
+        SELECT ex.slug AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
         INNER JOIN acls
           ON ex.language=acls.language
           AND ex.slug=acls.slug
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+          AND acls.user_id=views.user_id
         WHERE acls.user_id=#{viewer_id}
           AND ex.language='#{track_id}'
           AND ex.archived='f'
           AND ex.iteration_count > 0
-          AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
         GROUP BY ex.slug
       SQL
@@ -208,6 +152,59 @@ class TrackStream
 
     def url(id)
       "/tracks/%s/exercises/%s" % [track_id, id]
+    end
+  end
+
+  class ViewerFilter < Filter
+    private
+
+    attr_reader :track_id, :viewer_id, :only_mine
+    def initialize(viewer_id, track_id, only_mine)
+      @viewer_id = viewer_id
+      @track_id = track_id
+      @only_mine = only_mine
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def items_sql
+      <<-SQL
+        SELECT u.username AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN users u
+          ON u.id=ex.user_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id = #{viewer_id}
+          AND ex.language='#{track_id}'
+        GROUP BY u.username
+      SQL
+    end
+
+    def views_sql
+      <<-SQL
+        SELECT u.username AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN users u
+          ON u.id=ex.user_id
+        INNER JOIN views
+          ON views.user_id=u.id
+          AND views.exercise_id=ex.id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id=#{viewer_id}
+          AND ex.language='#{track_id}'
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY u.username
+      SQL
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def item(username, total)
+      Stream::FilterItem.new(username, 'My Solutions', url, only_mine, total.to_i)
+    end
+
+    def url
+      "/tracks/%s/my_solutions" % [track_id]
     end
   end
 end


### PR DESCRIPTION
* Reorder the filters themselves, to be from the most general to the most specific.
* Reorder the parts of the SQL queries so that they're consistent within each filter
* Count exercises not views in the views SQL, since in a heartbeat we'll be introducing
  watermarks, which won't have views to count on. This will let us stay consistent.