### PR TITLE
Swap trackler into the "language" helper in lib

### DIFF
--- a/lib/exercism/language.rb
+++ b/lib/exercism/language.rb
@@ -1,16 +1,11 @@
-# rubocop:disable Lint/RescueException
-# Allow all exceptions to be reported to Bugsnag
-
 class Language
-  def self.of(id)
-    by_track_id[id.to_s.downcase]
-  rescue Exception => e
-    Bugsnag.notify(e, track: id)
-    id
+  def self.of(track_id)
+    track = Trackler.tracks[track_id.to_s.downcase]
+    track.exists? ? track.language : track_id
   end
 
   def self.by_track_id
-    @by_track_id ||= X::Track.all.each_with_object({}) do |track, languages|
+    @by_track_id ||= Trackler.tracks.each_with_object({}) do |track, languages|
       languages[track.id] = track.language
     end
   end

--- a/test/exercism/language_test.rb
+++ b/test/exercism/language_test.rb
@@ -1,4 +1,5 @@
 require_relative '../test_helper'
+require 'trackler'
 require_relative '../../lib/exercism/language'
 
 class LanguageTest < Minitest::Test


### PR DESCRIPTION
This helps with the refactoring in #3164

Throughout the codebase we ask "what is the name of the programming language for the track with ID `$ID`". We were asking over HTTP, now we don't have to.

/cc @nickborromeo @mhelmetag @bernardoamc 