### PR TITLE
Remove Xapi calls from Iterations Route

### DIFF
--- a/api/v1/routes/iterations.rb
+++ b/api/v1/routes/iterations.rb
@@ -14,7 +14,9 @@ module ExercismAPI
           halt 401, { error: message }.to_json
         end
 
-        unless Xapi.exists?(language, slug)
+        track = Trackler.tracks[language]
+        problems = track.problems
+        unless problems.include? slug
           message = "Exercise '#{slug}' in language '#{language}' doesn't exist. "
           message << "Maybe you mispelled it?"
           halt 404, { error: message }.to_json

--- a/lib/exercism/use_cases/attempt.rb
+++ b/lib/exercism/use_cases/attempt.rb
@@ -15,7 +15,7 @@ class Attempt
   # rubocop:enable Metrics/AbcSize
 
   def valid?
-    !!slug && Xapi.exists?(track, slug)
+    !!slug && Trackler.tracks[track]
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/test/api/iterations_test.rb
+++ b/test/api/iterations_test.rb
@@ -22,18 +22,14 @@ class IterationsApiTest < Minitest::Test
       comment: '',
     }
 
-    Xapi.stub(:exists?, true) do
-      post '/user/assignments', submission.to_json
-    end
+    post '/user/assignments', submission.to_json
 
     assert_equal 0, Comment.count
 
     submission[:comment] = 'Awesome code!'
     submission[:solution] = { 'code.rb' => 'CODE2' }
 
-    Xapi.stub(:exists?, true) do
-      post '/user/assignments', submission.to_json
-    end
+    post '/user/assignments', submission.to_json
 
     assert_equal 1, Comment.count
     comment = Comment.first
@@ -79,9 +75,7 @@ class IterationsApiTest < Minitest::Test
       Hack::UpdatesUserExercise.new(*args).update
     end
 
-    Xapi.stub(:exists?, true) do
-      get '/iterations/latest', key: @alice.key
-    end
+    get '/iterations/latest', key: @alice.key
 
     output = last_response.body
     options = { format: :json, name: 'api_iterations' }
@@ -89,23 +83,18 @@ class IterationsApiTest < Minitest::Test
   end
 
   def test_skip_problem
-    Xapi.stub(:exists?, true) do
-      post '/iterations/ruby/one/skip', key: @alice.key
-    end
-
+    post "/iterations/animal/dog/skip", key: @alice.key
     exercise = @alice.exercises.first
-    assert_equal 'ruby', exercise.language
-    assert_equal 'one', exercise.slug
+    assert_equal 'animal', exercise.language
+    assert_equal 'dog', exercise.slug
     refute_equal nil, exercise.skipped_at
     assert_equal 204, last_response.status
   end
 
   def test_skip_non_existent_problem
-    Xapi.stub(:exists?, false) do
-      post '/iterations/ruby/not-found/skip', key: @alice.key
-    end
+    post '/iterations/animal/not-found/skip', key: @alice.key
 
-    expected_message = "Exercise 'not-found' in language 'ruby' doesn't exist. "
+    expected_message = "Exercise 'not-found' in language 'animal' doesn't exist. "
     expected_message << "Maybe you mispelled it?"
 
     assert_equal 404, last_response.status
@@ -113,9 +102,7 @@ class IterationsApiTest < Minitest::Test
   end
 
   def test_skip_problem_as_guest
-    Xapi.stub(:exists?, true) do
-      post '/iterations/ruby/one/skip', key: 'invalid-api-key'
-    end
+    post '/iterations/ruby/one/skip', key: 'invalid-api-key'
 
     expected_message = "Please double-check your exercism API key."
 
@@ -131,9 +118,7 @@ class IterationsApiTest < Minitest::Test
       "dir" => "/path/to/exercism/dir",
     }
 
-    Xapi.stub(:exists?, true) do
-      post '/user/assignments', submission.to_json
-    end
+    post '/user/assignments', submission.to_json
 
     submission = Submission.first
     assert_equal "go", submission.language
@@ -150,9 +135,7 @@ class IterationsApiTest < Minitest::Test
       "dir" => "/path/to/exercism/dir",
     }
 
-    Xapi.stub(:exists?, true) do
-      post '/user/assignments', submission.to_json
-    end
+    post '/user/assignments', submission.to_json
 
     submission = Submission.first
     assert_equal "binary", submission.slug

--- a/test/exercism/use_cases/attempt_test.rb
+++ b/test/exercism/use_cases/attempt_test.rb
@@ -10,13 +10,9 @@ class AttemptTest < Minitest::Test
   end
 
   def test_validity
-    Xapi.stub(:exists?, true) do
-      assert Attempt.new(user, Iteration.new({ 'two.py' => 'CODE' }, 'python', 'two')).valid?
-    end
+    assert Attempt.new(user, Iteration.new({ 'zoo.py' => 'CODE' }, 'animal', 'dog')).valid?
 
-    Xapi.stub(:exists?, false) do
-      refute Attempt.new(user, Iteration.new({ 'two.py' => 'CODE' }, 'python', 'two')).valid?
-    end
+    refute Attempt.new(user, Iteration.new({ 'two.py' => 'CODE' }, 'python', nil)).valid?
   end
 
   def test_saving_with_comments_creates_a_new_comment


### PR DESCRIPTION
Helps with https://github.com/exercism/exercism.io/pull/3164

This removes the `Xapi` call in the iterations route to check if a language and a slug exists. This now uses the Trackler gem to first check the language track and then derive the problems of the track.

Instead of passing the language and slug to the `Xapi.exists?` method it now checks if the slug is in the track's problems. An issue that I think that can arise here is that it will throw an exception when the language passed does not exist and it will throw a `nil:NilClass` error when trying to access problems of a non existent track.

One way to maybe fix this is to implement an `exists?` method in the `Trackler` module similar to `Xapi` but uses Track and Problem modules.
