### PR TITLE
Serve images from the track repos

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'rouge', '~> 2.0.5'
 gem 'sinatra', '~> 1.4.4', require: 'sinatra/base'
 gem 'sinatra-contrib'
 gem 'sidekiq'
+gem 'trackler', '~> 1.0.0'
 gem 'will_paginate'
 gem 'will_paginate-bootstrap'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     multipart-post (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    org-ruby (0.9.12)
+      rubypants (~> 0.2)
     parser (2.3.1.0)
       ast (~> 2.2)
     petroglyph (0.0.7)
@@ -124,6 +126,8 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
     ruby-progressbar (1.8.0)
+    rubypants (0.5.1)
+    rubyzip (1.1.7)
     sass (3.4.21)
     sidekiq (4.1.1)
       concurrent-ruby (~> 1.0)
@@ -154,6 +158,9 @@ GEM
     tilt (2.0.2)
     timecop (0.8.0)
     tins (1.6.0)
+    trackler (1.0.0)
+      org-ruby (~> 0.9.0)
+      rubyzip (~> 1.1.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     will_paginate (3.1.0)
@@ -200,8 +207,12 @@ DEPENDENCIES
   sinatra-contrib
   sqlite3
   timecop
+  trackler (~> 1.0.0)
   will_paginate
   will_paginate-bootstrap
 
+RUBY VERSION
+   ruby 2.2.2p95
+
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/helpers/track_image.rb
+++ b/app/helpers/track_image.rb
@@ -1,19 +1,10 @@
+require 'trackler'
+
 module ExercismWeb
   module Helpers
     module TrackImage
       def track_icon(track_id, size=40)
-        '<img src="%s" width="%d" height="%d" alt="">' % [track_png(track_id), size, size]
-      end
-
-      private
-
-      def track_png(track_id)
-        img = "/img/tracks/%s.png" % track_id
-        if File.exist?("./public/%s" % img)
-          img
-        else
-          "/img/e_red.png"
-        end
+        '<img src="/tracks/%s/icon" width="%d" height="%d" alt="">' % [track_id, size, size]
       end
     end
   end

--- a/app/routes/tracks.rb
+++ b/app/routes/tracks.rb
@@ -29,6 +29,15 @@ module ExercismWeb
 
         redirect ["", "tracks", id, "exercises", slug].compact.join('/')
       end
+
+      get '/tracks/:id/icon' do |id|
+        icon = Trackler.tracks[id].icon
+        if icon.exists?
+          send_file icon.path, type: icon.type
+        else
+          send_file File.absolute_path("../../../public/img/e_red.png", __FILE__), type: :png
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Earlier today I merged #3138 ... but I had totally forgotten that we also need to configure Exercism to actually serve the images from the new location. So all the track icons disappeared.

I rolled back the deploy.

This adds `trackler` as a dependency.

Trackler was extracted from exercism/x-api. It wraps all the basic Exercism data (x-common, the tracks, their implementations) into a single bundle, and has some wiring to make it easy to manage.

Then it

* adds an endpoint to serve the image and
* updates the view helper to reference the endpoint.

I've tested this locally:

<img width="624" alt="screen shot 2016-10-03 at 8 41 50 pm" src="https://cloud.githubusercontent.com/assets/276834/19060963/da4f183e-89a9-11e6-8b50-eadcf4141995.png">
