### PR TITLE
show the activity streams even if the current user has not submitted any solutions

### DIFF
--- a/app/views/application/_navbar.erb
+++ b/app/views/application/_navbar.erb
@@ -22,10 +22,8 @@
       </ul>
 
       <ul class="nav navbar-nav navbar-right">
-          <% if !current_user.guest? %>
-            <% if current_user.sees_exercises? %>
-              <li><a href="/inbox">Activity Streams</a></li>
-            <% end %>
+        <% if !current_user.guest? %>
+          <li><a href="/inbox">Activity Streams</a></li>
           <%= erb :"application/nav/notifications" %>
           <%= erb :"application/nav/account" %>
         <% else %>

--- a/app/views/application/_navbar.erb
+++ b/app/views/application/_navbar.erb
@@ -22,7 +22,7 @@
       </ul>
 
       <ul class="nav navbar-nav navbar-right">
-        <% if !current_user.guest? %>
+        <% unless current_user.guest? %>
           <li><a href="/inbox">Activity Streams</a></li>
           <%= erb :"application/nav/notifications" %>
           <%= erb :"application/nav/account" %>


### PR DESCRIPTION
This PR fixes https://github.com/exercism/exercism.io/issues/3220.

We have a check of the user's submissions before we show the activity streams page. I removed the check
