### PR TITLE
timestamp_improvement, cover the case from 23.5 to 24 hours

### DIFF
--- a/app/helpers/fuzzy_time.rb
+++ b/app/helpers/fuzzy_time.rb
@@ -20,7 +20,7 @@ module ExercismWeb
                        "about an hour ago"
                      when less_than(105 * minutes)
                        "about an hour and a half ago"
-                     else less_than(24 * hours)
+                     else
                        "about #{(diff / (1 * hours)).round} hours ago"
                      end
           "<span data-toggle='tooltip' data-title='#{formatted_date}'>#{response}</span>"

--- a/app/helpers/fuzzy_time.rb
+++ b/app/helpers/fuzzy_time.rb
@@ -20,7 +20,7 @@ module ExercismWeb
                        "about an hour ago"
                      when less_than(105 * minutes)
                        "about an hour and a half ago"
-                     when less_than(24 * hours)
+                     else less_than(24 * hours)
                        "about #{(diff / (1 * hours)).round} hours ago"
                      end
           "<span data-toggle='tooltip' data-title='#{formatted_date}'>#{response}</span>"

--- a/app/helpers/fuzzy_time.rb
+++ b/app/helpers/fuzzy_time.rb
@@ -22,6 +22,8 @@ module ExercismWeb
                        "about an hour and a half ago"
                      when less_than(23.5 * hours)
                        "about #{(diff / (1 * hours)).round} hours ago"
+                     when less_than(24 * hours)
+                       "about 23.5 to 24 hours ago"
                      end
           "<span data-toggle='tooltip' data-title='#{formatted_date}'>#{response}</span>"
         else

--- a/app/helpers/fuzzy_time.rb
+++ b/app/helpers/fuzzy_time.rb
@@ -20,10 +20,8 @@ module ExercismWeb
                        "about an hour ago"
                      when less_than(105 * minutes)
                        "about an hour and a half ago"
-                     when less_than(23.5 * hours)
-                       "about #{(diff / (1 * hours)).round} hours ago"
                      when less_than(24 * hours)
-                       "about 23.5 to 24 hours ago"
+                       "about #{(diff / (1 * hours)).round} hours ago"
                      end
           "<span data-toggle='tooltip' data-title='#{formatted_date}'>#{response}</span>"
         else

--- a/app/helpers/fuzzy_time.rb
+++ b/app/helpers/fuzzy_time.rb
@@ -6,7 +6,6 @@ module ExercismWeb
   module Helpers
     module FuzzyTime
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-      # rubocop:disable Metrics/CyclomaticComplexity
       def ago(timestamp)
         diff = (now - timestamp).to_i.to_f
         formatted_date = timestamp.strftime('%e %B %Y at %H:%M %Z')

--- a/test/app/helpers/fuzzy_time_test.rb
+++ b/test/app/helpers/fuzzy_time_test.rb
@@ -54,7 +54,7 @@ class FuzzyTimeHelperTest < Minitest::Test
   def test_a_bit_more_than_23_hours_and_a_half_ago
     more_than_23_hours_and_a_half = (23 * 60 * 60 + 45 * 60)
     ago = helper.ago(now - more_than_23_hours_and_a_half)
-    assert_equal link_text(now - more_than_23_hours_and_a_half, "about 23.5 to 24 hours ago"), ago
+    assert_equal link_text(now - more_than_23_hours_and_a_half, "about 24 hours ago"), ago
   end
 
   def test_bit_more_than_a_day

--- a/test/app/helpers/fuzzy_time_test.rb
+++ b/test/app/helpers/fuzzy_time_test.rb
@@ -51,6 +51,12 @@ class FuzzyTimeHelperTest < Minitest::Test
     assert_equal link_text(now - more_than_23_hours, "about 23 hours ago"), ago
   end
 
+  def test_a_bit_more_than_23_hours_and_a_half_ago
+    more_than_23_hours_and_a_half = (23 * 60 * 60 + 45 * 60)
+    ago = helper.ago(now - more_than_23_hours_and_a_half)
+    assert_equal link_text(now - more_than_23_hours_and_a_half, "about 23.5 to 24 hours ago"), ago
+  end
+
   def test_bit_more_than_a_day
     ago = helper.ago(now - (24 * 60 * 60 + 29 * 60))
     assert_equal "<span class='localize-time'> 1 January 2013 at 02:35 UTC</span>", ago


### PR DESCRIPTION
Fixes #3076 

This PR solves the timestamp problem referenced in #3076  , the problem is currently happening because we only consider the cases covering from 0 to 23.5 hours ago. We also also consider the case covering from 23.5 to 24 hours ago. 