### PR TITLE
Fix viewer filter pagination

### DIFF
--- a/lib/exercism/track_stream.rb
+++ b/lib/exercism/track_stream.rb
@@ -46,7 +46,21 @@ class TrackStream
   end
 
   def pagination_menu_item
-    menus.last.items.find(&:active?) || menus.first.items.find(&:active) || Stream::FilterItem.new(nil, nil, nil, nil, 0)
+    active_menu_item || Stream::FilterItem.new(nil, nil, nil, nil, 0)
+  end
+
+  def active_menu_item
+    if only_mine
+      menus.second.items.first
+    elsif by_problem?
+      menus.last.items.find(&:active?)
+    else
+      menus.first.items.find(&:active?)
+    end
+  end
+
+  def by_problem?
+    slug.present?
   end
 
   # This becomes unbearably slow if we do a left join on views to get the unread value

--- a/test/exercism/track_stream_test.rb
+++ b/test/exercism/track_stream_test.rb
@@ -204,6 +204,33 @@ class TrackStreamTest < Minitest::Test
     assert_equal expected, actual
   end
 
+  def test_pagination_menu_item
+    alice = User.create(username: 'alice')
+    bob = User.create(username: 'bob')
+
+    [
+      { user: alice, language: 'go', slug: 'leap', iteration_count: 1 },
+      { user: bob, language: 'go', slug: 'leap', iteration_count: 1 },
+      { user: bob, language: 'go', slug: 'hamming', iteration_count: 1 },
+      { user: bob, language: 'go', slug: 'clock', iteration_count: 1 },
+    ].each do |attributes|
+      exercise = UserExercise.create!(attributes)
+      ACL.authorize(alice, exercise.problem)
+    end
+
+    by_track = TrackStream.new(alice, 'go').pagination_menu_item
+    assert_equal 'go', by_track.id
+    assert_equal 4, by_track.total
+
+    by_problem = TrackStream.new(alice, 'go', 'leap').pagination_menu_item
+    assert_equal 'leap', by_problem.id
+    assert_equal 2, by_problem.total
+
+    mine = TrackStream.new(alice, 'go', nil, nil, true).pagination_menu_item
+    assert_equal 'alice', mine.id
+    assert_equal 1, mine.total
+  end
+
   private
 
   def assert_exercise(expected, actual)


### PR DESCRIPTION
Fixes #3133

This PR solves the pagination problem referenced in #3133 , the problem is currently happening because we only consider as active a problem stream or track stream filters, not the viewer filter. When we are in `My Solutions` we should consider the Viewer filter as active and paginate using its result.