### PR TITLE
Generate sourcemaps for js and css

### DIFF
--- a/frontend/config/application.coffee
+++ b/frontend/config/application.coffee
@@ -33,8 +33,8 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
 
   copy:
     dev:
-      files: [expand: true, cwd: 'generated', src: ['css/**', 'js/**', '!**/spec.js', 
-              '!**/*.less*', '!**/*.coffee*', '!**/*.*.map'], dest: '../public' ]
+      files: [expand: true, cwd: 'generated', src: ['css/**', 'js/**', '!**/spec.js',
+              '!**/*.less*', '!**/*.coffee*', '!**/spec.js.map'], dest: '../public' ]
 
   # configuration for grunt-ngmin, this happens _after_ concat once, which is the ngmin ideal :)
   ngmin: {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "grunt": "~0.4.1",
+    "grunt-concat-sourcemap": "^0.4.3",
     "grunt-ngmin": "~0.0.2",
     "lineman": ">=0.11.1"
   },


### PR DESCRIPTION
Lineman defaults to [grunt-concat-sourcemap](https://github.com/kozy4324/grunt-concat-sourcemap) for generating sourcemaps. Added it to `package.json` and copied generated sourcemaps to `/public`.

Issue #3199

PS: [grunt-concat-sourcemap](https://github.com/kozy4324/grunt-concat-sourcemap) is deprecated but lineman uses it as default for generating sourcemaps, hence using with the same.