### PR TITLE
Fix incorrect counts in activity stream after marking all as read.

### DIFF
--- a/lib/exercism/track_stream_filters.rb
+++ b/lib/exercism/track_stream_filters.rb
@@ -103,6 +103,7 @@ class TrackStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND mark.at < last_viewed_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.language
@@ -192,6 +193,7 @@ class TrackStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND mark.at < last_viewed_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.slug
@@ -273,6 +275,7 @@ class TrackStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND mark.at < last_viewed_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY u.username


### PR DESCRIPTION
Fixes #3154 

We were discarding the watermark if a view was present, but sometimes the watermark is more up to date than the view itself, so it should be considered instead of the view.