### PR TITLE
Use watermarks to determine read/unread status

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,10 +32,11 @@ Style/IdenticalConditionalBranches:
 Style/MethodName:
   Enabled: false
 
-# Offense count: 1
+# Offense count: 2
 Style/MultilineBlockChain:
   Exclude:
     - 'lib/exercism/track_stream_filters.rb'
+    - 'lib/exercism/team_stream_filters.rb'
 
 # Offense count: 8
 # Configuration parameters: NamePrefix, NamePrefixBlacklist, NameWhitelist.

--- a/db/migrate/201610012033_create_watermarks.rb
+++ b/db/migrate/201610012033_create_watermarks.rb
@@ -1,0 +1,12 @@
+class CreateWatermarks < ActiveRecord::Migration
+  def change
+    create_table :watermarks do |t|
+      t.integer   :user_id, null: false
+      t.string    :track_id, null: false
+      t.string    :slug, null: false
+      t.timestamp :at, null: false
+    end
+    add_index :watermarks, [:user_id, :track_id, :slug], unique: true, name: "index_watermarks_on_user_track_slug"
+    add_index :watermarks, :user_id
+  end
+end

--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -47,6 +47,7 @@ require 'exercism/view'
 require 'exercism/user_lookup'
 require 'exercism/daily'
 require 'exercism/tag'
+require 'exercism/watermark'
 
 require 'db/connection'
 DB::Connection.establish

--- a/lib/exercism/problem.rb
+++ b/lib/exercism/problem.rb
@@ -12,4 +12,8 @@ Problem = Struct.new(:track_id, :slug) do
   def in?(other_track_id)
     track_id == other_track_id
   end
+
+  def id
+    "%s:%s" % [track_id, slug]
+  end
 end

--- a/lib/exercism/team_stream.rb
+++ b/lib/exercism/team_stream.rb
@@ -105,6 +105,7 @@ class TeamStream
   def query_exercises
     exx = []
     ids = []
