### PR TITLE
Add documentation about contributing to tracks

### DIFF
--- a/docs/fixing-exercise-readmes.md
+++ b/docs/fixing-exercise-readmes.md
@@ -1,0 +1,22 @@
+# Fixing Exercise READMEs
+
+[x-common]: http://github.com/exercism/x-common/tree/master/exercises
+[trackler]: https://github.com/exercism/trackler
+[trackler-readme]: https://github.com/exercism/trackler/blob/master/lib/trackler/implementation.rb#L40-L42
+
+READMEs are automatically generated in the [trackler][] gem, which is a
+light-weight wrapper around all of the exercise data for all of the Exercism
+tracks.
+
+The README is assembled from:
+
+* The basic description (found in the `description.md` in the directory named after the exercise's slug in [x-common][])
+* The generic metadata (found in the `metadata.yml`, also in [x-common][])
+* The track-wide hints file (found in the root of the language track repository.
+  The file is named `SETUP.md`)
+* The exercise-specific hints file (found in the track repository, within the
+  directory containing the exercise implementation. The file is named
+  `HINTS.md`)
+
+In addition, there's some hard-coded, generic stuff that lives in the
+[file that assembles the README][trackler-readme] within the trackler gem.

--- a/docs/getting-involved-in-a-track.md
+++ b/docs/getting-involved-in-a-track.md
@@ -1,0 +1,100 @@
+# Getting Involved in an Exercism Language Track
+
+[repositories]: http://exercism.io/repositories
+[triaging-issues]: /docs/triaging-issues-in-a-track.md
+[reviewing-prs]: /docs/reviewing-a-pull-request.md
+[porting]: /docs/porting-an-exercise.md
+[xcommon]: http://github.com/exercism/x-common
+[blazon]: /docs/improving-consistency-across-tracks.md
+
+The Exercism language tracks are a great way to get involved in:
+
+- a programming language you love
+- a programming language you're curious about
+- open source (in general)
+
+Each language track lives in its own repository, which means that you can contribute
+to a track without having to know anything about the rest of the Exercism ecosystem.
+
+Also, each track is focused, containing implementations of trivial exercises and the tools
+to make development easier, so there's no big codebase to get acquainted with.
+
+## Submit a Couple of Solutions
+
+If you haven't used Exercism before, then we recommend submitting solutions to a couple of
+exercises. It doesn't matter which language track you submit to, it's just to get a feel
+for what a language track consists of.
+
+## Watch The Track Repository
+
+If you haven't picked a language you want to contribute to yet, check out the list of [language tracks
+and their respective repositories][repositories].
+
+Then go to the repository for the language you've chosen, click the _Watch_ button, and select _Watching_.
+This will notify you of any new issues, pull requests, or comments in the repository, which is a great way
+of getting acquainted with the people involved and the issues that tend to come up.
+
+## Orient Yourself
+
+Read the README, and look through the open issues and pull requests, and get a feel for what's going on.
+
+## Contribute!
+
+There are a number of ways to contribute to a track. All of them are sorely needed, and greatly appreciated!
+
+### Triaging Issues
+
+A great issue is detailed and actionable. When they're not, you can help ask the questions to make them so.
+
+For more detailed suggestions about things to keep in mind when triaging, check out [this documentation][triaging-issues].
+
+### Reviewing Pull Requests
+
+We always need more eyeballs on pull requests. On language tracks most pull requests tend to be related to
+the exercises themselves, and we have [detailed documentation][reviewing-prs] that should help
+you get started with code reviews.
+
+### Porting an Exercise
+
+The easiest way to add a new exercise is to find an exercise that has already been implemented in another language
+track, and port it over to your target language.
+
+We've got [a guide][porting] that walks you through how to find an exercise to port, and the things to
+keep in mind when implementing it.
+
+### Reordering Exercises
+
+We don't really have a formal process for deciding what order exercises should be in. The order is decided by the
+order of the `exercises` array in the `config.json` file in the track repository.
+
+As you do the exercises in a track, keep an eye on how you feel about an exercise.
+
+* If it's **too easy**, move it higher up in the array.
+* If it's **too hard**, move it further down in the array.
+* If two exercises are **too similar** then move one of them so that there are some different exercises between them.
+
+We can also deprecate an exercise by removing it from the `exercises` array and adding the slug to the `deprecated` key,
+which is also in the `config.json` file.
+
+### Improving the Contributing Documentation
+
+It's not always obvious how to get started contributing to a language track. As you get involved, help improve the
+README in the track repository.
+
+* Are there undocumented dependencies?
+* How do you run the tests? Is there a way to run all the tests for all the exercises?
+* Are there any naming conventions for files or types or classes or functions?
+* Is there any tooling that we're using? Linters?
+* Is there continuous integration? Are there any gotchas?
+
+### Improving the Curriculum
+
+Sometimes people run into edge cases. If you're considering adding a new test, open a discussion in the [x-common][xcommon]
+repository and get other track implementors' feedback on whether this makes sense. It might make sense only for this track,
+or perhaps it would be an improvement to all the various language tracks that have this exercise. If so then we'll want to
+
+- hash out all the details together
+- add it to the canonical data for the exercise (if it exists)
+- submit an issue to all the tracks that implement the exercise
+
+We have a [tool and a process][blazon] for doing that.

