### PR TITLE
Show team invites only when the current user is in its own profile.

### DIFF
--- a/app/presenters/profile.rb
+++ b/app/presenters/profile.rb
@@ -50,7 +50,11 @@ module ExercismWeb
       end
 
       def teams
-        user.team_invites | user.teams | user.managed_teams
+        user.teams | user.managed_teams | team_invites
+      end
+
+      def team_invites
+        own? ? user.team_invites : []
       end
 
       def has_teams?

--- a/test/acceptance/profile_test.rb
+++ b/test/acceptance/profile_test.rb
@@ -26,4 +26,20 @@ class ProfileTest < AcceptanceTestCase
       assert_content 'Fake: 1/4 (25%)'
     end
   end
+
+  def test_display_team_invites_only_in_users_own_profile
+    new_user = create_user(username: 'new_user', github_id: 456)
+    attributes = { slug: 'some-team', name: 'Some Name', usernames: 'new_user' }
+    Team.by(@user).defined_with(attributes, @user).save!
+
+    with_login(@user) do
+      visit "/#{new_user.username}"
+      refute_content 'Some Name'
+    end
+
+    with_login(new_user) do
+      visit "/#{new_user.username}"
+      assert_content 'Some Name'
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3273 

We want to display only the current teams of an user for the rest of the world, unless we are seeing our own profile.

@kotp Can you review that? Thanks for the issue. :)