### PR TITLE
Improve home layout above the "fold"

### DIFF
--- a/app/views/site/index.erb
+++ b/app/views/site/index.erb
@@ -16,20 +16,19 @@
   <div class="summary">
     <div class="container">
       <div class="row">
-        <div class="col-md-12">
-          <p>
-          <i class="fa fa-code"></i>
-          Download and solve practice problems in
-          <a href="/languages">over 30 different languages</a>.
-          </p>
-          <p>
-          <i class="fa fa-comment"></i>
-          Submit the solution to the site for feedback (<em>beta</em>).
-          </p>
-          <p>
-          <i class="fa fa-heart"></i>
-          For code newbies and experienced programmers.
-          </p>
+        <ul class="features">
+          <li>
+            <i class="fa fa-code"></i>
+            Solve practice problems in <a href="/languages">over 30 languages</a>.
+          </li>
+          <li>
+            <i class="fa fa-heart"></i>
+            For code newbies &amp; experienced programmers.
+          </li>
+          <li>
+            <i class="fa fa-comment"></i>
+            Submit a solution for feedback (<em>beta</em>).
+          </li>
         </div>
       </div>
     </div>

--- a/public/sass/layouts/home.scss
+++ b/public/sass/layouts/home.scss
@@ -8,11 +8,13 @@
     box-shadow: 0 10px 0 #f1f1f1;
     min-height: 300px;
     min-width: 100%;
-    padding: 40px 0;
+    padding: 1em 0;
+
     .home-top-header {
       color: white;
       letter-spacing: -0.05em;
-      margin-bottom: 0px;
+      margin-bottom: 0;
+      margin-top: 0;
     }
   }
   .summary {

--- a/public/sass/layouts/home.scss
+++ b/public/sass/layouts/home.scss
@@ -21,9 +21,19 @@
     padding: 20px 10px;
     box-shadow: 0 5px 0 #f1f1f1;
     border-bottom: 1px solid #eee;
-    p {
-      font-size: 1.5em;
-      margin: 0.5em;
+    li {
+      font-size: 1.6em;
+      margin: 1em 0;
+    }
+
+    i {
+      margin-right: .3em;
+    }
+
+    .features {
+      list-style: none;
+      width: 42em;
+      margin: 0 auto;
     }
   }
   .content-primary {


### PR DESCRIPTION
I know, there's no fold. But really there's a first impression.

This is the current home page:

![Screenshot of the current home page](https://d3vv6lp55qjaqc.cloudfront.net/items/1s0L352Y2r2l1T2m3x3y/Screen%20Shot%202016-10-13%20at%204.49.20%20PM.png)

And this is the home page with these changes:

![Screenshot of the included changes](https://d3vv6lp55qjaqc.cloudfront.net/items/403H0A3F171D3g2Z1C1U/Screen%20Shot%202016-10-13%20at%204.50.22%20PM.png)

Surely, these are minor changes, but you'll immediately notice that within the 
same viewport you can now digest what Exercism is _about_ more easily.

Main changes:
- Trim the copy from the feature list to remove unnecessary words
- Center the container of the feature list to make it align with the header
- Reduce the excessive margins between the Exercism logo, the edges of the header
  and the tagline.

Once again, very curious what @kytrinyx and @troubalex thing about this. I hope 
I'm not jumping the gun on changes that Alex had planned for later.

The last thing I want to focus on later today is the part below this section. 
I promise I won't submit 4 PRs every day. :-D

PS: It appears that the font size for the section directly below the feature list somehow 
changed but I didn't do that on purpose so I'll check to make sure I can revert that.
