### PR TITLE
Run Compass precompile before tests

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -25,5 +25,8 @@ bundle exec rake db:from_scratch
 # Set up the test database
 RACK_ENV=test bundle exec rake db:setup db:migrate
 
+# Precompile Compass CSS assets
+bundle exec compass compile -e production --force
+
 # Run the tests
 bundle exec rake


### PR DESCRIPTION
Tests actually require precompiled CSS assets otherwise they fail, so this
simply ensures that we run the compass compile command in bin/setup
before finishing up with bundle exec rake.