### PR TITLE
Disambiguate "missing track" and "no such topic"

### DIFF
--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -3,7 +3,7 @@ require_relative '../../x'
 module ExercismWeb
   module Routes
     class Languages < Core
-      TOPICS = [:about, :exercises, :installing, :tests, :learning, :resources, :help, :launch].freeze
+      TOPICS = %w(about exercises installing tests learning resources help launch).freeze
 
       get '/languages' do
         tracks = X::Track.all
@@ -44,7 +44,11 @@ module ExercismWeb
       end
 
       get '/languages/:track_id/:topic' do |track_id, topic|
-        return topic_not_found(topic) unless TOPICS.include?(topic.to_sym)
+        template = topic
+        unless TOPICS.include?(topic)
+          status 404
+          template = "topic_not_found"
+        end
 
         _, body = X::Xapi.get('tracks', track_id)
         parsed_body = JSON.parse(body)
@@ -55,6 +59,7 @@ module ExercismWeb
           erb :"languages/language", locals: {
             track: track,
             topic: topic,
+            template: template,
             docs: X::Docs::Launch.new(track.repository, track.checklist_issue),
           }
         end
@@ -63,11 +68,6 @@ module ExercismWeb
       def language_not_found(track_id)
         status 404
         erb :"languages/not_found", locals: { track_id: track_id }
-      end
-
-      def topic_not_found(topic)
-        status 404
-        erb :"languages/not_found", locals: { track_id: topic }
       end
     end
   end

--- a/app/views/languages/_topic_not_found.erb
+++ b/app/views/languages/_topic_not_found.erb
@@ -1,0 +1,3 @@
+<p>
+We don't know anything about <i><b><%= topic %></b></i> in the context of the <%= track.language %> track.
+</p>

--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -73,7 +73,7 @@
 
     <div class="col-md-8 tab-content">
       <div class="tab-pane active" id="<%= topic %>">
-        <%= erb :"languages/_#{topic}", locals: { track: track, docs: docs } %>
+        <%= erb :"languages/_#{template}", locals: { track: track, docs: docs, topic: topic } %>
       </div>
     </div>
   </div>

--- a/test/app/languages_test.rb
+++ b/test/app/languages_test.rb
@@ -96,9 +96,12 @@ class LanguagesRoutesTest < Minitest::Test
   end
 
   def test_route_valid_track_with_invalid_topic
-    get '/languages/valid_track/invalid_topic'
-    assert_equal 404, last_response.status
-    assert_match "It doesn't look like we have <b>invalid_topic</b> yet", last_response.body
+    fixture = './test/fixtures/xapi_v3_track.json'
+    X::Xapi.stub(:get, [200, File.read(fixture)]) do
+      get '/languages/animal/invalid-topic'
+      assert_equal 404, last_response.status
+    end
+    assert_match "We don't know anything about", last_response.body
   end
 
   def test_route_invalid_track_with_valid_topic


### PR DESCRIPTION
We have a particular set of documentation topics for each track.

If you ask for a topic outside of that set, we were showing you the
page that says "we don't have that track, but Katrina can make you one".

It's not a track, it's a topic within a track.

This changes it to show you the documentation page for that track, with
an error message that makes more sense ("no such topic in the context of
track X").

Here's some screenshots.

### Before

<img width="923" alt="before" src="https://cloud.githubusercontent.com/assets/276834/19600501/356c3994-979d-11e6-8009-55415a4537fb.png">

### After

<img width="781" alt="after" src="https://cloud.githubusercontent.com/assets/276834/19600502/37a176ac-979d-11e6-98ac-fa339a24d1d5.png">

/cc @nickborromeo @mhelmetag Want to sanity-check this really quickly? I'm hoping that this bit of cleanup will help make it a tiny bit easier to swap in Trackler in the language route.