### PR TITLE
Change so that most recent exercises for a language show at the top.

### DIFF
--- a/app/views/user/_exercises_table.erb
+++ b/app/views/user/_exercises_table.erb
@@ -18,7 +18,7 @@
       <th>Language</th>
       <th>Exercise</th>
       <th>Iterations</th>
-      <th data-sorted="true" data-sorted-direction="descending">Latest Iteration</th>
+      <th data-sorted="true" data-sorted-direction="ascending">Latest Iteration</th>
       <th>Comments</th>
     </tr>
   </thead>


### PR DESCRIPTION
Change the default sort order to last to first completed.  This makes sure that the most likely information desired is the easiest to find at the top of the list.  This maintains the ability to sort from first to last completed.  This is the second half of issue: [exercise in progress sort order #3246](https://github.com/exercism/exercism.io/issues/3246)