### PR TITLE
Don’t fail if development DB already exists

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -43,7 +43,14 @@ namespace :db do
     end
 
     system 'createdb', '-h', config.host, '-p', config.port, '-U', config.username, config.database
-    fail "Failed to create database" unless $CHILD_STATUS.success?
+
+    unless $CHILD_STATUS.success?
+      if system "psql -lqtA | grep -q #{config.database}"
+        $stdout.puts "#{config.database} already exists"
+      else
+        fail "Failed to create database"
+      end
+    end
   end
 
   desc "drop and recreate your database"


### PR DESCRIPTION
Previously we were failing if $CHILD_STATUS wasn’t success but
that can be the case simply when the config.database already exists in
psql.

With this we simply check to see if we have a matching database when
the status isn’t success, and output a helpful feedback message.

This allows bin/setup to be run multiple times without failure.
