### PR TITLE
Upgrade Ruby to 2.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.2
+  - 2.3.3
 script:
   - 'createuser exercism --superuser && createdb -O exercism exercism_test'
   - 'npm install -g lineman'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.2.2
+FROM ruby:2.3.3
 
 RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
   apt-get install -y nodejs postgresql-client && \

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.2.2'
+ruby '2.3.3'
 
 gem 'activesupport', '~> 4.2.1'
 gem 'activerecord', '~> 4.2.1'
@@ -16,8 +16,8 @@ gem 'rack-flash3', require: 'rack-flash'
 gem 'rake', '~> 10.5.0'
 gem 'redcarpet', '~> 3.1'
 gem 'rouge', '~> 2.0.5'
-gem 'sinatra', '~> 1.4.4', require: 'sinatra/base'
-gem 'sinatra-contrib'
+gem 'sinatra', '~> 1.4.7', require: 'sinatra/base'
+gem 'sinatra-contrib', '~> 1.4.7'
 gem 'sidekiq'
 gem 'trackler', '~> 2.0.0'
 gem 'will_paginate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
       rake
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
@@ -105,7 +105,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     puma (2.15.3)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-flash3 (1.0.5)
       rack
     rack-protection (1.5.3)
@@ -143,7 +143,7 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    sinatra-contrib (1.4.6)
+    sinatra-contrib (1.4.7)
       backports (>= 2.0)
       multi_json
       rack-protection
@@ -156,7 +156,7 @@ GEM
       tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.2)
+    tilt (2.0.5)
     timecop (0.8.0)
     tins (1.6.0)
     trackler (2.0.3.0)
@@ -205,8 +205,8 @@ DEPENDENCIES
   sass
   sidekiq
   simplecov
-  sinatra (~> 1.4.4)
-  sinatra-contrib
+  sinatra (~> 1.4.7)
+  sinatra-contrib (~> 1.4.7)
   sqlite3
   timecop
   trackler (~> 2.0.0)
@@ -214,7 +214,7 @@ DEPENDENCIES
   will_paginate-bootstrap
 
 RUBY VERSION
-   ruby 2.2.2p95
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.12.5
+   1.13.6


### PR DESCRIPTION
Previous attempt at upgrading to 2.3.0 was reverted due to lot of
errors in the logs (4b96e0b)

I saw following errors this time:
```
Thread.exclusive is deprecated, use Mutex
```

And found that these were coming out of `sinatra-contrib` which was
fixed in `1.4.7`:
https://github.com/sinatra/sinatra-contrib/issues/183

I suspect the errors were same with `2.3.0` at that time which were
intercepted by newrelic (we no more use newrelic).

Upgrading `sinatra-contrib` to `1.4.7` fixed the errors.