### PR TITLE
Add rake task to delete views below the watermarks

### DIFF
--- a/lib/exercism/view.rb
+++ b/lib/exercism/view.rb
@@ -1,2 +1,14 @@
 class View < ActiveRecord::Base
+  def self.delete_below_watermarks
+    sql = <<-SQL
+      DELETE FROM views v
+      USING user_exercises ex, watermarks w
+      WHERE w.user_id=v.user_id
+      AND v.exercise_id=ex.id
+      AND w.track_id=ex.language
+      AND w.slug=ex.slug
+      AND v.last_viewed_at <= w.at;
+    SQL
+    connection.execute(sql)
+  end
 end

--- a/lib/tasks/views.rake
+++ b/lib/tasks/views.rake
@@ -1,0 +1,11 @@
+namespace :views do
+  desc "delete all the views below the watermarks"
+  task :sweep do
+    require 'active_record'
+    require 'db/connection'
+    require './lib/exercism/view'
+    DB::Connection.establish
+
+    View.delete_below_watermarks
+  end
+end

--- a/test/exercism/view_test.rb
+++ b/test/exercism/view_test.rb
@@ -1,0 +1,35 @@
+require_relative '../integration_helper'
+require 'exercism'
+
+class ViewTest < Minitest::Test
+  include DBCleaner
+
+  def test_delete_below_watermark
+    alice = User.create(username: 'alice')
+    bob = User.create(username: 'bob')
+
+    mon, tue, wed, thu, fri = (4..8).map {|day| Time.new(2016, 1, day)}
+
+    attributes = {
+      language: 'go',
+      slug: 'hamming',
+      archived: false,
+      last_activity_at: fri,
+    }
+
+    [mon, tue, wed, thu, fri].each do |timestamp|
+      exercise = UserExercise.create(attributes.merge(user_id: timestamp.day)) # random, non-existent user
+      View.create(user_id: alice.id, exercise_id: exercise.id, last_viewed_at: timestamp)
+    end
+    View.create(user_id: bob.id, exercise_id: UserExercise.first.id, last_viewed_at: mon)
+
+    Watermark.create(user_id: alice.id, track_id: 'go', slug: 'hamming', at: thu)
+
+    assert_equal 6, View.count
+
+    # This should remove mon, tue, wed, and thu for Alice, but nothing for bob.
+    View.delete_below_watermarks
+
+    assert_equal 2, View.count
+  end
+end


### PR DESCRIPTION
This is a continuation of the work in #3130

We have watermarks that we're using to set the read/unread state in the activity streams. We also use views, which are recorded individually when you visit a solution.

Watermarks are much more economical—you have one single watermark for all the solutions for a given exercise in a given track. So, for example, if you have viewed the code for Hamming in Ruby submitted by 100 different people, then you will have 100 rows in the views table. If you then say "mark all as read" for Hamming in Ruby, then you will have _one_ watermark which sets everything as read. At this point we can delete the 100 rows in the views table.

This rake task is intended to run on a regular basis using a cron job, for example once a day.

/cc @bernardoamc 