### PR TITLE
Track completeness determination improvement

### DIFF
--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -26,11 +26,11 @@ class UserFinishedTracks
 
   def completed_count_sql
     <<-SQL
-    SELECT language AS track_id, CAST (COUNT(id) AS INTEGER) AS completed_count
+    SELECT language AS track_id, slug AS problem_slug
     FROM user_exercises
     WHERE user_id=#{user.id}
     AND (iteration_count > 0 OR skipped_at IS NOT NULL)
-    GROUP BY language
+    ORDER BY language
     SQL
   end
 

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -15,14 +15,24 @@ class UserFinishedTracks
   def completed_tracks
     advanced_tracks = {}
     started_tracks.group_by{|e| e["track_id"]}
-                  .map{|key, value|
-                    advanced_tracks[key] = value.map{|e| e["problem_slug"]
-                      }
-                    }
-    
+                  .map do |key, value|
+                    advanced_tracks[key] = value.map{|e| e["problem_slug"]}
+                  end
+    started_tracks = []
+    advanced_tracks.map do |key, value|
+                     track = tracks.find { |t| t.id == key }
+                     count = 0
+                     value.each do |user_exercised_slug|
+                       if track.problems.map(&:slug).include?(user_exercised_slug)
+                         count = count + 1
+                       end
+                     end
+                     temp = {'track_id' => key, 'completed_count' => count}
+                     started_tracks << temp
+                    end
     @completed_tracks ||= started_tracks.each_with_object([]) do |db_row, arr|
       track = tracks.find { |t| t.id == db_row['track_id'] }
-      arr << track if db_row['problem_slug'].to_i >= track.problems.count
+      arr << track if db_row['completed_count'].to_i >= track.problems.count
       arr
     end
   end

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -31,7 +31,7 @@ class UserFinishedTracks
     WHERE user_id=#{user.id}
     AND (iteration_count > 0 OR skipped_at IS NOT NULL)
     GROUP BY language
-    SQLs
+    SQL
   end
 
   def tracks

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -23,8 +23,12 @@ class UserFinishedTracks
   def started_tracks
     ActiveRecord::Base.connection.execute(completed_count_sql).to_a.each do |db_row|
       track = tracks.find { |t| t.id == db_row['track_id'] }
-      db_row['completed_problems_count'] = (db_row['completed_problems'].split(',') & track.problems.map(&:slug)).size
+      db_row['completed_problems_count'] = count_finished_problems(db_row['completed_problems'].split(','), track)
     end
+  end
+
+  def count_finished_problems(user_finished_exercises, track)
+    (user_finished_exercises & track.problems.map(&:slug)).size
   end
 
   def completed_count_sql

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -11,26 +11,9 @@ class UserFinishedTracks
   end
 
   def completed_tracks
-    advanced_tracks = {}
-    started_tracks.group_by{|e| e["track_id"]}
-                  .map do |key, value|
-                    advanced_tracks[key] = value.map{|e| e["problem_slug"]}
-                  end
-    started_tracks = []
-    advanced_tracks.map do |key, value|
-                     track = tracks.find { |t| t.id == key }
-                     count = 0
-                     value.each do |user_exercised_slug|
-                       if track.problems.map(&:slug).include?(user_exercised_slug)
-                         count = count + 1
-                       end
-                     end
-                     temp = {'track_id' => key, 'completed_count' => count}
-                     started_tracks << temp
-                    end
     @completed_tracks ||= started_tracks.each_with_object([]) do |db_row, arr|
       track = tracks.find { |t| t.id == db_row['track_id'] }
-      arr << track if db_row['completed_count'].to_i >= track.problems.count
+      arr << track if (db_row['completed_problems'] & track.problems).size >= track.problems.count
       arr
     end
   end
@@ -43,12 +26,12 @@ class UserFinishedTracks
 
   def completed_count_sql
     <<-SQL
-    SELECT language AS track_id, slug AS problem_slug
+    SELECT language AS track_id, string_agg(slug, ',') AS completed_problems
     FROM user_exercises
-    WHERE user_id=#{user.id}
+    WHERE user_id=7
     AND (iteration_count > 0 OR skipped_at IS NOT NULL)
-    ORDER BY language
-    SQL
+    GROUP BY language;
+    SQLs
   end
 
   def tracks

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -12,8 +12,8 @@ class UserFinishedTracks
 
   def completed_tracks
     @completed_tracks ||= started_tracks.each_with_object([]) do |db_row, arr|
-      track = completed?(db_row)
-      arr << track if track
+      track = tracks.find { |t| t.id == db_row['track_id'] }
+      arr << track if completed?(db_row, track)
       arr
     end
   end
@@ -28,10 +28,9 @@ class UserFinishedTracks
     (user_finished_exercises & track.problems.map(&:slug)).size
   end
 
-  def completed?(track_attributes)
-    track = tracks.find { |t| t.id == track_attributes['track_id'] }
-    problems_solved = count_finished_problems(track_attributes['completed_problems'].split(','), track)
-    track if problems_solved >= track.problems.count
+  def completed?(user_track, full_track)
+    problems_solved = count_finished_problems(user_track['completed_problems'].split(','), full_track)
+    problems_solved >= full_track.problems.size
   end
 
   def completed_count_sql

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -28,9 +28,9 @@ class UserFinishedTracks
     <<-SQL
     SELECT language AS track_id, string_agg(slug, ',') AS completed_problems
     FROM user_exercises
