### PR TITLE
Improve profile load time.

### DIFF
--- a/lib/exercism/user_tracks_summary.rb
+++ b/lib/exercism/user_tracks_summary.rb
@@ -30,23 +30,23 @@ class UserTracksSummary
   end
 
   def completed_exercises_hash
-    @completed_exercises_hash ||= completed_exercises_by_language.each_with_object({}) do |(lan, exercises), hash|
-      hash[lan] = { completed: exercises.size }
+    @completed_exercises_hash ||= completed_exercises_by_language.each_with_object({}) do |(lan, exercise_count), hash|
+      hash[lan] = { completed: exercise_count }
     end
   end
 
   def reviewed_exercises_hash
-    @reviewed_exercises_hash = reviewed_exercises_by_language.each_with_object({}) do |(lan, reviewed), hash|
-      hash[lan] = { reviewed: reviewed.size }
+    @reviewed_exercises_hash = reviewed_exercises_by_language.each_with_object({}) do |(lan, reviewed_count), hash|
+      hash[lan] = { reviewed: reviewed_count }
     end
   end
 
   def completed_exercises_by_language
-    user.exercises.completed.group_by(&:language)
+    user.exercises.where('iteration_count > 0').group(:language).count(:id)
   end
 
   def reviewed_exercises_by_language
-    user.comments.group_by { |c| c.submission.language }
+    user.comments.joins(:submission).group(:language).count('comments.id')
   end
 
   class TrackSummary


### PR DESCRIPTION
Starting the investigation of #3181 

The goal of these changes is to avoid grouping exercises by language
in memory and N+1 queries for comments and submissions.

Did a few benchmarks and the changes looks solid. I tried as much as possible to avoid warming up  database indexes/queries. Here is the benchmark running locally:



**kotp and NobbZ before**
-------------------------------------------------
  0.850000   0.060000   0.910000 (  1.237934)

**after**

  0.010000   0.000000   0.010000 (  0.282434)


**kytrinyx before**
-------------------------------------------------
  2.670000   0.210000   2.880000 (  3.749523)

**after**

  0.030000   0.000000   0.030000 (  0.932170)


**etrepum before**
-------------------------------------------------
  3.100000   0.220000   3.320000 (  4.374569)

**after**

  0.010000   0.000000   0.010000 (  1.232230)

