### PR TITLE
allow toggle languages progress to avoid overloading the profile page

### DIFF
--- a/app/views/user/_tracks_progress.erb
+++ b/app/views/user/_tracks_progress.erb
@@ -1,5 +1,5 @@
 <% if user_tracks_summary.any? %>
-  <h3> Progess </h3>
+  <h3> Progress </h3>
   <% if params[:all] == 'true' %>
     <% user_tracks_summary.each_slice(3) do |batch| %>
       <div class="row bottom-margin">
@@ -11,11 +11,11 @@
     <a href="?all=false"> Fewer Languages </a>
   <% else %>
     <div class="row bottom-margin">
-      <% user_tracks_summary.each_slice(3).first.each do |track_info| %>
+      <% user_tracks_summary.first(3).each do |track_info| %>
         <%= erb :"user/_track_progress", locals: { track_info: track_info } %>
       <% end %>
     </div>
-    <% if user_tracks_summary.size > 1 %>
+    <% if user_tracks_summary.size > 3 %>
       <a href="?all=true"> More Languages </a>
     <% end %>
   <% end %>

--- a/app/views/user/_tracks_progress.erb
+++ b/app/views/user/_tracks_progress.erb
@@ -1,0 +1,22 @@
+<% if user_tracks_summary.any? %>
+  <h3> Progess </h3>
+  <% if params[:all] == 'true' %>
+    <% user_tracks_summary.each_slice(3) do |batch| %>
+      <div class="row bottom-margin">
+        <% batch.each do |track_info| %>
+          <%= erb :"user/_track_progress", locals: { track_info: track_info } %>
+        <% end %>
+      </div>
+    <% end %>
+    <a href="?all=false"> Fewer Languages </a>
+  <% else %>
+    <div class="row bottom-margin">
+      <% user_tracks_summary.each_slice(3).first.each do |track_info| %>
+        <%= erb :"user/_track_progress", locals: { track_info: track_info } %>
+      <% end %>
+    </div>
+    <% if user_tracks_summary.size > 1 %>
+      <a href="?all=true"> More Languages </a>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/user/show.erb
+++ b/app/views/user/show.erb
@@ -21,16 +21,7 @@
       <% end %>
     <% end %>
 
-    <% if profile.user_tracks_summary.any? %>
-      <h3> Progess </h3>
-      <% profile.user_tracks_summary.each_slice(3) do |batch| %>
-        <div class="row bottom-margin">
-          <% batch.each do |track_info| %>
-            <%= erb :"user/_track_progress", locals: { track_info: track_info } %>
-          <% end %>
-        </div>
-      <% end %>
-    <% end %>
+    <%= erb :"user/_tracks_progress", locals: { user_tracks_summary: profile.user_tracks_summary } %>
 
     <% if profile.finished_tracks.any? && profile.own? %>
       <h3>Contribute:</h3>


### PR DESCRIPTION
#3137
@kytrinyx, @NobbZ I just simply added a filter param, that let the user decide if he/she want to shoe more languages, just like in the old progress bar. Please tell me what you think.

Here are some examples:
Collapsed
![image](https://cloud.githubusercontent.com/assets/4672858/19055361/c8082548-89c3-11e6-80a6-510177ffb1db.png)

Uncollapsed
![image](https://cloud.githubusercontent.com/assets/4672858/19055371/e00f7916-89c3-11e6-97d5-c4cd432271d0.png)
![image](https://cloud.githubusercontent.com/assets/4672858/19055389/f3a467a2-89c3-11e6-8407-65442e8b8015.png)


