### PR TITLE
Fix broken language contribution pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     tilt (2.0.2)
     timecop (0.8.0)
     tins (1.6.0)
-    trackler (2.0.0.10)
+    trackler (2.0.1.0)
       org-ruby (~> 0.9.0)
       rubyzip (~> 1.1)
     tzinfo (1.2.2)

--- a/app/views/languages/_contribute_exercise.erb
+++ b/app/views/languages/_contribute_exercise.erb
@@ -1,27 +1,27 @@
 <div class="col-lg-4">
-  <h3 class="exercise-name"><%= exercise.name %></h3>
+  <h3 class="exercise-name"><%= problem.name %></h3>
 </div>
 <div class="col-lg-4">
-  <p><%= exercise.blurb %></p>
+  <p><%= problem.blurb %></p>
   <p>
   <div class="link-icons">
-    <% if exercise.readme_url %>
-      <a href="<%= exercise.readme_url %>" target="_blank"><i style="font-size: 20px;" class="fa fa-info-circle" data-toggle="tooltip" data-placement="top" title="Problem description"></i>Description</a>
+    <% if problem.md_url %>
+      <a href="<%= problem.md_url %>" target="_blank"><i style="font-size: 20px;" class="fa fa-info-circle" data-toggle="tooltip" data-placement="top" title="Problem description"></i>Description</a>
     <% end %>
   </div>
   <div class="link-icons">
-    <% if exercise.data %>
-      <a href="<%= exercise.data %>" target="_blank"><i style="font-size: 20px;" class="fa fa-list" data-toggle="tooltip" data-placement="top" title="Test data"></i>Test Data</a>
+    <% if problem.json_url %>
+      <a href="<%= problem.json_url %>" target="_blank"><i style="font-size: 20px;" class="fa fa-list" data-toggle="tooltip" data-placement="top" title="Test data"></i>Test Data</a>
     <% end %>
   </div>
   </p>
 </div>
 <div class="col-lg-4">
-  <% exercise.implementations.each_slice(4) do |im| %>
-    <% im.each do |i| %>
-      <a a href="<%= i["url"] %>" target="_blank" class="col-xs-3 col-sm-3 col-md-3 col-lg-3" data-toggle="tooltip" data-placement="top" title="<%= i["track_id"] %>">
+  <% Trackler.implementations[problem.slug].each_slice(4) do |implementations| %>
+    <% implementations.each do |implementation| %>
+      <a a href="/exercises/<%= implementation.track_id %>/<%= implementation.problem.slug %>/readme" target="_blank" class="col-xs-3 col-sm-3 col-md-3 col-lg-3" data-toggle="tooltip" data-placement="top" title="<%= implementation.track_id %>">
         <div class="text-center">
-          <%= track_icon(i["track_id"], 30) %>
+          <%= track_icon(implementation.track_id, 30) %>
         </div>
       </a>
     <% end %>

--- a/app/views/languages/_todo.erb
+++ b/app/views/languages/_todo.erb
@@ -16,7 +16,8 @@
 Once you've picked an exercise, follow the instructions in the <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#porting-an-exercise-to-another-language-track" target="_blank">Contributing Guide</a> and submit your pull request to the <a href="<%= track.repository %>" target="_blank"><%= track.language %> track repository</a> on GitHub.
 </p>
 
-<% if track.unimplemented_problems.count.zero? %>
+<% todos = Trackler.todos[track.id] %>
+<% if todos.count.zero? %>
   <div class="col-md-12 jumbotron">
     <p>All exercises are implemented in <%= track.language %>, you will need to <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#implementing-a-completely-new-exercise">invent a new exercise.</a></p>
   </div>
@@ -33,9 +34,9 @@ Once you've picked an exercise, follow the instructions in the <a href="https://
     </div>
   </div>
 
-  <% track.unimplemented_problems.each do |todo| %>
+  <% todos.each do |todo| %>
     <div class="row padding-row exercise-todo">
-      <%= erb :'languages/_contribute_exercise', locals: { exercise: todo} %>
+      <%= erb :'languages/_contribute_exercise', locals: { problem: todo} %>
     </div>
   <% end %>
   </div>

--- a/app/views/languages/contribute.erb
+++ b/app/views/languages/contribute.erb
@@ -32,7 +32,7 @@
       <% exercises.sort_by { |e| [-e.implementations.count,e.name] }.each_slice(3) do |todo| %>
         <div class="row padding-row">
           <% todo.each do |problem| %>
-            <%= erb :'languages/_contribute_exercise', locals: { exercise: problem } %>
+            <%= erb :'languages/_contribute_exercise', locals: { problem: problem } %>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
Closes #3266

We've been working on swapping out the x-api calls to use the Trackler gem directly. I missed the fact that the contribute/todo page hadn't gotten updated in the mix.

This changes the erb files to use the Trackler gem.

/cc @ferhatelmas who reported the issue, and @Insti @tejasbubane who have done work to fix it.