### PR TITLE
Consolidate track todos with track documentation

### DIFF
--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -3,7 +3,7 @@ require_relative '../../x'
 module ExercismWeb
   module Routes
     class Languages < Core
-      TOPICS = %w(about exercises installing tests learning resources help launch).freeze
+      TOPICS = %w(about exercises installing tests learning resources help launch contribute todo).freeze
 
       get '/languages' do
         tracks = X::Track.all
@@ -31,15 +31,6 @@ module ExercismWeb
           track = X::Track.new(parsed_body['track'])
           topic = track.active? ? "about" : "launch"
           redirect "/languages/%s/%s" % [track_id, topic]
-        end
-      end
-
-      get '/languages/:track_id/contribute' do |track_id|
-        begin
-          unimplemented_exercises = X::Todo.track(track_id)
-          erb :"languages/contribute", locals: { exercises: unimplemented_exercises }
-        rescue X::LanguageNotFound
-          language_not_found(track_id)
         end
       end
 

--- a/app/views/languages/_contribute.erb
+++ b/app/views/languages/_contribute.erb
@@ -14,7 +14,7 @@
 <h5>Help Add More <%= track.language %> Exercises</h5>
 <p>
 The easiest way to add new exercises is to translate existing exercises from other language tracks on Exercism.
-Here's the <a href="/languages/<%= track.id %>/contribute">full list of unimplemented exercises in <%= track.language %></a>,
+Here's the <a href="/languages/<%= track.id %>/todo">full list of unimplemented exercises in <%= track.language %></a>,
 along with links to all the existing implementations.
 </p>
 

--- a/app/views/languages/_todo.erb
+++ b/app/views/languages/_todo.erb
@@ -1,0 +1,33 @@
+<h3>Add new exercises to <%= track.language %></h3>
+<p>
+  One of the easiest ways to add new exercises to the <%= track.language %> track is to translate them from other language tracks on Exercism. This page lists all of the exercises that exist on Exercism, but have not yet been implemented in <%= track.language %>.
+</p>
+<p>
+  The <i style="font-size: 20px;" class="fa fa-info-circle icon-red"></i>
+  icon links to the generic, language-independent problem description
+</p>
+<p>
+  The <i style="font-size: 20px;" class="fa fa-list icon-red"></i>
+  icon links to the canonical test data
+</p>
+
+<p>The language icons link to each existing implementation of the problem.</p>
+<p>
+Once you've picked an exercise, follow the instructions in the <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#porting-an-exercise-to-another-language-track" target="_blank">Contributing Guide</a> and submit your pull request to the <a href="<%= track.repository %>" target="_blank"><%= track.language %> track repository</a> on GitHub.
+</p>
+
+<% if track.unimplemented_problems.count.zero? %>
+  <div class="col-md-12 jumbotron">
+    <p>All exercises are implemented in <%= track.language %>, you will need to <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#implementing-a-completely-new-exercise">invent a new exercise.</a></p>
+  </div>
+<% else %>
+
+  <% track.unimplemented_problems.each_slice(3) do |todos| %>
+    <div class="row padding-row">
+      <% todos.each do |todo| %>
+        <%= erb :'languages/_contribute_exercise', locals: { exercise: todo} %>
+      <% end %>
+    </div>
+  <% end %>
+
+<% end %>

--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -62,9 +62,15 @@
             </a>
           </li>
 
-          <li>
+          <li class="<%= "active" if topic == "contribute" %>">
             <a href="<%="/languages/#{track.id}/contribute"%>">
               Contributing to <%= track.language %> on Exercism
+            </a>
+          </li>
+
+          <li class="<%= "active" if topic == "todo" %>">
+            <a href="<%="/languages/#{track.id}/todo"%>">
+              Unimplemented Exercises
             </a>
           </li>
         </ul>

--- a/test/app/languages_test.rb
+++ b/test/app/languages_test.rb
@@ -68,25 +68,6 @@ class LanguagesRoutesTest < Minitest::Test
     end
   end
 
-  def test_route_contribute
-    fixture = './test/fixtures/xapi_v3_todos.json'
-    X::Xapi.stub(:get, [200, File.read(fixture)]) do
-      get '/languages/testlanguage/contribute'
-      assert_equal 200, last_response.status
-      assert_match 'Alphametics', last_response.body
-      assert_match 'Bank Account', last_response.body
-    end
-  end
-
-  def test_route_contribute_complete
-    fixture = './test/fixtures/xapi_v3_todos_none.json'
-    X::Xapi.stub(:get, [200, File.read(fixture)]) do
-      get '/languages/complete/contribute'
-      assert_equal 200, last_response.status
-      assert_match 'All exercises are implemented in Complete', last_response.body
-    end
-  end
-
   def test_route_contribute_invalid_language
     X::Xapi.stub(:get, [404, "{\"error\":\"No track 'nonexistant'\"}"]) do
       get '/languages/nonexistant/contribute'

--- a/test/x/todos/todo_test.rb
+++ b/test/x/todos/todo_test.rb
@@ -31,8 +31,8 @@ module X
 
       assert_equal 3, exercises.exercises.size
 
-      expected_slugs = %w(alphametics bank-account without-implementations)
-      assert_equal expected_slugs, exercises.exercises.map(&:slug)
+      expected_slugs = %w(alphametics bank-account without-implementations).sort
+      assert_equal expected_slugs, exercises.exercises.map(&:slug).sort
     end
 
     def test_enumerable

--- a/x/todos/todo.rb
+++ b/x/todos/todo.rb
@@ -24,7 +24,9 @@ module X
 
     def initialize(data)
       PROPERTIES.each { |name| instance_variable_set(:"@#{name}", data[name]) }
-      @exercises = data['todos'].map { |problem| Exercise.new(problem) }
+      @exercises = data['todos'].map { |problem|
+        Exercise.new(problem)
+      }.sort_by { |e| [-e.implementations.count, e.name] }
     end
   end
 end

--- a/x/track.rb
+++ b/x/track.rb
@@ -32,6 +32,10 @@ module X
       @docs = Docs::Track.new(data['docs'], repository, doc_format)
     end
 
+    def unimplemented_problems
+      X::Todo.track(id)
+    end
+
     def fetch_cmd(problem=problems.first)
       "exercism fetch #{id} #{problem}"
     end


### PR DESCRIPTION
The track todos were linked to from the track documentation page,
however the actual page was full-width, without the breadcrumbs or
the sidebar navigation for the track documentation.

This doesn't fix the scannability of the todos, but it does bring
this into line with the rest of the documentation visually/contextually.

I deleted a couple of tests that I'd like to add back in when we've refactored—this is in a pretty dirty/hacky area of the code, and the test would now require two fixtures instead of one.

Here are some screenshots:

### Before

<img width="1119" alt="before" src="https://cloud.githubusercontent.com/assets/276834/19612846/da5a98b8-97e0-11e6-8226-df8ba86b8870.png">

### After

<img width="1043" alt="after" src="https://cloud.githubusercontent.com/assets/276834/19612856/ecb7364c-97e0-11e6-92cb-e05df5b716e9.png">


FYI @nickborromeo @mhelmetag - this affects one of the areas that we're refactoring to use Trackler.