### PR TITLE
Add missing 'fetch' to fetch instructions. Fixes #3270

### DIFF
--- a/app/views/languages/_about.erb
+++ b/app/views/languages/_about.erb
@@ -5,7 +5,7 @@
   If you've downloaded the <a href='/cli'>command-line client</a> and have <%= track.language %> installed
   on your machine, then go ahead and fetch the first problem.
 </p>
-<%= syntax "exercism fetch #{track.id} #{track.problems.first.slug}", "plain" %>
+<%= syntax "exercism fetch #{track.id}", "plain" %>
 
 <p>
   In order to be able to submit your solution, you'll need to configure the client with your

--- a/app/views/languages/_about.erb
+++ b/app/views/languages/_about.erb
@@ -5,7 +5,7 @@
   If you've downloaded the <a href='/cli'>command-line client</a> and have <%= track.language %> installed
   on your machine, then go ahead and fetch the first problem.
 </p>
-<%= syntax "exercism #{track.id} #{track.problems.first.slug}", "plain" %>
+<%= syntax "exercism fetch #{track.id} #{track.problems.first.slug}", "plain" %>
 
 <p>
   In order to be able to submit your solution, you'll need to configure the client with your


### PR DESCRIPTION
Add missing 'fetch' to fetch instructions on the language "about" page.