### PR TITLE
Use Trackler for Tracks Route

### DIFF
--- a/api/v1/routes/tracks.rb
+++ b/api/v1/routes/tracks.rb
@@ -3,17 +3,17 @@ module ExercismAPI
     class Tracks < Core
       # Status on a track for a user.
       # Called by the CLI.
-      get '/tracks/:language/status' do |language|
+      get '/tracks/:track_id/status' do |track_id|
         require_key
 
-        track = Trackler.tracks[language]
+        track = Trackler.tracks[track_id]
         unless track.exists?
-          message = "Track #{language} not found."
+          message = "Track #{track_id} not found."
           halt 404, { error: message }.to_json
         end
 
         begin
-          Homework.new(current_user).status(language).to_json
+          Homework.new(current_user).status(track_id).to_json
           # rubocop:disable Lint/RescueException
         rescue Exception => e
           Bugsnag.notify(e, nil, request)

--- a/api/v1/routes/tracks.rb
+++ b/api/v1/routes/tracks.rb
@@ -3,16 +3,17 @@ module ExercismAPI
     class Tracks < Core
       # Status on a track for a user.
       # Called by the CLI.
-      get '/tracks/:id/status' do |id|
+      get '/tracks/:language/status' do |language|
         require_key
 
-        unless Xapi.exists?(id)
-          message = "Track #{id} not found."
+        track = Trackler.tracks[language]
+        unless track.exists?
+          message = "Track #{language} not found."
           halt 404, { error: message }.to_json
         end
 
         begin
-          Homework.new(current_user).status(id).to_json
+          Homework.new(current_user).status(language).to_json
           # rubocop:disable Lint/RescueException
         rescue Exception => e
           Bugsnag.notify(e, nil, request)

--- a/test/api/tracks_test.rb
+++ b/test/api/tracks_test.rb
@@ -17,4 +17,10 @@ class TracksApiTest < Minitest::Test
     get '/tracks/invalid-language/status', key: @alice.key
     assert_equal 404, last_response.status
   end
+
+  def test_language_status_when_language_is_valid_but_has_no_solutions
+    get '/tracks/animal/status', key: @alice.key
+    assert_equal 200, last_response.status
+    assert_match "You haven't submitted any solutions yet.", last_response.body
+  end
 end

--- a/test/api/tracks_test.rb
+++ b/test/api/tracks_test.rb
@@ -1,6 +1,6 @@
 require_relative '../api_helper'
 
-class TrackssApiTest < Minitest::Test
+class TracksApiTest < Minitest::Test
   include Rack::Test::Methods
   include DBCleaner
 

--- a/test/api/tracks_test.rb
+++ b/test/api/tracks_test.rb
@@ -1,0 +1,20 @@
+require_relative '../api_helper'
+
+class TrackssApiTest < Minitest::Test
+  include Rack::Test::Methods
+  include DBCleaner
+
+  def app
+    ExercismAPI::App
+  end
+
+  def setup
+    super
+    @alice = User.create!(username: 'alice', github_id: 1)
+  end
+
+  def test_language_status_returns_404_when_language_does_not_exist
+    get '/tracks/invalid-language/status', key: @alice.key
+    assert_equal 404, last_response.status
+  end
+end


### PR DESCRIPTION
Helps with https://github.com/exercism/exercism.io/pull/3164

This removes the call to `Xapi` from the route that checks the status of
the language. It now uses the Trackler gem to determine if the the track
exists.

The variable name of the route was also changed from `id` to `language`
so that it makes a little more sense.
