### PR TITLE
Fix unread count bug in stream filters

### DIFF
--- a/lib/exercism/team_stream_filters.rb
+++ b/lib/exercism/team_stream_filters.rb
@@ -113,6 +113,7 @@ class TeamStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND last_viewed_at > ex.last_activity_at
           )
           AND mark.at > ex.last_activity_at
       SQL
@@ -177,6 +178,7 @@ class TeamStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND last_viewed_at > ex.last_activity_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.language
@@ -249,6 +251,7 @@ class TeamStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND last_viewed_at > ex.last_activity_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.slug
@@ -324,6 +327,7 @@ class TeamStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND last_viewed_at > ex.last_activity_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY u.username
@@ -389,6 +393,7 @@ class TeamStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND last_viewed_at > ex.last_activity_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.language

--- a/lib/exercism/track_stream_filters.rb
+++ b/lib/exercism/track_stream_filters.rb
@@ -103,6 +103,7 @@ class TrackStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND last_viewed_at > ex.last_activity_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.language
@@ -192,6 +193,7 @@ class TrackStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND last_viewed_at > ex.last_activity_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.slug
@@ -273,6 +275,7 @@ class TrackStream
             SELECT exercise_id
             FROM views
             WHERE user_id=#{viewer_id}
+            AND last_viewed_at > ex.last_activity_at
           )
           AND mark.at > ex.last_activity_at
         GROUP BY u.username


### PR DESCRIPTION
When we have a view timestamp that is outdated (the exercise has
a more recent timestamp than the last viewed at timestamp), but
a watermark that was newer, the exercise was getting counted as
unread.

@bernardoamc I realized that I had to compare to the `last_activity_at` on exercises instead of `mark.at` as we first discussed, since excluding the view based on `mark.at` would fail in the following scenario:

- last viewed at: Monday
- last activity at: Tuesday
- watermark at: Wednesday

In that case it would _not_ be counted in the "views" query, and then it would _not_ be counted in the watermark query, either.

Fixes #3154 