### PR TITLE
Reverse counting logic in stream filters

### DIFF
--- a/lib/exercism/team_stream_filters.rb
+++ b/lib/exercism/team_stream_filters.rb
@@ -95,6 +95,12 @@ class TeamStream
           AND ex.user_id IN (#{user_ids_param})
           AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
+          AND ex.language || ex.slug NOT IN (
+            SELECT track_id || slug
+            FROM watermarks
+            WHERE user_id=#{viewer_id}
+            AND at > ex.last_activity_at
+          )
       SQL
     end
 
@@ -109,12 +115,6 @@ class TeamStream
           AND ex.iteration_count > 0
           AND ex.user_id IN (#{user_ids_param})
           AND mark.user_id=#{viewer_id}
-          AND ex.id NOT IN (
-            SELECT exercise_id
-            FROM views
-            WHERE user_id=#{viewer_id}
-            AND last_viewed_at > ex.last_activity_at
-          )
           AND mark.at > ex.last_activity_at
       SQL
     end
@@ -159,6 +159,12 @@ class TeamStream
           AND ex.user_id IN (#{user_ids_param})
           AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
+          AND ex.language || ex.slug NOT IN (
+            SELECT track_id || slug
+            FROM watermarks
+            WHERE user_id=#{viewer_id}
+            AND at > ex.last_activity_at
+          )
         GROUP BY ex.language
       SQL
     end
@@ -174,12 +180,6 @@ class TeamStream
           AND ex.iteration_count > 0
           AND ex.user_id IN (#{user_ids_param})
           AND mark.user_id=#{viewer_id}
-          AND ex.id NOT IN (
-            SELECT exercise_id
-            FROM views
-            WHERE user_id=#{viewer_id}
-            AND last_viewed_at > ex.last_activity_at
-          )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.language
       SQL
@@ -231,6 +231,12 @@ class TeamStream
           AND ex.language='#{current_id}'
           AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
+          AND ex.language || ex.slug NOT IN (
+            SELECT track_id || slug
+            FROM watermarks
+            WHERE user_id=#{viewer_id}
+            AND at > ex.last_activity_at
+          )
         GROUP BY ex.slug
       SQL
     end
@@ -247,12 +253,6 @@ class TeamStream
           AND ex.user_id IN (#{user_ids_param})
           AND ex.language='#{current_id}'
           AND mark.user_id=#{viewer_id}
-          AND ex.id NOT IN (
-            SELECT exercise_id
-            FROM views
-            WHERE user_id=#{viewer_id}
-            AND last_viewed_at > ex.last_activity_at
-          )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.slug
       SQL
@@ -306,6 +306,12 @@ class TeamStream
           AND ex.user_id IN (#{user_ids_param})
           AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
+          AND ex.language || ex.slug NOT IN (
+            SELECT track_id || slug
+            FROM watermarks
+            WHERE user_id=#{viewer_id}
+            AND at > ex.last_activity_at
+          )
         GROUP BY u.username
       SQL
     end
@@ -323,12 +329,6 @@ class TeamStream
           AND ex.iteration_count > 0
           AND ex.user_id IN (#{user_ids_param})
           AND mark.user_id=#{viewer_id}
-          AND ex.id NOT IN (
-            SELECT exercise_id
-            FROM views
-            WHERE user_id=#{viewer_id}
-            AND last_viewed_at > ex.last_activity_at
-          )
           AND mark.at > ex.last_activity_at
         GROUP BY u.username
       SQL
@@ -374,6 +374,12 @@ class TeamStream
           AND ex.user_id IN (#{user_ids_param})
           AND views.user_id=#{viewer_id}
           AND views.last_viewed_at > ex.last_activity_at
+          AND ex.language || ex.slug NOT IN (
+            SELECT track_id || slug
+            FROM watermarks
+            WHERE user_id=#{viewer_id}
+            AND at > ex.last_activity_at
+          )
         GROUP BY ex.language
       SQL
     end
@@ -389,12 +395,6 @@ class TeamStream
           AND ex.iteration_count > 0
           AND ex.user_id IN (#{user_ids_param})
           AND mark.user_id=#{viewer_id}
-          AND ex.id NOT IN (
-            SELECT exercise_id
-            FROM views
-            WHERE user_id=#{viewer_id}
-            AND last_viewed_at > ex.last_activity_at
-          )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.language
       SQL

--- a/lib/exercism/track_stream_filters.rb
+++ b/lib/exercism/track_stream_filters.rb
@@ -83,6 +83,12 @@ class TrackStream
           AND ex.archived='f'
           AND ex.iteration_count > 0
           AND views.last_viewed_at > ex.last_activity_at
+          AND ex.language || ex.slug NOT IN (
+            SELECT track_id || slug
+            FROM watermarks
+            WHERE user_id=#{viewer_id}
+            AND at > ex.last_activity_at
+          )
         GROUP BY ex.language
       SQL
     end
@@ -99,12 +105,6 @@ class TrackStream
           AND ex.slug=mark.slug
           AND acls.user_id=mark.user_id
         WHERE acls.user_id=#{viewer_id}
-          AND ex.id NOT IN (
-            SELECT exercise_id
-            FROM views
-            WHERE user_id=#{viewer_id}
-            AND last_viewed_at > ex.last_activity_at
-          )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.language
       SQL
@@ -170,6 +170,12 @@ class TrackStream
           AND ex.archived='f'
           AND ex.iteration_count > 0
           AND views.last_viewed_at > ex.last_activity_at
+          AND ex.language || ex.slug NOT IN (
+            SELECT track_id || slug
+            FROM watermarks
+            WHERE user_id=#{viewer_id}
+            AND at > ex.last_activity_at
+          )
         GROUP BY ex.slug
       SQL
     end
@@ -189,12 +195,6 @@ class TrackStream
           AND ex.language='#{track_id}'
           AND ex.archived='f'
           AND ex.iteration_count > 0
-          AND ex.id NOT IN (
-            SELECT exercise_id
-            FROM views
-            WHERE user_id=#{viewer_id}
-            AND last_viewed_at > ex.last_activity_at
-          )
           AND mark.at > ex.last_activity_at
         GROUP BY ex.slug
       SQL
@@ -253,6 +253,12 @@ class TrackStream
           AND ex.user_id=#{viewer_id}
           AND ex.language='#{track_id}'
           AND views.last_viewed_at > ex.last_activity_at
+          AND ex.language || ex.slug NOT IN (
+            SELECT track_id || slug
+            FROM watermarks
+            WHERE user_id=#{viewer_id}
+            AND at > ex.last_activity_at
+          )
         GROUP BY u.username
       SQL
     end
@@ -271,12 +277,6 @@ class TrackStream
           AND ex.iteration_count > 0
           AND ex.user_id=#{viewer_id}
           AND ex.language='#{track_id}'
-          AND ex.id NOT IN (
-            SELECT exercise_id
-            FROM views
-            WHERE user_id=#{viewer_id}
-            AND last_viewed_at > ex.last_activity_at
-          )
           AND mark.at > ex.last_activity_at
         GROUP BY u.username
       SQL


### PR DESCRIPTION
We count all the exercises that are marked as 'read' so that we can compute the
'unread' count for the sidebar navigation in each category.

Since some things will be marked as read both based on a watermark and
based on direct views, we would double count them. To avoid that we need
to either exclude the relevant views when counting the watermarks, or
exclude the relevant watermarks when counting the relevant views.

The performance of using NOT IN against the views table (7MM rows) was
dismal to the point of taking down production when certain users
accessed the activity stream.

This reverses the logic so we're excluding watermarks when counting
direct views.

/cc @bernardoamc I'm going to merge and deploy since I had to rollback the previous deploy.