### PR TITLE
Add a description of teams on the account page

### DIFF
--- a/app/views/account/show.erb
+++ b/app/views/account/show.erb
@@ -33,6 +33,7 @@
     <hr>
 
     <h3>Teams</h3>
+    <p>By setting up a team you will be able to view a separate activity stream for your team members' submissions.</p>
     <% if profile.has_teams? %>
       <ul class="nav nav-stacked nav-bordered" style="max-width: 400px">
         <% profile.teams.each do |team| %>


### PR DESCRIPTION
This adds a description of teams to the account page about the team details which follows in line with the other descriptions on this page. This should address #1673 and uses the description provided by @mandel01. 

If we want to also add information about teams to the help that can be done also. 
