### PR TITLE
db.rake & test.rake should not do code outside task context

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,8 +1,6 @@
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-  require 'bundler'
-  Bundler.require
   t.test_files = FileList['test/**/*_test.rb'].exclude('test/fixtures/**/*')
 end
 


### PR DESCRIPTION
There is code that is executed regardless the task you are mean to execute, for examples, if you try to do rubocop, it will always try to connect... 
This also will get some improvement on how much time it takes to run a task:

``` sh
# before
$ time rake rubocop
Running RuboCop...
Inspecting 212 files
....................................................................................................................................................................................................................

212 files inspected, no offenses detected

real    0m10.431s
user    0m3.100s
sys     0m6.356s

# after
$time rake rubocop
Running RuboCop...
Inspecting 212 files
....................................................................................................................................................................................................................

212 files inspected, no offenses detected

real    0m4.797s
user    0m2.072s
sys     0m2.452s
```