--- a/docs/getting-involved-in-a-track.md
+++ b/docs/getting-involved-in-a-track.md
@@ -4,8 +4,10 @@
 [triaging-issues]: /docs/triaging-issues-in-a-track.md
 [reviewing-prs]: /docs/reviewing-a-pull-request.md
 [porting]: /docs/porting-an-exercise.md
-[xcommon]: http://github.com/exercism/x-common
-[blazon]: /docs/improving-consistency-across-tracks.md
+[x-common]: https://github.com/exercism/x-common
+[blazon]: https://github.com/exercism/blazon
+[blazon-process]: /docs/improving-consistency-across-tracks.md
+[fixing-readmes]: /docs/fixing-exercise-readmes.md
 
 The Exercism language tracks are a great way to get involved in:
 
@@ -62,20 +64,6 @@ track, and port it over to your target language.
 We've got [a guide][porting] that walks you through how to find an exercise to port, and the things to
 keep in mind when implementing it.
 
-### Reordering Exercises
-
-We don't really have a formal process for deciding what order exercises should be in. The order is decided by the
-order of the `exercises` array in the `config.json` file in the track repository.
-
-As you do the exercises in a track, keep an eye on how you feel about an exercise.
-
-* If it's **too easy**, move it higher up in the array.
-* If it's **too hard**, move it further down in the array.
-* If two exercises are **too similar** then move one of them so that there are some different exercises between them.
-
-We can also deprecate an exercise by removing it from the `exercises` array and adding the slug to the `deprecated` key,
-which is also in the `config.json` file.
-
 ### Improving the Contributing Documentation
 
 It's not always obvious how to get started contributing to a language track. As you get involved, help improve the
@@ -87,14 +75,75 @@ README in the track repository.
 * Is there any tooling that we're using? Linters?
 * Is there continuous integration? Are there any gotchas?
 
-### Improving the Curriculum
+## Improving the Curriculum
 