+    by_problem_id = Hash.new { |h, k| h[k] = [] }
     exx_by_id = execute(exercises_sql).each_with_object({}) do |row, by_id|
       problem = Problem.new(row["language"], row["slug"])
       attrs = [
@@ -122,7 +123,16 @@ class TeamStream
       exx << ex
 
       ids << row["id"]
+      by_problem_id[ex.problem.id] << ex
       by_id[row["id"]] = ex
+    end
+
+    watermarks(by_problem_id.keys).each do |watermark|
+      by_problem_id[watermark.problem_id].each do |ex|
+        if DateTime.parse(ex.last_activity_at) <= watermark.at
+          ex.viewed!
+        end
+      end
     end
 
     viewed(ids).each do |id|
@@ -151,6 +161,12 @@ class TeamStream
     return [] if ids.empty?
 
     execute(viewed_sql(ids)).map { |row| row["id"] }
+  end
+
+  def watermarks(problem_ids)
+    return [] if problem_ids.empty?
+
+    Watermark.where(user_id: viewer_id).where("track_id || ':' || slug IN (?)", problem_ids)
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/lib/exercism/team_stream_filters.rb
+++ b/lib/exercism/team_stream_filters.rb
@@ -73,8 +73,8 @@ class TeamStream
     def views_sql
       <<-SQL
       SELECT 'team_stream' AS id, COUNT(1) AS total
-      FROM views
-      INNER JOIN user_exercises ex
+      FROM user_exercises ex
+      INNER JOIN views
         ON ex.id=views.exercise_id
       WHERE ex.archived='f'
         AND ex.iteration_count > 0
@@ -103,28 +103,28 @@ class TeamStream
 
     def sql
       <<-SQL
-      SELECT language AS id, COUNT(id) AS total
-      FROM user_exercises
-      WHERE archived='f'
-        AND iteration_count > 0
-        AND user_id IN (#{user_ids_param})
-      GROUP BY language
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+        GROUP BY ex.language
       SQL
     end
 
     # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-      SELECT ex.language AS id, COUNT(views.id) AS total
-      FROM views
-      INNER JOIN user_exercises ex
-        ON ex.id=views.exercise_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-        AND views.user_id=#{viewer_id}
-        AND views.last_viewed_at > ex.last_activity_at
-      GROUP BY ex.language
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND views.user_id=#{viewer_id}
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY ex.language
       SQL
     end
     # rubocop:enable Metrics/MethodLength
@@ -151,30 +151,30 @@ class TeamStream
 
     def sql
       <<-SQL
-      SELECT slug AS id, COUNT(id) AS total
-      FROM user_exercises
-      WHERE archived='f'
-        AND iteration_count > 0
-        AND user_id IN (#{user_ids_param})
-        AND language='#{current_id}'
-      GROUP BY slug
+        SELECT ex.slug AS id, COUNT(id) AS total
+        FROM user_exercises ex
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND ex.language='#{current_id}'
+        GROUP BY ex.slug
       SQL
     end
 
     # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-      SELECT ex.slug AS id, COUNT(views.id) AS total
-      FROM views
-      INNER JOIN user_exercises ex
-        ON ex.id=views.exercise_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-        AND ex.language='#{current_id}'
-        AND views.user_id=#{viewer_id}
-        AND views.last_viewed_at > ex.last_activity_at
-      GROUP BY ex.slug
+        SELECT ex.slug AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND ex.language='#{current_id}'
+          AND views.user_id=#{viewer_id}
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY ex.slug
       SQL
     end
     # rubocop:enable Metrics/MethodLength
@@ -201,32 +201,32 @@ class TeamStream
 
     def sql
       <<-SQL
-      SELECT u.username AS id, COUNT(ex.id) AS total
-      FROM users u
-      INNER JOIN user_exercises ex
-        ON u.id=ex.user_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-      GROUP BY u.username
+        SELECT u.username AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN users u
+          ON u.id=ex.user_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+        GROUP BY u.username
       SQL
     end
 
     # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-      SELECT u.username AS id, COUNT(views.id) AS total
-      FROM views
-      INNER JOIN user_exercises ex
-        ON ex.id=views.exercise_id
-      INNER JOIN users u
-        ON u.id=ex.user_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-        AND views.user_id=#{viewer_id}
-        AND views.last_viewed_at > ex.last_activity_at
-      GROUP BY u.username
+        SELECT u.username AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN users u
+          ON u.id=ex.user_id
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND views.user_id=#{viewer_id}
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY u.username
       SQL
     end
     # rubocop:enable Metrics/MethodLength
@@ -249,28 +249,28 @@ class TeamStream
 
     def sql
       <<-SQL
-        SELECT language AS id, COUNT(id) AS total
-        FROM user_exercises
-        WHERE archived='f'
-          AND iteration_count > 0
-          AND user_id IN (#{user_ids_param})
-        GROUP BY language
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+        GROUP BY ex.language
       SQL
     end
 
     # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-      SELECT ex.language AS id, COUNT(views.id) AS total
-      FROM views
-      INNER JOIN user_exercises ex
-        ON ex.id=views.exercise_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-        AND views.user_id=#{viewer_id}
-        AND views.last_viewed_at > ex.last_activity_at
-      GROUP BY ex.language
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND views.user_id=#{viewer_id}
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY ex.language
       SQL
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/exercism/team_stream_filters.rb
+++ b/lib/exercism/team_stream_filters.rb
@@ -9,14 +9,22 @@ class TeamStream
     end
 
     def items
-      @items ||= rows.map { |row| item(row["id"], row["total"]) }
-                     .sort(&order)
-                     .each do |item|
-        item.unread = [item.total - views_by_id[item.id], 0].max
+      @items ||= execute(sql).map do |row|
+        item(row["id"], row["total"])
+      end.sort(&order).each do |item|
+        item.unread = unread(item)
       end
     end
 
     private
+
+    def unread(item)
+      [item.total - read(item.id), 0].max
+    end
+
+    def read(id)
+      views_by_id[id] + watermarked_by_id[id]
+    end
 
     def order
       proc { 0 }
@@ -28,8 +36,14 @@ class TeamStream
       end
     end
 
-    def rows
-      execute(sql)
+    def watermarked_by_id
+      @watermarked_by_id ||= execute(watermarks_sql).each_with_object(Hash.new(0)) do |row, watermarked|
+        watermarked[row["id"]] = row["total"].to_i
+      end
+    end
+
+    def watermarks_sql
+      ""
     end
 
     def execute(query)
@@ -72,15 +86,35 @@ class TeamStream
     # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-      SELECT 'team_stream' AS id, COUNT(1) AS total
-      FROM user_exercises ex
-      INNER JOIN views
-        ON ex.id=views.exercise_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id IN (#{user_ids_param})
-        AND views.user_id=#{viewer_id}
-        AND views.last_viewed_at > ex.last_activity_at
+        SELECT 'team_stream' AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND views.user_id=#{viewer_id}
+          AND views.last_viewed_at > ex.last_activity_at
+      SQL
+    end
+
+    def watermarks_sql
+      <<-SQL
+        SELECT 'team_stream' AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN watermarks mark
+          ON ex.language=mark.track_id
+          AND ex.slug=mark.slug
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND mark.user_id=#{viewer_id}
+          AND ex.id NOT IN (
+            SELECT exercise_id
+            FROM views
+            WHERE user_id=#{viewer_id}
+          )
+          AND mark.at > ex.last_activity_at
       SQL
     end
     # rubocop:enable Metrics/MethodLength
@@ -124,6 +158,27 @@ class TeamStream
           AND ex.user_id IN (#{user_ids_param})
           AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY ex.language
+      SQL
+    end
+
+    def watermarks_sql
+      <<-SQL
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN watermarks mark
+          ON ex.language=mark.track_id
+          AND ex.slug=mark.slug
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND mark.user_id=#{viewer_id}
+          AND ex.id NOT IN (
+            SELECT exercise_id
+            FROM views
+            WHERE user_id=#{viewer_id}
+          )
+          AND mark.at > ex.last_activity_at
         GROUP BY ex.language
       SQL
     end
@@ -174,6 +229,28 @@ class TeamStream
           AND ex.language='#{current_id}'
           AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY ex.slug
+      SQL
+    end
+
+    def watermarks_sql
+      <<-SQL
+        SELECT ex.slug AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN watermarks mark
+          ON ex.language=mark.track_id
+          AND ex.slug=mark.slug
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND ex.language='#{current_id}'
+          AND mark.user_id=#{viewer_id}
+          AND ex.id NOT IN (
+            SELECT exercise_id
+            FROM views
+            WHERE user_id=#{viewer_id}
+          )
+          AND mark.at > ex.last_activity_at
         GROUP BY ex.slug
       SQL
     end
@@ -229,6 +306,29 @@ class TeamStream
         GROUP BY u.username
       SQL
     end
+
+    def watermarks_sql
+      <<-SQL
+        SELECT u.username AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN users u
+          ON u.id=ex.user_id
+        INNER JOIN watermarks mark
+          ON ex.language=mark.track_id
+          AND ex.slug=mark.slug
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND mark.user_id=#{viewer_id}
+          AND ex.id NOT IN (
+            SELECT exercise_id
+            FROM views
+            WHERE user_id=#{viewer_id}
+          )
+          AND mark.at > ex.last_activity_at
+        GROUP BY u.username
+      SQL
+    end
     # rubocop:enable Metrics/MethodLength
 
     def item(username, total)
@@ -270,6 +370,27 @@ class TeamStream
           AND ex.user_id IN (#{user_ids_param})
           AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY ex.language
+      SQL
+    end
+
+    def watermarks_sql
+      <<-SQL
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN watermarks mark
+          ON ex.language=mark.track_id
+          AND ex.slug=mark.slug
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id IN (#{user_ids_param})
+          AND mark.user_id=#{viewer_id}
+          AND ex.id NOT IN (
+            SELECT exercise_id
+            FROM views
+            WHERE user_id=#{viewer_id}
+          )
+          AND mark.at > ex.last_activity_at
         GROUP BY ex.language
       SQL
     end

--- a/lib/exercism/track_stream_filters.rb
+++ b/lib/exercism/track_stream_filters.rb
@@ -9,7 +9,6 @@ class TrackStream
         item.unread = unread(item)
       end
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
@@ -30,59 +29,6 @@ class TrackStream
 
     def execute(query)
       ActiveRecord::Base.connection.execute(query).to_a
-    end
-  end
-
-  class ViewerFilter < Filter
-    private
-
-    attr_reader :track_id, :viewer_id, :only_mine
-    def initialize(viewer_id, track_id, only_mine)
-      @viewer_id = viewer_id
-      @track_id = track_id
-      @only_mine = only_mine
-    end
-
-    # rubocop:disable Metrics/MethodLength
-    def items_sql
-      <<-SQL
-      SELECT u.username AS id, COUNT(ex.id) AS total
-      FROM users u
-      INNER JOIN user_exercises ex
-        ON u.id=ex.user_id
-      WHERE ex.archived='f'
-        AND ex.iteration_count > 0
-        AND ex.user_id = #{viewer_id}
-        AND ex.language='#{track_id}'
-      GROUP BY u.username
-      SQL
-    end
-
-    def views_sql
-      <<-SQL
-        SELECT u.username AS id, COUNT(views.id) AS total
-        FROM users u
-        INNER JOIN user_exercises ex
-          ON u.id=ex.user_id
-        INNER JOIN views
-          ON views.user_id=u.id
-          AND views.exercise_id=ex.id
-        WHERE ex.archived='f'
-          AND ex.iteration_count > 0
-          AND ex.user_id=#{viewer_id}
-          AND ex.language='#{track_id}'
-          AND views.last_viewed_at > ex.last_activity_at
-        GROUP BY u.username
-      SQL
-    end
-    # rubocop:enable Metrics/MethodLength
-
-    def item(username, total)
-      Stream::FilterItem.new(username, 'My Solutions', url, only_mine, total.to_i)
-    end
-
-    def url
-      "/tracks/%s/my_solutions" % [track_id]
     end
   end
 
@@ -115,17 +61,17 @@ class TrackStream
 
     def views_sql
       <<-SQL
-        SELECT ex.language AS id, COUNT(views.id) AS total
-        FROM views
-        INNER JOIN user_exercises ex
-          ON ex.id=views.exercise_id
+        SELECT ex.language AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
         INNER JOIN acls
           ON ex.language=acls.language
           AND ex.slug=acls.slug
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+          AND acls.user_id=views.user_id
         WHERE acls.user_id=#{viewer_id}
           AND ex.archived='f'
           AND ex.iteration_count > 0
-          AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
         GROUP BY ex.language
       SQL
@@ -175,23 +121,21 @@ class TrackStream
         GROUP BY ex.slug
       SQL
     end
-    # rubocop:enable Metrics/MethodLength
 
-    # rubocop:disable Metrics/MethodLength
     def views_sql
       <<-SQL
-        SELECT ex.slug AS id, COUNT(views.id) AS total
-        FROM views
-        INNER JOIN user_exercises ex
-          ON ex.id=views.exercise_id
+        SELECT ex.slug AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
         INNER JOIN acls
           ON ex.language=acls.language
           AND ex.slug=acls.slug
+        INNER JOIN views
+          ON ex.id=views.exercise_id
+          AND acls.user_id=views.user_id
         WHERE acls.user_id=#{viewer_id}
           AND ex.language='#{track_id}'
           AND ex.archived='f'
           AND ex.iteration_count > 0
-          AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
         GROUP BY ex.slug
       SQL
@@ -208,6 +152,59 @@ class TrackStream
 
     def url(id)
       "/tracks/%s/exercises/%s" % [track_id, id]
+    end
+  end
+
+  class ViewerFilter < Filter
+    private
+
+    attr_reader :track_id, :viewer_id, :only_mine
+    def initialize(viewer_id, track_id, only_mine)
+      @viewer_id = viewer_id
+      @track_id = track_id
+      @only_mine = only_mine
+    end
+
+    # rubocop:disable Metrics/MethodLength
+    def items_sql
+      <<-SQL
+        SELECT u.username AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN users u
+          ON u.id=ex.user_id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id = #{viewer_id}
+          AND ex.language='#{track_id}'
+        GROUP BY u.username
+      SQL
+    end
+
+    def views_sql
+      <<-SQL
+        SELECT u.username AS id, COUNT(ex.id) AS total
+        FROM user_exercises ex
+        INNER JOIN users u
+          ON u.id=ex.user_id
+        INNER JOIN views
+          ON views.user_id=u.id
+          AND views.exercise_id=ex.id
+        WHERE ex.archived='f'
+          AND ex.iteration_count > 0
+          AND ex.user_id=#{viewer_id}
+          AND ex.language='#{track_id}'
+          AND views.last_viewed_at > ex.last_activity_at
+        GROUP BY u.username
+      SQL
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def item(username, total)
+      Stream::FilterItem.new(username, 'My Solutions', url, only_mine, total.to_i)
+    end
+
+    def url
+      "/tracks/%s/my_solutions" % [track_id]
     end
   end
 end

--- a/lib/exercism/watermark.rb
+++ b/lib/exercism/watermark.rb
@@ -1,0 +1,5 @@
+class Watermark < ActiveRecord::Base
+  def problem_id
+    "%s:%s" % [track_id, slug]
+  end
+end

--- a/test/exercism/team_stream_filters_test.rb
+++ b/test/exercism/team_stream_filters_test.rb
@@ -6,7 +6,7 @@ class TeamStreamFiltersTest < Minitest::Test
   def setup
     super
     Language.instance_variable_set(:"@by_track_id", "go" => "Go", "elixir" => "Elixir")
-    Stream.instance_variable_set(:"@ordered_slugs", "go" => %w(clock anagram))
+    Stream.instance_variable_set(:"@ordered_slugs", "go" => %w(leap clock anagram))
   end
 
   def teardown
@@ -16,19 +16,32 @@ class TeamStreamFiltersTest < Minitest::Test
   end
 
   def test_filters
-    alice = User.create!(username: 'alice', avatar_url: 'alice.jpg')
-    bob = User.create!(username: 'bob', avatar_url: 'bob.jpg')
-    charlie = User.create!(username: 'charlie', avatar_url: 'charlie.jpg')
+    alice = User.create!(username: 'alice')
+    bob = User.create!(username: 'bob')
+    charlie = User.create!(username: 'charlie')
+    nobody = nil
 
+    # Go
+    create_exercise(alice, 'go', 'leap', nobody)
     create_exercise(alice, 'go', 'clock', alice.id)
-    create_exercise(bob, 'go', 'clock', alice.id)
-    create_exercise(bob, 'go', 'anagram')
-    create_exercise(bob, 'elixir', 'triangle')
-    create_exercise(charlie, 'go', 'clock')
+
+    create_exercise(bob, 'go', 'leap', nobody)
+    create_exercise(bob, 'go', 'clock', bob.id)
+    create_exercise(bob, 'go', 'anagram', alice.id)
+
+    create_exercise(charlie, 'go', 'leap', nobody)
+    create_exercise(charlie, 'go', 'clock', nobody)
+
+    # Elixir
+    create_exercise(bob, 'elixir', 'leap', nobody)
+    create_exercise(charlie, 'elixir', 'clock', alice.id)
 
     user_ids = [alice.id, bob.id, charlie.id]
 
+    # Team filters ignore ACLs.
+
     # Team filter
+    # This should include the count of everything in the track.
     filter = TeamStream::TeamFilter.new(alice.id, user_ids, 'teamster')
     assert_equal 1, filter.items.size
 
@@ -36,8 +49,8 @@ class TeamStreamFiltersTest < Minitest::Test
 
     assert_equal 'All', item.text
     assert_equal '/teams/teamster/streams', item.url
-    assert_equal 5, item.total
-    assert_equal 3, item.unread
+    assert_equal 9, item.total
+    assert_equal 6, item.unread
 
     # Track filter, no track currently selected.
     filter = TeamStream::TrackFilter.new(alice.id, user_ids, 'teamster', nil)
@@ -47,14 +60,14 @@ class TeamStreamFiltersTest < Minitest::Test
 
     assert_equal 'Elixir', item1.text
     assert_equal '/teams/teamster/streams/tracks/elixir', item1.url
-    assert_equal 1, item1.total
+    assert_equal 2, item1.total
     assert_equal 1, item1.unread
     refute item1.active?
 
     assert_equal 'Go', item2.text
     assert_equal '/teams/teamster/streams/tracks/go', item2.url
-    assert_equal 4, item2.total
-    assert_equal 2, item2.unread
+    assert_equal 7, item2.total
+    assert_equal 5, item2.unread
     refute item2.active?
 
     # Track filter, Elixir selected.
@@ -70,32 +83,42 @@ class TeamStreamFiltersTest < Minitest::Test
 
     # Problems in Go, none currently selected.
     filter = TeamStream::ProblemFilter.new(alice.id, user_ids, 'teamster', 'go', nil)
-    assert_equal 2, filter.items.size
+    assert_equal 3, filter.items.size
 
-    item1, item2 = filter.items
+    item1, item2, item3 = filter.items
 
-    assert_equal 'Clock', item1.text
-    assert_equal '/teams/teamster/streams/tracks/go/exercises/clock', item1.url
+    assert_equal 'Leap', item1.text
+    assert_equal '/teams/teamster/streams/tracks/go/exercises/leap', item1.url
     assert_equal 3, item1.total
-    assert_equal 1, item1.unread
+    assert_equal 3, item1.unread
     refute item1.active?
 
-    assert_equal 'Anagram', item2.text
-    assert_equal '/teams/teamster/streams/tracks/go/exercises/anagram', item2.url
-    assert_equal 1, item2.total
-    assert_equal 1, item1.unread
+    assert_equal 'Clock', item2.text
+    assert_equal '/teams/teamster/streams/tracks/go/exercises/clock', item2.url
+    assert_equal 3, item2.total
+    assert_equal 2, item2.unread
     refute item2.active?
+
+    assert_equal 'Anagram', item3.text
+    assert_equal '/teams/teamster/streams/tracks/go/exercises/anagram', item3.url
+    assert_equal 1, item3.total
+    assert_equal 0, item3.unread
+    refute item3.active?
 
     # Problems in Go, Anagram selected.
     filter = TeamStream::ProblemFilter.new(alice.id, user_ids, 'teamster', 'go', 'anagram')
-    assert_equal 2, filter.items.size
+    assert_equal 3, filter.items.size
 
-    item1, item2 = filter.items
-    assert_equal 'Clock', item1.text
+    item1, item2, item3 = filter.items
+
+    assert_equal 'Leap', item1.text
     refute item1.active?
 
-    assert_equal 'Anagram', item2.text
-    assert item2.active?
+    assert_equal 'Clock', item2.text
+    refute item2.active?
+
+    assert_equal 'Anagram', item3.text
+    assert item3.active?
 
     # Users, none currently selected
     filter = TeamStream::UserFilter.new(alice.id, user_ids, 'teamster', nil)
@@ -104,20 +127,20 @@ class TeamStreamFiltersTest < Minitest::Test
     item1, item2, item3 = filter.items
     assert_equal 'alice', item1.text
     assert_equal '/teams/teamster/streams/users/alice', item1.url
-    assert_equal 1, item1.total
-    assert_equal 0, item1.unread
+    assert_equal 2, item1.total
+    assert_equal 1, item1.unread
     refute item1.active?
 
     assert_equal 'bob', item2.text
     assert_equal '/teams/teamster/streams/users/bob', item2.url
-    assert_equal 3, item2.total
-    assert_equal 2, item2.unread
+    assert_equal 4, item2.total
+    assert_equal 3, item2.unread
     refute item2.active?
 
     assert_equal 'charlie', item3.text
     assert_equal '/teams/teamster/streams/users/charlie', item3.url
-    assert_equal 1, item3.total
-    assert_equal 1, item3.unread
+    assert_equal 3, item3.total
+    assert_equal 2, item3.unread
     refute item3.active?
 
     # Users, bob selected
@@ -148,30 +171,21 @@ class TeamStreamFiltersTest < Minitest::Test
 
     assert_equal 'Go', item2.text
     assert_equal '/teams/teamster/streams/users/bob/tracks/go', item2.url
-    assert_equal 2, item2.total
-    assert_equal 1, item2.unread
+    assert_equal 3, item2.total
+    assert_equal 2, item2.unread
     refute item2.active?
 
-    # Tracks for charlie, no track selected
-    filter = TeamStream::UserTrackFilter.new(alice.id, [charlie.id], 'teamster', 'charlie', nil)
-    assert_equal 1, filter.items.size
+    # Tracks for bob, Go selected
+    filter = TeamStream::UserTrackFilter.new(alice.id, [bob.id], 'teamster', 'bob', 'go')
+    assert_equal 2, filter.items.size
 
-    item = filter.items.first
+    item1, item2 = filter.items
 
-    assert_equal 'Go', item.text
-    assert_equal '/teams/teamster/streams/users/charlie/tracks/go', item.url
-    assert_equal 1, item.total
-    assert_equal 1, item.unread
-    refute item.active?
+    assert_equal 'Elixir', item1.text
+    refute item1.active?
 
-    # Tracks for charlie, Go selected
-    filter = TeamStream::UserTrackFilter.new(alice.id, [charlie.id], 'teamster', 'charlie', 'go')
-    assert_equal 1, filter.items.size
-
-    item = filter.items.first
-
-    assert_equal 'Go', item.text
-    assert item.active?
+    assert_equal 'Go', item2.text
+    assert item2.active?
   end
 
   private

--- a/test/exercism/track_stream_filters_test.rb
+++ b/test/exercism/track_stream_filters_test.rb
@@ -26,7 +26,7 @@ class TrackStreamFiltersTest < Minitest::Test
     charlie = User.create!(username: 'charlie', avatar_url: 'charlie.jpg')
     nobody = nil
 
-    mon, tue, wed = (4..6).map {|day| DateTime.new(2016, 1, day)}
+    mon, tue, wed, thu = (4..7).map {|day| DateTime.new(2016, 1, day)}
 
     # We will use Alice as the viewer for all the filters.
     #
@@ -57,16 +57,16 @@ class TrackStreamFiltersTest < Minitest::Test
 
     # Go
     create_exercise(alice, 'go', 'leap', alice.id, mon)
-    create_exercise(alice, 'go', 'clock', bob.id, tue)
+    create_exercise(alice, 'go', 'clock', bob.id, mon)
     create_exercise(alice, 'go', 'anagram', nobody, mon)
 
     create_exercise(bob, 'go', 'leap', nobody, mon)
-    create_exercise(bob, 'go', 'clock', alice.id, mon)
+    create_exercise(bob, 'go', 'clock', alice.id, tue)
     create_exercise(bob, 'go', 'anagram', bob.id, mon)
     create_exercise(bob, 'go', 'triangle', nobody, mon)
 
     create_exercise(charlie, 'go', 'leap', nobody, mon)
-    create_exercise(charlie, 'go', 'clock', bob.id, tue)
+    create_exercise(charlie, 'go', 'clock', bob.id, thu)
     create_exercise(charlie, 'go', 'triangle', alice.id, mon) # viewed (directly) without ACL
 
     # Elixir
@@ -89,6 +89,8 @@ class TrackStreamFiltersTest < Minitest::Test
       ACL.authorize(alice, problem)
     end
 
+    Watermark.create!(user_id: alice.id, track_id: 'go', slug: 'clock', at: wed)
+
     filter = TrackStream::TrackFilter.new(alice.id, 'go')
     assert_equal 2, filter.items.size
 
@@ -103,7 +105,7 @@ class TrackStreamFiltersTest < Minitest::Test
     assert_equal 'Go', item2.text
     assert_equal '/tracks/go/exercises', item2.url
     assert_equal 8, item2.total
-    assert_equal 6, item2.unread
+    assert_equal 5, item2.unread
     assert item2.active?
 
     filter = TrackStream::ProblemFilter.new(alice.id, 'go', 'clock')
@@ -120,7 +122,7 @@ class TrackStreamFiltersTest < Minitest::Test
     assert_equal 'Clock', item2.text
     assert_equal '/tracks/go/exercises/clock', item2.url
     assert_equal 3, item2.total
-    assert_equal 2, item2.unread
+    assert_equal 1, item2.unread
     assert item2.active?, "clock should be active"
 
     assert_equal 'Anagram', item3.text
@@ -138,7 +140,7 @@ class TrackStreamFiltersTest < Minitest::Test
     assert_equal 'My Solutions', item.text
     assert_equal '/tracks/go/my_solutions', item.url
     assert_equal 3, item.total
-    assert_equal 2, item.unread
+    assert_equal 1, item.unread
     assert item.active?
   end
 


### PR DESCRIPTION
**Note: this is a follow-on pull request building on three separate PRs (#3141, #3142, and #3131) that should all be merged before this gets merged. This will make it easier to review, as it will contain significantly fewer changes.**

This ensures that the exercises in the stream itself get the correct read/unread status, and that the sidebar takes the watermark into account when displaying the unread counts.

See https://github.com/exercism/exercism.io/issues/3130