### PR TITLE
Ignore manager when counting number of members in a team.

### DIFF
--- a/lib/exercism/team.rb
+++ b/lib/exercism/team.rb
@@ -105,7 +105,7 @@ class Team < ActiveRecord::Base
   end
 
   def members_size
-    members.size + 1 # manager
+    members.size
   end
 
   private


### PR DESCRIPTION
Fixes #3275

We don't really need to count the manager when getting the number of members for a team.

@Insti Can you review this one? :)