### PR TITLE
Delete obsolete view records

### DIFF
--- a/lib/exercism/view.rb
+++ b/lib/exercism/view.rb
@@ -11,4 +11,17 @@ class View < ActiveRecord::Base
     SQL
     connection.execute(sql)
   end
+
+  # When an exercise has new activity since
+  # the last time it was viewed, the record is
+  # no longer useful.
+  def self.delete_obsolete
+    sql = <<-SQL
+      DELETE FROM views v
+      USING user_exercises ex
+      WHERE v.exercise_id=ex.id
+      AND v.last_viewed_at < ex.last_activity_at;
+    SQL
+    connection.execute(sql)
+  end
 end

--- a/lib/tasks/views.rake
+++ b/lib/tasks/views.rake
@@ -7,5 +7,6 @@ namespace :views do
     DB::Connection.establish
 
     View.delete_below_watermarks
+    View.delete_obsolete
   end
 end


### PR DESCRIPTION
When an exercise has activity that is newer than the most recent view,
then the view isn't serving any purpose.

@bernardoamc I'm trying to find ways to shave off records from the views table, which is by far the largest table. This will delete over 100k records in production, which is not a whole lot given that we have over 7 million views, but every little bit helps.