### PR TITLE
update links in cli overview.md

### DIFF
--- a/x/docs/md/cli/overview.md
+++ b/x/docs/md/cli/overview.md
@@ -5,5 +5,5 @@ Exercism takes place in two places: the discussions happen on the website, and y
 
 This is a stand-alone binary, which means that you don't need to install any particular language or environment in order to use it.
 
-Choose your operating system: [mac](/cli/mac) | [windows](/cli/windows) | [linux](/cli/linux)
+Choose your operating system: [mac](mac.md) | [windows](windows.md) | [linux](linux.md)
 


### PR DESCRIPTION
i was assuming that the links in this overview were supposed to refer to the respective OS documentation pages and that they were just outdated.
