### PR TITLE
display notifications by language

### DIFF
--- a/app/helpers.rb
+++ b/app/helpers.rb
@@ -7,6 +7,7 @@ module ExercismWeb
       Markdown: 'markdown',
       Syntax: 'syntax',
       NotificationCount: 'notification_count',
+      NotificationByLanguage: 'notification_by_language',
       Gravatar: 'gravatar',
       Profile: 'profile',
       Submission: 'submission',

--- a/app/helpers/notification_by_language.rb
+++ b/app/helpers/notification_by_language.rb
@@ -1,0 +1,18 @@
+module ExercismWeb
+  module Helpers
+    module NotificationByLanguage
+      # rubocop:disable Metrics/AbcSize
+      def notification_by_language(notifications)
+        notification_hash = Hash.new([])
+        notifications.each do |notification|
+          if notification_hash[notification.iteration.problem.language].empty?
+            notification_hash[notification.iteration.problem.language] = [notification]
+          else
+            notification_hash[notification.iteration.problem.language] << notification
+          end
+        end
+        notification_hash
+      end
+    end
+  end
+end

--- a/app/routes/core.rb
+++ b/app/routes/core.rb
@@ -42,6 +42,7 @@ module ExercismWeb
       use Rack::Flash
 
       helpers Helpers::NotificationCount # total hack
+      helpers Helpers::NotificationByLanguage
       helpers Helpers::FuzzyTime
       helpers Helpers::NgEsc
       helpers Helpers::Markdown

--- a/app/views/notifications/index.erb
+++ b/app/views/notifications/index.erb
@@ -56,71 +56,81 @@
           <% end %>
         </ul>
       <% end %>
+      <% notification_hash = Hash.new([]) %>
+      <% inbox.notifications.each do |notification| %>
+        <% if notification_hash[notification.iteration.problem.language].empty? %>
+          <% notification_hash[notification.iteration.problem.language] = [notification] %>
+        <% else %>
+          <% notification_hash[notification.iteration.problem.language] << notification %>
+        <% end %>
+      <% end %>
+      <% notification_hash.each do | lang, notifications | %>
+        <h3><%= lang %></h3>
+        <ul style="list-style-type: none; margin: 0;">
+          <% notifications.each do | notification | %>
+            <li class="alert-row">
+              <span style="padding-right: 15px;" class="fa fa-<%= notification.icon %>"></span>
 
-      <ul style="list-style-type: none; margin: 0;">
-        <% inbox.notifications.each do |notification| %>
-          <li class="alert-row">
-            <span style="padding-right: 15px;" class="fa fa-<%= notification.icon %>"></span>
+              <% if notification.action == 'like' %>
+                <a href="/<%= notification.actor.username %>">
+                  <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
+                  <%= notification.actor.username %>
+                </a>
+                liked your
+                <a href="<%= notification.url %>">
+                  <%= notification.iteration.problem.name %> in <%= notification.iteration.problem.language %>
+                </a>
+              <% end %>
 
-            <% if notification.action == 'like' %>
-              <a href="/<%= notification.actor.username %>">
+              <% if notification.action == 'mention' %>
                 <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
                 <%= notification.actor.username %>
-              </a>
-              liked your
-              <a href="<%= notification.url %>">
-                <%= notification.iteration.problem.name %> in <%= notification.iteration.problem.language %>
-              </a>
-            <% end %>
+                mentioned you
+                <%= ago(notification.created_at) %>
 
-            <% if notification.action == 'mention' %>
-              <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
-              <%= notification.actor.username %>
-              mentioned you
-              <%= ago(notification.created_at) %>
+                &middot;
 
-              &middot;
+                <%= notification.whose %>
+                <a href="<%= notification.url %>">
+                  <%= notification.iteration.problem.name %> in <%= notification.iteration.problem.language %>
+                </a>
+              <% end %>
 
-              <%= notification.whose %>
-              <a href="<%= notification.url %>">
-                <%= notification.iteration.problem.name %> in <%= notification.iteration.problem.language %>
-              </a>
-            <% end %>
+              <% if notification.action == 'comment' %>
+                <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
+                <%= notification.actor.username %>
+                commented
+                <%= ago(notification.created_at) %>
 
-            <% if notification.action == 'comment' %>
-              <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
-              <%= notification.actor.username %>
-              commented
-              <%= ago(notification.created_at) %>
+                &middot;
 
