### PR TITLE
Development: Give a helpful error message if css not generated.

### DIFF
--- a/app/helpers.rb
+++ b/app/helpers.rb
@@ -14,6 +14,7 @@ module ExercismWeb
       TrackImage: 'track_image',
       UserProgressBar: 'user_progress_bar',
       TeamAccess: 'team_access',
+      CssUrl: 'css_url',
     }.each do |name, file|
       autoload name, Exercism.relative_to_root('app', 'helpers', file)
     end

--- a/app/helpers/css_url.rb
+++ b/app/helpers/css_url.rb
@@ -1,0 +1,41 @@
+module ExercismWeb
+  module Helpers
+    # Returns the url for the current version of the application.css file
+    module CssUrl
+      def css_url
+        @css_url ||= url_for_resource('/css/application.css')
+      end
+
+      private
+
+      def url_for_resource(resource)
+        fail IOError.new not_found_message(resource) unless exist?(resource)
+        "#{resource}?t=#{timestamp(resource)}"
+      end
+
+      def not_found_message(resource)
+        css_filename = filename(resource)
+        command = "bundle exec compass compile"
+        url = 'https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md#scss'
+
+        <<-MESSAGE.gsub(/^ */, '')
+            '#{css_filename}' not found.
+            Try running '#{command}' to generate it.
+            For more information: #{url}
+            MESSAGE
+      end
+
+      def exist?(resource)
+        File.exist?(filename(resource))
+      end
+
+      def filename(resource)
+        File.join(settings.public_folder, resource)
+      end
+
+      def timestamp(resource)
+        File.mtime(filename(resource)).to_i
+      end
+    end
+  end
+end

--- a/app/routes/core.rb
+++ b/app/routes/core.rb
@@ -102,8 +102,26 @@ module ExercismWeb
         end
 
         def css_url
-          @css_url || "/css/application.css?t=#{File.mtime('./public/css/application.css').to_i}"
+          @css_url ||= css_url_generate('/css/application.css')
         end
+
+        def css_url_generate(resource)
+          css_filename = File.join(settings.public_folder, resource)
+          raise css_url_generate_error(css_filename) unless File.exists?(css_filename)
+          "#{resource}?t=#{File.mtime(css_filename).to_i}"
+        end
+
+        def css_url_generate_error(css_filename)
+          command = "bundle exec compass compile"
+          url = 'https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md#scss'
+
+          IOError.new <<-MESSAGE.gsub(/^ */,'')
+            '#{css_filename}' not found.
+            Try running '#{command}' to generate it.
+            For more information: #{url}
+          MESSAGE
+        end
+
       end
     end
   end

--- a/app/routes/core.rb
+++ b/app/routes/core.rb
@@ -55,6 +55,7 @@ module ExercismWeb
       helpers Helpers::UserProgressBar
       helpers Helpers::TeamAccess
       helpers WillPaginate::Sinatra::Helpers
+      helpers Helpers::CssUrl
 
       helpers do
         def github_client_id
@@ -99,27 +100,6 @@ module ExercismWeb
 
         def tracks
           ExercismWeb::Presenters::Tracks.tracks
-        end
-
-        def css_url
-          @css_url ||= css_url_generate('/css/application.css')
-        end
-
-        def css_url_generate(resource)
-          css_filename = File.join(settings.public_folder, resource)
-          raise css_url_generate_error(css_filename) unless File.exists?(css_filename)
-          "#{resource}?t=#{File.mtime(css_filename).to_i}"
-        end
-
-        def css_url_generate_error(css_filename)
-          command = "bundle exec compass compile"
-          url = 'https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md#scss'
-
-          IOError.new <<-MESSAGE.gsub(/^ */,'')
-            '#{css_filename}' not found.
-            Try running '#{command}' to generate it.
-            For more information: #{url}
-          MESSAGE
         end
 
       end

--- a/test/app/helpers/css_url_test.rb
+++ b/test/app/helpers/css_url_test.rb
@@ -1,0 +1,38 @@
+require_relative '../../test_helper'
+require_relative '../../../app/helpers/css_url'
+
+class CssUrlHelperTest < Minitest::Test
+  class FakeApplication
+    def settings
+      Struct.new(:public_folder).new('fake_public_folder')
+    end
+  end
+
+  def helper
+    FakeApplication.new.extend ExercismWeb::Helpers::CssUrl
+  end
+
+  def test_application_css_exists
+    fake_timestamp = '123456789'
+    File.stub(:exist?, true) do
+      File.stub(:mtime, fake_timestamp) do
+        assert_equal "/css/application.css?t=#{fake_timestamp}", helper.css_url
+      end
+    end
+  end
+
+  def test_application_css_nonexistant
+    expected_error_message = <<-MESSAGE.gsub(/^ */, '')
+    'fake_public_folder/css/application.css' not found.
+    Try running 'bundle exec compass compile' to generate it.
+    For more information: https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md#scss
+    MESSAGE
+
+    File.stub(:exists?, false) do
+      error = assert_raises IOError do
+        helper.css_url
+      end
+      assert_equal expected_error_message, error.message
+    end
+  end
+end


### PR DESCRIPTION
When setting up an Exercism development environment, if the application.css file has not been generated the error message is not very helpful, the new message provides more details about what went wrong and what can be done to rectify the problem.

Old message:

>Errno::ENOENT at /
No such file or directory @ rb_file_s_mtime - ./public/css/application.css

New message:

>IOError at /
'\<developers exercism.io path>/public/css/application.css' not found.
Try running 'bundle exec compass compile' to generate it.
For more information: https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md#scss