### PR TITLE
Swap trackler into stats routes

### DIFF
--- a/app/routes/stats.rb
+++ b/app/routes/stats.rb
@@ -2,28 +2,29 @@ module ExercismWeb
   module Routes
     class Stats < Core
       get '/stats' do
-        redirect "/stats/#{tracks.find(&:active?).slug}"
+        track = Trackler.tracks.sort_by(&:language).find(&:active?)
+        redirect "/stats/%s" % track.id
       end
 
       get '/stats/:track_id' do |track_id|
-        track_id = track_id.downcase
-        tracks = X::Track.all.reject { |track| track.problems.empty? }
-        track = tracks.find { |t| t.id == track_id }
-
-        if !!track
-          slugs = track.problems.map(&:slug)
-          stats = ExercismLib::Stats.new(track_id, slugs)
-          datasets = [
-            stats,
-            ExercismLib::Stats.new(track_id, slugs, ExercismLib::Stats::LastN.new(90)),
-            ExercismLib::Stats.new(track_id, slugs, ExercismLib::Stats::LastN.new(120)),
-          ] + stats.historical(6)
-
-          erb :"stats/index", locals: { tracks: tracks.select(&:active?).sort_by(&:language), track: track, datasets: datasets }
-        else
-          status 404
-          erb :"errors/not_found"
+        track = Trackler.tracks[track_id]
+        unless track.exists?
+          redirect '/stats'
         end
+
+        slugs = track.problems.map(&:slug)
+        stats = ExercismLib::Stats.new(track.id, slugs)
+        datasets = [
+          stats,
+          ExercismLib::Stats.new(track_id, slugs, ExercismLib::Stats::LastN.new(90)),
+          ExercismLib::Stats.new(track_id, slugs, ExercismLib::Stats::LastN.new(120)),
+        ] + stats.historical(6)
+
+        erb :"stats/index", locals: {
+          tracks: Trackler.tracks.reject {|track| track.problems.count.zero? }.sort_by(&:language),
+          track: track,
+          datasets: datasets,
+        }
       end
     end
   end


### PR DESCRIPTION
This is a PR onto the open trackler PR: #3164

The stats routes aren't linked to from anywhere and they're completely experimental, but track maintainers sometimes have a look at them.

/cc @mhelmetag @nickborromeo 