-              &middot;
+                <%= notification.whose %>
+                <a href="<%= notification.url %>">
+                  <%= notification.iteration.problem.name %> in <%= notification.iteration.problem.language %>
+                  (#<%= notification.iteration.version %>)
+                </a>
+              <% end %>
 
-              <%= notification.whose %>
-              <a href="<%= notification.url %>">
-                <%= notification.iteration.problem.name %> in <%= notification.iteration.problem.language %>
-                (#<%= notification.iteration.version %>)
-              </a>
-            <% end %>
+              <% if notification.action == 'iteration' %>
+                <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
+                <%= notification.actor.username %>
+                submitted
+                <a href="<%= notification.url %>">
+                  <%= notification.iteration.problem.name %>
+                  in
+                  <%= notification.iteration.problem.language %>
+                  (#<%= notification.iteration.version %>)
+                </a>
+                <%= ago(notification.created_at) %>
+              <% end %>
 
-            <% if notification.action == 'iteration' %>
-              <%= gravatar_tag notification.actor.avatar_url, size: 20 %>
-              <%= notification.actor.username %>
-              submitted
-              <a href="<%= notification.url %>">
-                <%= notification.iteration.problem.name %>
-                in
-                <%= notification.iteration.problem.language %>
-                (#<%= notification.iteration.version %>)
-              </a>
-              <%= ago(notification.created_at) %>
-            <% end %>
-
-            <span style="float: right;">
-              <%= track_icon(notification.iteration.track_id, 20) %>
-            </span>
-          </li>
-        <% end %>
-      </ul>
+              <span style="float: right;">
+                <%= track_icon(notification.iteration.track_id, 20) %>
+              </span>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
     </div>
    <% if inbox.has_notifications? %>
      <div class="col-xs-4 text-center">

--- a/app/views/notifications/index.erb
+++ b/app/views/notifications/index.erb
@@ -56,15 +56,7 @@
           <% end %>
         </ul>
       <% end %>
-      <% notification_hash = Hash.new([]) %>
-      <% inbox.notifications.each do |notification| %>
-        <% if notification_hash[notification.iteration.problem.language].empty? %>
-          <% notification_hash[notification.iteration.problem.language] = [notification] %>
-        <% else %>
-          <% notification_hash[notification.iteration.problem.language] << notification %>
-        <% end %>
-      <% end %>
-      <% notification_hash.each do | lang, notifications | %>
+      <% notification_by_language(inbox.notifications).each do | lang, notifications | %>
         <h3><%= lang %></h3>
         <ul style="list-style-type: none; margin: 0;">
           <% notifications.each do | notification | %>

--- a/test/app/helpers/notification_by_language_test.rb
+++ b/test/app/helpers/notification_by_language_test.rb
@@ -6,9 +6,9 @@ class AppHelpersNotificationByLanguageTest < Minitest::Test
 
   def setup
     super
-    @alice      = User.create(username: 'alice', email: 'alice@example.com')
-    @fred       = User.create(username: 'fred', email: 'fred@example.com')
-    @submission = Submission.create(user: @alice)
+    @kara      = User.create(username: 'kara', email: 'kara@example.com')
+    @oliver       = User.create(username: 'oliver', email: 'oliver@example.com')
+    @submission = Submission.create(user: @kara)
   end
 
   def helper
@@ -24,13 +24,9 @@ class AppHelpersNotificationByLanguageTest < Minitest::Test
   end
 
   def test_notification_by_language_many
-    langs = ['ruby', 'clojure', 'javascript']
-    actions = ['comment', 'iteration', 'mention', 'like']
-    10.times do |i|
-      submission = Submission.create(language: langs[i%3], slug: "Test #{i}", user: @alice)
-      Notification.on(submission, user_id: @fred.id, action: actions[i%4], actor_id: @alice.id)
-    end
-    assert_equal 4, helper.notification_by_language(@fred.notifications)['Ruby'].count
+    submission = Submission.create(language: 'animal', slug: "rainbow", user: @kara)
+    Notification.on(submission, user_id: @oliver.id, action: 'iteration', actor_id: @kara.id)
+    assert_equal 1, helper.notification_by_language(@oliver.notifications)['Animal'].count
   end
 
 end

--- a/test/app/helpers/notification_by_language_test.rb
+++ b/test/app/helpers/notification_by_language_test.rb
@@ -1,0 +1,36 @@
+require_relative '../../integration_helper'
+require_relative '../../../app/helpers/notification_by_language'
+
+class AppHelpersNotificationByLanguageTest < Minitest::Test
+  include DBCleaner
+
+  def setup
+    super
+    @alice      = User.create(username: 'alice', email: 'alice@example.com')
+    @fred       = User.create(username: 'fred', email: 'fred@example.com')
+    @submission = Submission.create(user: @alice)
+  end
+
+  def helper
+    return @helper if @helper
+    @helper = Object.new
+    @helper.extend(ExercismWeb::Helpers::NotificationByLanguage)
+    @helper
+  end
+
+  def test_notification_by_language_empty
+    empty_hash = Hash.new([])
+    assert_equal empty_hash, helper.notification_by_language([])
+  end
+
+  def test_notification_by_language_many
+    langs = ['ruby', 'clojure', 'javascript']
+    actions = ['comment', 'iteration', 'mention', 'like']
+    10.times do |i|
+      submission = Submission.create(language: langs[i%3], slug: "Test #{i}", user: @alice)
+      Notification.on(submission, user_id: @fred.id, action: actions[i%4], actor_id: @alice.id)
+    end
+    assert_equal 4, helper.notification_by_language(@fred.notifications)['Ruby'].count
+  end
+
+end


### PR DESCRIPTION
The bulk of this is whitespace changes with the bulk of the actual changes in lines 59-70.

In the seed data, I noticed that a lot of the notifications had the "code" action. Since "code" actions are not displayed in notifications, I'm assuming those have been removed from production. If not, I can make a change as this will display a bit strangly (86 mentions, but all are code gives you blank lines with icons).
