### PR TITLE
Refactor Xapi out of languages route

### DIFF
--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -6,9 +6,11 @@ module ExercismWeb
       TOPICS = %w(about exercises installing tests learning resources help launch contribute todo).freeze
 
       get '/languages' do
-        tracks = X::Track.all
-        active, inactive = tracks.partition(&:active?)
-        planned, inactive = inactive.partition(&:planned?)
+        tracks = Trackler.tracks
+        active, inactive = tracks.partition { |t| t.active? }
+        planned = []
+
+        # planned, inactive = inactive.partition(&:planned?)
         inactive.sort! { |a, b| b.problems.count <=> a.problems.count }
         erb :"languages/index", locals: { active: active, inactive: inactive, planned: planned }
       end

--- a/app/views/languages/_about.erb
+++ b/app/views/languages/_about.erb
@@ -1,11 +1,11 @@
-<%= md track.docs.about %>
+<%= md docs["about"] %>
 
 <h3>Try It!</h3>
 <p>
   If you've downloaded the <a href='/cli'>command-line client</a> and have <%= track.language %> installed
   on your machine, then go ahead and fetch the first problem.
 </p>
-<%= syntax track.fetch_cmd, "plain" %>
+<%= syntax "exercism #{track.id} #{track.problems.first.name}", "plain" %>
 
 <p>
   In order to be able to submit your solution, you'll need to configure the client with your

--- a/app/views/languages/_about.erb
+++ b/app/views/languages/_about.erb
@@ -5,7 +5,7 @@
   If you've downloaded the <a href='/cli'>command-line client</a> and have <%= track.language %> installed
   on your machine, then go ahead and fetch the first problem.
 </p>
-<%= syntax "exercism #{track.id} #{track.problems.first.name}", "plain" %>
+<%= syntax "exercism #{track.id} #{track.problems.first.slug}", "plain" %>
 
 <p>
   In order to be able to submit your solution, you'll need to configure the client with your

--- a/app/views/languages/index.erb
+++ b/app/views/languages/index.erb
@@ -14,7 +14,7 @@
     <section class="page-header">
       <h3>Upcoming</h3>
     </section>
-    <% inactive.each_slice(6) do |tracks| %>
+    <% upcoming.each_slice(6) do |tracks| %>
       <div class="row">
         <% tracks.each do |t| %>
           <%= erb :'languages/_block', locals: { track: t } %>

--- a/test/app/languages_test.rb
+++ b/test/app/languages_test.rb
@@ -10,16 +10,13 @@ class LanguagesRoutesTest < Minitest::Test
   end
 
   def test_route_languages
-    fixture = './test/fixtures/xapi_v3_tracks.json'
-    X::Xapi.stub(:get, [200, File.read(fixture)]) do
-      get '/languages'
-      assert_equal 200, last_response.status
-      assert_match 'Animal', last_response.body
-      assert_match 'Fake', last_response.body
-      assert_match 'Fancy Stones', last_response.body
-      assert_match 'Fruit', last_response.body
-      assert_match 'Shoes & Boots', last_response.body
-    end
+    get '/languages'
+    assert_equal 200, last_response.status
+    assert_match 'Animal', last_response.body
+    assert_match 'Fake', last_response.body
+    assert_match 'Fancy Stones', last_response.body
+    assert_match 'Fruit', last_response.body
+    assert_match 'Shoes & Boots', last_response.body
   end
 
   def test_route_repositories

--- a/test/app/languages_test.rb
+++ b/test/app/languages_test.rb
@@ -20,84 +20,56 @@ class LanguagesRoutesTest < Minitest::Test
   end
 
   def test_route_repositories
-    fixture = './test/fixtures/xapi_v3_tracks.json'
-    X::Xapi.stub(:get, [200, File.read(fixture)]) do
-      get '/repositories'
-      assert_equal 200, last_response.status
-      assert_match 'Exercism Repositories', last_response.body
-      assert_match 'Basic Components', last_response.body
-      assert_match 'Exercises', last_response.body
-      assert_match 'Interesting Tools', last_response.body
-      assert_match 'Language tracks you can contribute to', last_response.body
-      assert_match 'In Progress', last_response.body
-      assert_match 'Planned', last_response.body
-    end
+    get '/repositories'
+    assert_equal 200, last_response.status
+    assert_match 'Exercism Repositories', last_response.body
+    assert_match 'Basic Components', last_response.body
+    assert_match 'Exercises', last_response.body
+    assert_match 'Interesting Tools', last_response.body
+    assert_match 'Language tracks you can contribute to', last_response.body
+    assert_match 'In Progress', last_response.body
+    assert_match 'Planned', last_response.body
   end
 
   def test_route_languages_invalid_track
