### PR TITLE
Inbox redirect to activity stream about page

### DIFF
--- a/app/routes/inbox.rb
+++ b/app/routes/inbox.rb
@@ -5,7 +5,11 @@ module ExercismWeb
         please_login
 
         session[:inbox] ||= ACL.select('DISTINCT language').where(user_id: current_user.id).order(:language).map(&:language).first
-        redirect ['', 'tracks', session[:inbox], 'exercises', session[:inbox_slug]].compact.join('/')
+        if session[:inbox]
+          redirect ['', 'tracks', session[:inbox], 'exercises', session[:inbox_slug]].compact.join('/')
+        else
+          erb :"stream/_about"
+        end
       end
     end
   end

--- a/app/views/stream/_about.erb
+++ b/app/views/stream/_about.erb
@@ -1,5 +1,25 @@
-<main id="track-exercises" class="col-md-8">
+<div class="container about">
+  <section class="page-header">
+    <h1>Activity streams</h1>
+  </section>
 
-  <h2>About streams</h2>
+  <section class="main">
+    <article class="article-block">
+      <div class="article-contents">
+        <h4 class="header">How it works</h4>
+        <p> Activity Streams show you how other people approach to the problems. </p>
+        <p> When you have submitted a solution to at least one exercise, then the stream starts getting filled with the solutions that other people have submitted to the same exercise.</p>
+        <p> It will differentiate your submissions from the others by <a href="http://exercism.io/languages">langauge track</a> </p>
+        <p> You will be able to view and comment on others' submissions <p>
+      </div>
+    </article>
+    <hr>
+    <article class="article-block">
+      <div class="article-contents">
+        <h4 class="header">Track Mentor</h4>
+        <p>Want to be a Track Mentor? Working on exercises and giving great feedback is the best way to get noticed!</p>
+      </div>
+    </article>
 
-</main>
+  </section>
+</div>

--- a/app/views/stream/_about.erb
+++ b/app/views/stream/_about.erb
@@ -1,0 +1,5 @@
+<main id="track-exercises" class="col-md-8">
+
+  <h2>About streams</h2>
+
+</main>


### PR DESCRIPTION
This PR fixes https://github.com/exercism/exercism.io/issues/3153

I added an about page linked to the activity streams. 
![image](https://cloud.githubusercontent.com/assets/10900547/19839863/5de7a488-9ec0-11e6-8756-b96b2750c74f.png)