-Sometimes people run into edge cases. If you're considering adding a new test, open a discussion in the [x-common][xcommon]
-repository and get other track implementors' feedback on whether this makes sense. It might make sense only for this track,
-or perhaps it would be an improvement to all the various language tracks that have this exercise. If so then we'll want to
+As you solve exercises on the site, pay attention to what you like and dislike
+about the exercises.
+
+### Improving Exercise READMEs
+
+If the README is ambiguous or confusing, then there's almost certainly
+something we can do to clarify.
+
+Or maybe you found a typo (you wouldn't be the first).
+
+The READMEs are generated, and all the details are explained [here][fixing-readmes].
+
+### Changing Exercise Test Suites
+
+* Did the test suite force you towards a certain solution? (It shouldn't.)
+* Did you come across a solution that passed the tests, but that had a bug?
+  (Maybe we're missing a test case.)
+
+The test suite is straight forward to find: look in the `exercises`
+directory in the language track repository for the directory named after the
+slug of the exercise. The test file will be right there.
+
+That said, some test suites are generated based on the `canonical-data.json`
+file found in [x-common][]. The README for the language track repository
+should tell you what you need to know.
+
+For every change that you make to the test suite, ask yourself: **Should this
+change also affect other language tracks that implement the same exercise?**
+
+If you think it might, open a discussion in the [x-common][] repository and get
+other track implementors' feedback on the subject.
+
+If this change should affect the broader Exercism curriculum, then use the
+issue in x-common to
 
 - hash out all the details together
-- add it to the canonical data for the exercise (if it exists)
-- submit an issue to all the tracks that implement the exercise
+- figure out the necessary changes to the `canonical-data.json` for the
+  exercise (if it exists)
+- draft an issue that can be submitted to all the tracks that implement the
+  exercise using the [blazon][] tool (which automates the tedious parts).
+  More about that [here][blazon-process].
 
-We have a [tool and a process][blazon] for doing that.
+### Reordering Exercises
+
+We don't have a formal process for deciding how the exercises should be
+ordered, and often as we add more exercises, we get some less-than-optimal
+sequences of exercises.
+
+As you work through the exercises in the track, notice whether an exercise
+seems vastly more difficult than the previous one, or much easier, or boring.
+
+The order is decided by the `exercises` array in `config.json`.
+
+* If it's **too easy**, move it higher up in the array.
+* If it's **too hard**, move it further down in the array.
+* If two exercises are **too similar** then move one of them so that there are
+  some different exercises between them.
+
+We can also deprecate an exercise by removing it from the `exercises` array
+and adding the slug to the `deprecated` key, which is also in the
+`config.json` file.
+
+### Adding Hints
+
+Sometimes an exercise is in the right place in the sequence, but it's really
+hard to figure out how to solve it anyway.
+
+In this case consider whether there's a blog post or some documentation that
+you could point people to, and add it to `HINTS.md` in the exercise directory
+in the language track. If the file doesn't exist, create a new one.

--- a/docs/improving-consistency-across-tracks.md
+++ b/docs/improving-consistency-across-tracks.md
@@ -1,8 +1,7 @@
 # Improving Consistency Across Tracks
 
 [blazon]: https://github.com/exercism/blazon
-[xcommon]: https://github.com/exercism/x-common/tree/master/exercises
-[xcommon-issue]: http://github.com/exercism/x-common/issues
+[x-common]: https://github.com/exercism/x-common/tree/master/exercises
 
 ## Canonical Data
 
@@ -18,7 +17,7 @@ We want to avoid
 
 Once we've found a good set of tests, we formalize the inputs and outputs and
 store it in a file called `canonical-data.json` alongside the language-agnostic
-problem description in the [x-common][xcommon] repository.
+problem description in the [x-common][] repository.
 
 Some things vary from language to language, so don't feel constrained to
 implementing exactly what is in the `canonical-data.json` file.

--- a/docs/improving-consistency-across-tracks.md
+++ b/docs/improving-consistency-across-tracks.md
@@ -1,0 +1,74 @@
+# Improving Consistency Across Tracks
+
+[blazon]: https://github.com/exercism/blazon
+[xcommon]: https://github.com/exercism/x-common/tree/master/exercises
+[xcommon-issue]: http://github.com/exercism/x-common/issues
+
+## Canonical Data
+
+Each exercise has a generic, language-agnostic problem description, which
+can then be implemented in any of the Exercism language tracks.
+
+A great test suite will help people solve the problem gradually.
+
+We want to avoid
+
+* too much redundancy
+* steps that are too big
+
+Once we've found a good set of tests, we formalize the inputs and outputs and
+store it in a file called `canonical-data.json` alongside the language-agnostic
+problem description in the [x-common][xcommon] repository.
+
+Some things vary from language to language, so don't feel constrained to
+implementing exactly what is in the `canonical-data.json` file.
+
+## Evolving Exercises
+
+Over time we find that the problem definitions can be improved in various ways.
+
+When they do, we need to notify all of the tracks that have an implementation
+of that problem so that they can update it.
+
+We've built some tooling for this, [blazon][blazon], to make it easier to manage.
+
+The process goes like this:
+
+**Open an issue** in the x-common repository describing the problem, the fix,
+and the reasoning behind it. Link to any relevant discussions. This is the _parent
+issue_.
+
+In the comment of the issue, **draft the body of an issue** which will be
+submitted to each of the language tracks that have implemented this problem.
+
+This should contain:
+
+- a description of the edge case or change
+- explicit instructions about what change to make
+- a note saying "if this isn't relevant in this language track, close the
+  issue"
+- a link to the canonical data (if it exists)
+- a link to the parent issue.
+
+Linking back to the parent issue is important for two reasons:
+
+1. It provides context. If someone wants to know more about the issue,
+   they can follow links to read the history.
+2. It will show a _living TODO list_. The parent issue will have a list
+   of links to the open issues, showing whether the issue is open or
+   closed. Once all of the child issues are closed, then we can
+   close the parent issue.
+
+It's worth drafting this in a comment because other people will often weigh in
+to help make it as clear as possible, or add any missing context, and it's
+easier to fix this _before_ it get submitted to a bajillion different repos.
+
+**Create a text file** containing the issue template that you drafted.
+
+The first line of the file will be used as the issue title. Make it
+descriptive. It should contain the slug of the relevant exercise.
+
+**Download [blazon][blazon]** and use it to submit the issue.
+
+    $ blazon -exercise=<slug> -file=<filename>
+

--- a/docs/maintaining-a-track.md
+++ b/docs/maintaining-a-track.md
@@ -87,4 +87,4 @@ In addition to the language track repository itself, you may also want to watch:
 ### Perform Common Tasks
 
 - Triage issues [TODO: link to documentation]
-- Review pull requests [TODO: link to documentation]
+- [Review pull requests](/docs/reviewing-a-pull-request.md)

--- a/docs/porting-an-exercise.md
+++ b/docs/porting-an-exercise.md
@@ -1,13 +1,13 @@
 # Porting an Exercise to Another Language Track
 
-[xcommon]: http://github.com/exercism/x-common/tree/master/exercises
+[x-common]: http://github.com/exercism/x-common/tree/master/exercises
 [support-chat]: https://gitter.im/exercism/support
 [topics]: https://github.com/exercism/x-common/blob/master/TOPICS.txt
 [configlet]: https://github.com/exercism/configlet#configlet
 
 Exercism has a lot of exercises in a lot of languages.
 
-Each exercise is defined in a language-agnostic way in the [x-common][xcommon]
+Each exercise is defined in a language-agnostic way in the [x-common][]
 repository, and then each individual language track can create an implementation
 of that exercise.
 
@@ -66,7 +66,7 @@ master, which will make the WIP commit go away.
 You'll need to find the `slug` for the exercise. That's the URL-friendly identifier
 for an exercise that is used throughout all of Exercism.
 
-**The name of the exercise directory in the [x-common][xcommon] repository is the slug.**
+**The name of the exercise directory in the [x-common][] repository is the slug.**
 
 Create a new directory named after the slug in the `exercises` directory of the language
 track repository.

--- a/docs/porting-an-exercise.md
+++ b/docs/porting-an-exercise.md
@@ -1,0 +1,136 @@
+# Porting an Exercise to Another Language Track
+
+[xcommon]: http://github.com/exercism/x-common/tree/master/exercises
+[support-chat]: https://gitter.im/exercism/support
+[topics]: https://github.com/exercism/x-common/blob/master/TOPICS.txt
+[configlet]: https://github.com/exercism/configlet#configlet
+
+Exercism has a lot of exercises in a lot of languages.
+
+Each exercise is defined in a language-agnostic way in the [x-common][xcommon]
+repository, and then each individual language track can create an implementation
+of that exercise.
+
+    /exercises/$SLUG/
+    ├── canonical-data.json (OPTIONAL)
+    ├── description.md
+    └── metadata.yml
+
+The shared data will always have a `description.md` file which contains the basic
+problem specification, and which later gets used to generate the README for the
+exercises.
+
+The `metadata.yml` contains a summary (or "blurb") of the exercise, as well as
+attribution and some other handy things that get used in various places.
+
+For some exercises we have defined a `canonical-data.json` file. If this exists
+then you won't need to go look at implementations in other languages. This will
+contain the implementation notes and test inputs and outputs that you'll need
+to create a test suite in your target language.
+
+## Finding an Exercise to Port
+
+Navigate to the language track on Exercism via the [http://exercism.io/languages][] page.
+
+The last item in the sidebar will be about contributing. Go to that.
+
+This is a full list of every exercise that exists, but has not yet been implemented
+in that language track.
+
+For every exercise it will link to:
+
+- the generic README
+- the canonical data (if it exists)
+- all the individual language implementations
+
+## Avoiding Duplicate Work
+
+When you decide to implement an exercise, first check that there are no open pull requests
+for the same exercise.
+
+Then open a "work in progress" (WIP) pull request, so others will see that you're working on it.
+
+The way to open a WIP pull request even if you haven't done any work yet is:
+
+* Fork and clone the repository
+* Check out a branch for your the exercise
+* Add an empty commit `git commit --allow-empty -m "Implement exercise <slug>"`
+  (replace <slug> with the actual name of the exercise).
+* Push the new branch to your repository, and open a pull request against that branch.
+
+Once you have added the actual exercise, then you can rebase your branch onto the upstream
+master, which will make the WIP commit go away.
+
+## Implementing the Exercise
+
+You'll need to find the `slug` for the exercise. That's the URL-friendly identifier
+for an exercise that is used throughout all of Exercism.
+
+**The name of the exercise directory in the [x-common][xcommon] repository is the slug.**
+
+Create a new directory named after the slug in the `exercises` directory of the language
+track repository.
+
+The exercise should consist of, at minimum:
+
+* A test suite
+* A reference solution that passes the tests
+
+Each language track might have additional requirements; check the README in
+the repository for the track.
+
+### The Test Suite
+
+Look at the other exercises in the track to get an idea of
+
+* the conventions used
+* how to name the test file
+
+### The Reference Solution
+
+The reference solution is named something with `example` or `Example` in the path.
+
+Again, check the other exercises to see what the naming pattern is.
+
+The solution does not need to be particularly great code, it is only used to verify
+that the exercise is coherent.
+
+### Configuring the Exercise
+
+Add a new entry in the `exercises` key in the `config.json` file in the root of the repository.
+
+Add the slug, estimate the difficulty level. Topics are optional, but can be really helpful.
+
+
+    {
+      "slug": <slug>,
+      "difficulty": <a number from 1 to 10>,
+      "topics": [ ]
+    }
+
+Take a look at the (non-exhaustive) [topics list][topics] and see if any of these make sense.
+
+We have a tool, [configlet][configlet] that will help make sure that everything is configured right.
+Download that and run it against the track repository.
+
+### Submitting a Pull Request
+
+Rebase against the most recent upstream master, and submit a pull request.
+
+If you have questions your best bet is the [support chat][support-chat]. Once you
+figure it out, if you could help improve this documentation, that would be great!
+
+### Providing Feedback on the Site for an Exercise You Implemented
+
+Once you've created an exercise, you'll probably want to provide feedback to people who
+submit solutions to it. By default you only get access to exercises you've submitted
+a solution for.
+
+You can fetch the problem using the CLI:
+
+```bash
+$ exercism fetch <track_id> <slug>
+```
+
+Go ahead submit the reference solution that you wrote when creating the problem.
+Remember to archive it if you don't want other people to comment on it.

--- a/docs/triaging-issues-in-a-track.md
+++ b/docs/triaging-issues-in-a-track.md
@@ -1,0 +1,33 @@
+# Triaging Issues in an Exercism Language Track
+
+Issues need to be unambiguous and actionable. If it's hard to figure out what
+an issue is about, or what to do about it, then the issue probably won't get
+fixed.
+
+## Making Issues Great
+
+The goal of triaging issues is to make sure that each issue is actionable.
+
+I great issue also has enough context that it could be tackled by someone who has never contributed
+to Exercism before.
+
+When reading an issue you should be able to answer questions like...
+
+* What is the problem?
+* Why is this a problem?
+* Who might run into it? Everyone? Or is it an edge case?
+* What needs to be done? How will we know that the issue can be closed?
+  Is there something we need to figure out or decide before it can be fixed?
+* Where in the code will the fix go? This might be obvious, but it might not be. If we can point
+  to the right directory or file, that helps.
+
+If the issue isn't great yet, then the best help you can provide is to ask clarifying questions to help
+make it great.
+
+## Still Relevant?
+
+Along the way you might run into issues that have already been resolved (we just forgot to close it), or
+that just aren't relevant any more, because the world has moved on.
+
+If you see one of these, then add a comment suggesting that we close it, with a note about why it can be
+closed.

--- a/docs/triaging-issues-in-a-track.md
+++ b/docs/triaging-issues-in-a-track.md
@@ -1,14 +1,14 @@
 # Triaging Issues in an Exercism Language Track
 
 Issues need to be unambiguous and actionable. If it's hard to figure out what
-an issue is about, or what to do about it, then the issue probably won't get
+an issue is about, or what needs to be done, then the issue probably won't get
 fixed.
 
 ## Making Issues Great
 
 The goal of triaging issues is to make sure that each issue is actionable.
 
-I great issue also has enough context that it could be tackled by someone who has never contributed
+A great issue also has enough context that it could be tackled by someone who has never contributed
 to Exercism before.
 
 When reading an issue you should be able to answer questions like...


### PR DESCRIPTION
@exercism/track-maintainers I've been working on documenting more of the work that's involved in contributing to a language track. I think that if we can get this properly documented, we can do a bit more around explicitly trying to find more people to contribute (and eventually to maintain) the tracks.

I'd love feedback about anything that catches your eye. Clarity, missing topics, correctness, whatever it is.

View the rendered files:

- [getting involved in a track](https://github.com/exercism/exercism.io/blob/language-track-docs/docs/getting-involved-in-a-track.md)
- [triaging issues](https://github.com/exercism/exercism.io/blob/language-track-docs/docs/triaging-issues-in-a-track.md)
- [improving consistency across tracks](https://github.com/exercism/exercism.io/blob/language-track-docs/docs/improving-consistency-across-tracks.md)
- [porting an exercise to another track](https://github.com/exercism/exercism.io/blob/language-track-docs/docs/porting-an-exercise.md)

