### PR TITLE
User experience experiments on landing pages

### DIFF
--- a/public/sass/application.scss
+++ b/public/sass/application.scss
@@ -63,18 +63,20 @@ li.alert-row {
 p.cta {
   float: right;
 }
+
 .cta-btn {
-  background: #fff;
   font-family: $headings-font-family;
-  color: #212121;
+  color: #fefefe;
+  background-color: $link-color;
   margin: 0px auto;
   text-align: center;
   margin-bottom: 30px;
   margin-top: 30px;
   width: 400px;
-  @include border-radius(0);
+  @include border-radius(2);
   &:hover {
-    color: $link-color;
+    color: #fefefe;
+    background-color: darken($link-color, 10%);
     text-decoration: none;
   }
 }


### PR DESCRIPTION
Don't mean to step on feet at all with these. I was chatting with @kytrinyx 
recently and looking at the home page specifically. I noticed that despite 
having a strong key color in the header, this key color wasn't used to direct 
attention to the call to action buttons lower on the page.

Those sort of act like "choose your own adventure" buttons, but as they stand, 
they sort of fade into the background of the page; looking more like links than 
actions. 

I've re-used the exercism red on these buttons and given them more of a button 
shape and appearance. This is just a first step and what I've suggested to 
@kytrinyx is that much of the copy currently used on the home page to explain 
each individual "path" that visitors can take depending on their skill-level 
should be transfered to the specific pages for each (newbie, polyglot, artisan).

This would allow for a more succinct home page experience. It would also allow 
visitors to visually parse the page more quickly and help them decide which path
they want to explore.

/cc @troubalex Katrina mentioned that you're working on a some broader changes 
to the styles so this is more of a temporary experiment since I'm sure you have 
tons of ideas in mind. Feel free to :-1: real hard on this, I won't be offended :-)

## Before

![image](https://cloud.githubusercontent.com/assets/65950/19347955/cf53eb2c-914b-11e6-898c-1149b813df68.png)

## After

![image](https://cloud.githubusercontent.com/assets/65950/19348007/0245cba4-914c-11e6-8674-7bf50fea415c.png)


Note: this is a work in progress, I do realize this is a tiny change, but 👶 steps!
