### PR TITLE
Rework rake tasks to remove Bundle.require

### DIFF
--- a/lib/tasks/connection.rake
+++ b/lib/tasks/connection.rake
@@ -1,0 +1,5 @@
+task :connection do
+  require 'active_record'
+  require 'db/connection'
+  DB::Connection.establish
+end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -16,10 +16,8 @@ namespace :data do
 
     desc "fix broken iterations with missing language"
     task missing_language: [:connection] do
-      require 'exercism/submission'
-      require 'exercism/user_exercise'
-      require 'exercism/user'
-      require 'exercism/acl'
+      # Submission#before_create requires Exercism.uuid
+      require 'exercism'
 
       Submission.where(language: '').find_each do |submission|
         submission.language = submission.slug

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,12 +1,7 @@
 namespace :data do
   namespace :cleanup do
     desc "normalize action names"
-    task :notifications do
-      require 'active_record'
-      require 'db/connection'
-
-      DB::Connection.establish
-
+    task notifications: [:connection] do
       sql = <<-SQL
       UPDATE notifications
       SET action=(CASE
@@ -20,14 +15,11 @@ namespace :data do
     end
 
     desc "fix broken iterations with missing language"
-    task :missing_language do
-      require 'active_record'
-      require 'db/connection'
-      require './lib/exercism/submission'
-      require './lib/exercism/user_exercise'
-      require './lib/exercism/user'
-      require './lib/exercism/acl'
-      DB::Connection.establish
+    task missing_language: [:connection] do
+      require 'exercism/submission'
+      require 'exercism/user_exercise'
+      require 'exercism/user'
+      require 'exercism/acl'
 
       Submission.where(language: '').find_each do |submission|
         submission.language = submission.slug
@@ -67,10 +59,7 @@ namespace :data do
     end
 
     desc "fix iteration count"
-    task :iteration_counts do
-      require 'active_record'
-      require 'db/connection'
-      DB::Connection.establish
+    task iteration_counts: [:connection] do
 
       # update the count for all exercises with submissions
       sql = <<-SQL
@@ -102,11 +91,7 @@ namespace :data do
     end
 
     desc "delete orphan comments"
-    task :comments do
-      require 'active_record'
-      require 'db/connection'
-
-      DB::Connection.establish
+    task comments: [:connection] do
 
       sql = <<-SQL
       DELETE FROM comments WHERE id IN (
@@ -123,11 +108,7 @@ namespace :data do
 
   namespace :migrate do
     desc "migrate subscriptions"
-    task :subscriptions do
-      require 'active_record'
-      require 'db/connection'
-
-      DB::Connection.establish
+    task subscriptions: [:connection] do
 
       # CAN ONLY BE USED PRIOR TO EXPOSING SUBSCRIBE/UNSUBSCRIBE IN UI.
 
@@ -166,11 +147,7 @@ namespace :data do
     end
 
     desc "migrate last iteration timestamps"
-    task :last_iteration do
-      require 'active_record'
-      require 'db/connection'
-
-      DB::Connection.establish
+    task last_iteration: [:connection] do
 
       sql = <<-SQL
       UPDATE user_exercises ex SET last_iteration_at=t.ts
@@ -185,11 +162,7 @@ namespace :data do
     end
 
     desc "reset last activity timestamps and descriptions"
-    task :last_activity do
-      require 'active_record'
-      require 'db/connection'
-      require './lib/exercism'
-      DB::Connection.establish
+    task last_activity: [:connection] do
 
       # Reset all exercises to have "last activity" be the submission.
       sql = <<-SQL
@@ -238,15 +211,12 @@ namespace :data do
     end
 
     desc "migrate acls"
-    task :acls do
-      require 'active_record'
-      require 'db/connection'
-      require './lib/exercism/acl'
-      require './lib/exercism/named'
-      require './lib/exercism/problem'
-      require './lib/exercism/submission'
-      require './lib/exercism/user'
-      DB::Connection.establish
+    task acls: [:connection] do
+      require 'exercism/acl'
+      require 'exercism/named'
+      require 'exercism/problem'
+      require 'exercism/submission'
+      require 'exercism/user'
 
       Submission.find_each do |submission|
         if submission.user.present?
@@ -256,15 +226,12 @@ namespace :data do
     end
 
     desc "migrate mentor acls"
-    task :mentor_acls do
-      require 'active_record'
-      require 'db/connection'
-      require './lib/exercism/acl'
-      require './lib/exercism/named'
-      require './lib/exercism/problem'
-      require './lib/exercism/submission'
-      require './lib/exercism/user'
-      DB::Connection.establish
+    task mentor_acls: [:connection] do
+      require 'exercism/acl'
+      require 'exercism/named'
+      require 'exercism/problem'
+      require 'exercism/submission'
+      require 'exercism/user'
 
       User.where('track_mentor IS NOT NULL').where("track_mentor != '--- []\n'").find_each do |user|
         Submission.select('DISTINCT language, slug').where(language: user.track_mentor).each do |submission|
@@ -274,10 +241,7 @@ namespace :data do
     end
 
     desc "migrate unconfirmed memberships to membership_invites"
-    task :migrate_unconfirmed_memberships do
-      require 'active_record'
-      require 'db/connection'
-      DB::Connection.establish
+    task migrate_unconfirmed_memberships: [:connection] do
 
       sql = <<-SQL
         INSERT INTO team_membership_invites(team_id, user_id, inviter_id, created_at, updated_at)

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,28 +1,20 @@
 namespace :db do
-
-  require 'bundler'
   require 'English'
-  Bundler.require
-
-  require 'db/connection'
 
   desc "migrate your database"
-  task :migrate do
-    connect
+  task migrate: [:connection] do
     ActiveRecord::Migrator.migrate('./db/migrate')
   end
 
-  task :rollback do
-    connect
+  task rollback: [:connection] do
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
     ActiveRecord::Migrator.rollback('./db/migrate', step)
   end
 
   namespace :migrate do
-    task :down do
+    task down: [:connection] do
       version = ENV['VERSION'] ? ENV['VERSION'].to_i : nil
       fail 'VERSION is required - To go down one migration, run db:rollback' unless version
-      connect
       ActiveRecord::Migrator.run(:down, './db/migrate', version)
     end
   end
@@ -30,7 +22,7 @@ namespace :db do
   desc "set up your database"
   task :setup do
     require 'open3'
-
+    require 'db/connection'
     user = DB::Connection.escape(config.username)
     pass = DB::Connection.escape(config.password)
 
@@ -99,10 +91,7 @@ end
   end
 
   def config
+    require 'db/config'
     DB::Config.new
-  end
-
-  def connect
-    DB::Connection.establish
   end
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -1,7 +1,7 @@
 namespace :dev do
   namespace :seed do
     desc "insert a bunch of iterations for the given user"
-    task :iterations do
+    task iterations: [:connection] do
       username = ENV['username'] || ENV['USERNAME']
       if username.nil?
         $stderr.puts "Usage: rake dev:seed:iterations username=$USERNAME"
@@ -21,11 +21,7 @@ namespace :dev do
         FakeTrack.new("haskell", "hs", haskell, "-- code"),
       ]
 
-      require 'bundler'
-      Bundler.require
-      require './lib/exercism'
-      require './lib/db/connection'
-      DB::Connection.establish
+      require 'exercism'
 
       user = User.find_by_username(username)
 
@@ -42,19 +38,15 @@ namespace :dev do
     end
 
     desc "create a bunch of notifications"
-    task :notifications do
+    task notifications: [:connection] do
       username = ENV['username'] || ENV['USERNAME']
       if username.nil?
         $stderr.puts "Usage: rake dev:seed:notifications username=$USERNAME"
         exit 1
       end
-
-      require 'active_record'
-      require './lib/db/connection'
-      require './lib/exercism/notification'
-      require './lib/exercism/user'
-      require './lib/exercism/submission'
-      DB::Connection.establish
+      require 'exercism/notification'
+      require 'exercism/user'
+      require 'exercism/submission'
 
       user = User.find_by_username(username)
       actor_id = User.where("username <> '%s'" % user.username).limit(100).pluck(:id).sample.to_i

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -1,9 +1,6 @@
 namespace :emails do
   desc "reset known invalid values"
-  task :reset_invalid do
-    require 'active_record'
-    require 'db/connection'
-    DB::Connection.establish
+  task reset_invalid: [:connection] do
 
     sql = "UPDATE users SET email=NULL WHERE email=''"
     ActiveRecord::Base.connection.execute(sql)

--- a/lib/tasks/rikki.rake
+++ b/lib/tasks/rikki.rake
@@ -1,14 +1,11 @@
 namespace :rikki do
   desc "dump go stuff for experimentation"
-  task :dump do
+  task dump: [:connection] do
     class Submission < ActiveRecord::Base
       serialize :solution, JSON
     end
-
-    require 'active_record'
-    require 'db/connection'
     require 'fileutils'
-    DB::Connection.establish
+
     Submission.where(language: 'go').find_each do |submission|
       dir = File.join('.', 'rikki', submission.key)
       FileUtils.mkdir_p(dir)
@@ -23,12 +20,8 @@ namespace :rikki do
   end
 
   desc "comment on old go issues"
-  task :go do
-    require 'active_record'
-    require 'db/connection'
-    require './lib/jobs/analyze'
-    require './lib/exercism'
-    DB::Connection.establish
+  task go: [:connection] do
+    require 'jobs/analyze'
 
     # Select only:
     # - the most recent submission

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -1,6 +1,7 @@
 namespace :db do
   desc "Fetch seed data from github and save to db/seeds.sql"
   task "seeds:fetch", %s(debug) do |_, args|
+    require 'faraday'
     args.with_defaults(debug: ENV["DEBUG"])
     puts "fetching over the wire"
     conn = Faraday.new(url: "https://raw.githubusercontent.com") do |c|
@@ -20,15 +21,9 @@ namespace :db do
   desc "reset db and reseed data"
   task reseed: ["db:drop", "db:create", "db:migrate", "db:seed"]
 
-  task :connection do
-    require 'bundler'
-    Bundler.require
-    require 'exercism'
-    require_relative '../db/config'
-  end
-
   desc "generate seed data"
   task seed: [:connection] do
+    require_comments
     config = DB::Config.new
     # rubocop:disable Style/AlignParameters
     system({ 'PGPASSWORD' => config.password },
@@ -43,6 +38,7 @@ namespace :db do
 
   desc "generate seed data on Heroku"
   task heroku_seed: [:connection] do
+    require_comments
     if ENV['DATABASE_URL']
       system('psql', ENV['DATABASE_URL'], '-f', 'db/seeds.sql')
       # Trigger generation of html body
@@ -51,5 +47,10 @@ namespace :db do
       puts "No DATABASE_URL environment variable found. Did you add postgresql addon?"
       puts "If you're trying to run this task on your local machine, prefer the `db:seed` task instead"
     end
+  end
+
+  def require_comments
+    require 'exercism/converts_markdown_to_html'
+    require 'exercism/comment'
   end
 end

--- a/lib/tasks/views.rake
+++ b/lib/tasks/views.rake
@@ -1,10 +1,7 @@
 namespace :views do
   desc "delete all the views below the watermarks"
-  task :sweep do
-    require 'active_record'
-    require 'db/connection'
-    require './lib/exercism/view'
-    DB::Connection.establish
+  task sweep: [:connection] do
+    require 'exercism/view'
 
     View.delete_below_watermarks
     View.delete_obsolete

--- a/lib/tasks/xapi.rake
+++ b/lib/tasks/xapi.rake
@@ -1,8 +1,7 @@
 namespace :xapi do
   desc "seed database with test data for x-api acceptance tests"
-  task :seed do
-    require 'bundler'
-    Bundler.require
+  task seed: [:connection] do
+    # User, Submission and UserExercise require Exercism.uuid
     require 'exercism'
 
     user = User.find_by_key('abc123') || User.create(github_id: -1, key: 'abc123', username: 'xapi-test-user')


### PR DESCRIPTION
The goal of this PR is remove the use of Bundle.require on the rake task to minimize the required time to run any given task.

In order to achieve the goal was needed:

- Create a top-level rake task `connection` and make it required by other rake task that need connection to the database
- Remove the duplicated required and calls needed to create the connection
- Require 'manually' all the dependencies on gems and classes

Note: At some points I had to require `lib/exercism` which requires all the models, it needs to be done like that because some classes has dependency to `Exercism.uuid`.

Please comment on any issue.

P.S. I manually run every rake task with no errors, but some internal work (inside loops) may or may not be executed/processed because preconditions/data.