-    WHERE user_id=7
+    WHERE user_id=#{user.id}
     AND (iteration_count > 0 OR skipped_at IS NOT NULL)
-    GROUP BY language;
+    GROUP BY language
     SQLs
   end
 

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -12,8 +12,8 @@ class UserFinishedTracks
 
   def completed_tracks
     @completed_tracks ||= started_tracks.each_with_object([]) do |db_row, arr|
-      track = tracks.find { |t| t.id == db_row['track_id'] }
-      arr << track if completed?(db_row)
+      track = completed?(db_row)
+      arr << track if track
       arr
     end
   end
@@ -31,7 +31,7 @@ class UserFinishedTracks
   def completed?(track_attributes)
     track = tracks.find { |t| t.id == track_attributes['track_id'] }
     problems_solved = count_finished_problems(track_attributes['completed_problems'].split(','), track)
-    problems_solved >= track.problems.count
+    track if problems_solved >= track.problems.count
   end
 
   def completed_count_sql

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -10,7 +10,6 @@ class UserFinishedTracks
     @user = user
   end
 
-  # Resource : http://stackoverflow.com/questions/5490952/merge-array-of-hashes-to-get-hash-of-arrays-of-values
 
   def completed_tracks
     advanced_tracks = {}

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -10,7 +10,6 @@ class UserFinishedTracks
     @user = user
   end
 
-
   def completed_tracks
     advanced_tracks = {}
     started_tracks.group_by{|e| e["track_id"]}

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -10,10 +10,19 @@ class UserFinishedTracks
     @user = user
   end
 
+  # Resource : http://stackoverflow.com/questions/5490952/merge-array-of-hashes-to-get-hash-of-arrays-of-values
+
   def completed_tracks
+    advanced_tracks = {}
+    started_tracks.group_by{|e| e["track_id"]}
+                  .map{|key, value|
+                    advanced_tracks[key] = value.map{|e| e["problem_slug"]
+                      }
+                    }
+    
     @completed_tracks ||= started_tracks.each_with_object([]) do |db_row, arr|
       track = tracks.find { |t| t.id == db_row['track_id'] }
-      arr << track if db_row['completed_count'].to_i >= track.problems.count
+      arr << track if db_row['problem_slug'].to_i >= track.problems.count
       arr
     end
   end

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -13,7 +13,7 @@ class UserFinishedTracks
   def completed_tracks
     @completed_tracks ||= started_tracks.each_with_object([]) do |db_row, arr|
       track = tracks.find { |t| t.id == db_row['track_id'] }
-      arr << track if (db_row['completed_problems'] & track.problems).size >= track.problems.count
+      arr << track if (db_row['completed_problems'].split(',') & track.problems.map(&:slug)).size >= track.problems.count
       arr
     end
   end

--- a/lib/exercism/user_finished_tracks.rb
+++ b/lib/exercism/user_finished_tracks.rb
@@ -13,7 +13,7 @@ class UserFinishedTracks
   def completed_tracks
     @completed_tracks ||= started_tracks.each_with_object([]) do |db_row, arr|
       track = tracks.find { |t| t.id == db_row['track_id'] }
-      arr << track if (db_row['completed_problems'].split(',') & track.problems.map(&:slug)).size >= track.problems.count
+      arr << track if db_row['completed_problems_count'] >= track.problems.count
       arr
     end
   end
@@ -21,7 +21,10 @@ class UserFinishedTracks
   private
 
   def started_tracks
-    ActiveRecord::Base.connection.execute(completed_count_sql).to_a
+    ActiveRecord::Base.connection.execute(completed_count_sql).to_a.each do |db_row|
+      track = tracks.find { |t| t.id == db_row['track_id'] }
+      db_row['completed_problems_count'] = (db_row['completed_problems'].split(',') & track.problems.map(&:slug)).size
+    end
   end
 
   def completed_count_sql

--- a/test/exercism/user_finished_tracks_test.rb
+++ b/test/exercism/user_finished_tracks_test.rb
@@ -14,7 +14,7 @@ class UserFinishedTracksTest < Minitest::Test
     create_exercise('fake', 'two')
     create_exercise('jewels', 'hello-world')
     create_exercise('jewels', 'gemerald')
-    create_exercise('shoes','Hello-world')
+    create_exercise('shoes','deprecated-problem')
   end
 
   def test_user_contributions

--- a/test/exercism/user_finished_tracks_test.rb
+++ b/test/exercism/user_finished_tracks_test.rb
@@ -14,6 +14,7 @@ class UserFinishedTracksTest < Minitest::Test
     create_exercise('fake', 'two')
     create_exercise('jewels', 'hello-world')
     create_exercise('jewels', 'gemerald')
+    create_exercise('shoes','Hello-world')
   end
 
   def test_user_contributions


### PR DESCRIPTION
Fixes https://github.com/exercism/exercism.io/issues/3029

This PR solves the ambiguity of how to determined user finished tracks in #3029  , the problem is currently happening because we count the completed exercises by number but some of the completed exercised are deprecated. We need to filter the deprecated ones first and then continue our counting.

TODO: 
- [x] fix travis-ci check
- [x] add a test case for deprecated exercises