-    fixture = './test/fixtures/xapi_v3_tracks_error.json'
-    X::Xapi.stub(:get, [200, File.read(fixture)]) do
-      get '/languages/invalid_track/about'
-      assert_equal 404, last_response.status
-      assert_match "It doesn't look like we have <b>invalid_track</b> yet", last_response.body
-    end
+    get '/languages/invalid_track/about'
+    assert_equal 404, last_response.status
+    assert_match "It doesn't look like we have <b>invalid_track</b> yet", last_response.body
   end
 
-  def test_route_languages_valid_track
-    fixture = './test/fixtures/xapi_v3_track.json'
-    X::Xapi.stub(:get, [200, File.read(fixture)]) do
-      get '/languages/animal/about'
-      assert_equal 200, last_response.status
-      assert_match "About the Animal Track", last_response.body
-      assert_match "Available Exercises", last_response.body
-      assert_match "Installing Animal", last_response.body
-      assert_match "Running the Tests", last_response.body
-      assert_match "Learning Animal", last_response.body
-      assert_match "Useful Animal Resources", last_response.body
-      assert_match "Getting Help", last_response.body
-      assert_match "Contributing to Animal on Exercism", last_response.body
-    end
+  def test_route_languages_valid_track_redirects_to_about_page
+    get '/languages/animal'
+    assert_equal 302, last_response.status
   end
 
   def test_route_contribute_invalid_language
-    X::Xapi.stub(:get, [404, "{\"error\":\"No track 'nonexistant'\"}"]) do
-      get '/languages/nonexistant/contribute'
-      assert_equal 404, last_response.status
-      assert_match 'It doesn\'t look like we have <b>nonexistant</b> yet.', last_response.body
-    end
+    get '/languages/nonexistant/contribute'
+    assert_equal 404, last_response.status
+    assert_match 'It doesn\'t look like we have <b>nonexistant</b> yet.', last_response.body
   end
 
   def test_route_valid_track_with_invalid_topic
-    fixture = './test/fixtures/xapi_v3_track.json'
-    X::Xapi.stub(:get, [200, File.read(fixture)]) do
-      get '/languages/animal/invalid-topic'
-      assert_equal 404, last_response.status
-    end
+    get '/languages/animal/invalid-topic'
+    assert_equal 404, last_response.status
     assert_match "We don't know anything about", last_response.body
   end
 
   def test_route_invalid_track_with_valid_topic
-    fixture = './test/fixtures/xapi_v3_tracks_error.json'
-    X::Xapi.stub(:get, [404, File.read(fixture)]) do
-      get '/languages/invalid_track/about'
-      assert_equal 404, last_response.status
-      assert_match "It doesn't look like we have <b>invalid_track</b> yet", last_response.body
-    end
+    get '/languages/invalid_track/about'
+    assert_equal 404, last_response.status
+    assert_match "It doesn't look like we have <b>invalid_track</b> yet", last_response.body
   end
 
   def test_route_valid_track_with_valid_topic
-    fixture = './test/fixtures/xapi_v3_track.json'
-    X::Xapi.stub(:get, [200, File.read(fixture)]) do
-      get '/languages/animal/about'
-      assert_equal 200, last_response.status
-      assert_match "About the Animal Track", last_response.body
-      assert_match "Available Exercises", last_response.body
-      assert_match "Installing Animal", last_response.body
-      assert_match "Running the Tests", last_response.body
-      assert_match "Learning Animal", last_response.body
-      assert_match "Useful Animal Resources", last_response.body
-      assert_match "Getting Help", last_response.body
-      assert_match "Contributing to Animal on Exercism", last_response.body
-    end
+    get '/languages/animal/about'
+    assert_equal 200, last_response.status
+    assert_match "About the Animal Track", last_response.body
+    assert_match "Available Exercises", last_response.body
+    assert_match "Installing Animal", last_response.body
+    assert_match "Running the Tests", last_response.body
+    assert_match "Learning Animal", last_response.body
+    assert_match "Useful Animal Resources", last_response.body
+    assert_match "Getting Help", last_response.body
+    assert_match "Contributing to Animal on Exercism", last_response.body
   end
 end


### PR DESCRIPTION
Part of #3164

Instead of using Xapi calls to get information about languages, the language route now uses the Trackler gem.

The main benefit of this is to no longer have to stub out requests since the information is now coming from the Trackler gem's fixtures. 

Some of the views were also changed in order to make use of some new variables introduced. 
