### PR TITLE
Add tests for all topics on language pages

### DIFF
--- a/test/app/languages_test.rb
+++ b/test/app/languages_test.rb
@@ -31,36 +31,12 @@ class LanguagesRoutesTest < Minitest::Test
     assert_match 'Planned', last_response.body
   end
 
-  def test_route_languages_invalid_track
-    get '/languages/invalid_track/about'
-    assert_equal 404, last_response.status
-    assert_match "It doesn't look like we have <b>invalid_track</b> yet", last_response.body
-  end
-
-  def test_route_languages_valid_track_redirects_to_about_page
+  def test_route_languages_redirects_to_about_page
     get '/languages/animal'
     assert_equal 302, last_response.status
   end
 
-  def test_route_contribute_invalid_language
-    get '/languages/nonexistant/contribute'
-    assert_equal 404, last_response.status
-    assert_match 'It doesn\'t look like we have <b>nonexistant</b> yet.', last_response.body
-  end
-
-  def test_route_valid_track_with_invalid_topic
-    get '/languages/animal/invalid-topic'
-    assert_equal 404, last_response.status
-    assert_match "We don't know anything about", last_response.body
-  end
-
-  def test_route_invalid_track_with_valid_topic
-    get '/languages/invalid_track/about'
-    assert_equal 404, last_response.status
-    assert_match "It doesn't look like we have <b>invalid_track</b> yet", last_response.body
-  end
-
-  def test_route_valid_track_with_valid_topic
+  def test_route_valid_language_with_valid_topic
     get '/languages/animal/about'
     assert_equal 200, last_response.status
     assert_match "About the Animal Track", last_response.body
@@ -71,5 +47,31 @@ class LanguagesRoutesTest < Minitest::Test
     assert_match "Useful Animal Resources", last_response.body
     assert_match "Getting Help", last_response.body
     assert_match "Contributing to Animal on Exercism", last_response.body
+  end
+
+  def test_route_valid_language_with_invalid_topic
+    get '/languages/animal/invalid-topic'
+    assert_equal 404, last_response.status
+    assert_match "We don't know anything about", last_response.body
+  end
+
+  def test_route_invalid_language_with_valid_topic
+    get '/languages/invalid_track/about'
+    assert_equal 404, last_response.status
+    assert_match "It doesn't look like we have <b>invalid_track</b> yet", last_response.body
+  end
+
+  def test_route_invalid_language_invalid_topic
+    get '/languages/invalid_track/invalid_topic'
+    assert_equal 404, last_response.status
+    assert_match 'It doesn\'t look like we have <b>invalid_track</b> yet.', last_response.body
+  end
+
+  def test_all_topics_for_valid_language
+    ExercismWeb::Routes::Languages::TOPICS.each do |topic|
+      get "/languages/animal/#{topic}"
+      assert_equal 200, last_response.status
+      assert_match "Animal", last_response.body
+    end
   end
 end


### PR DESCRIPTION
For now this just includes test cases which should fail as per issue #3266 
@Insti has sent a [fix to trackler](https://github.com/exercism/trackler/pull/8). If any changes are required here, I will update this PR accordingly.

Includes:
* Test routes against all topics.
* Use `language` instead of `track` and maintain consistency through the test file.
* Reorder some tests for better reading.