### PR TITLE
Fixing Twitter Share functionality. #3285

### DIFF
--- a/app/helpers/twitter_intent.rb
+++ b/app/helpers/twitter_intent.rb
@@ -1,0 +1,26 @@
+module ExercismWeb
+  module Helpers
+    module TwitterIntent
+
+      def twitter_share_from_submission(submission)
+        text =
+          'I just submitted the #%s %s exercise at @exercism_io '\
+          '- Leave me a nitpick at ' \
+          % [submission.problem.language, submission.slug]
+        url = 'http://exercism.io/submissions/%s' % [submission.key]
+        twitter_share(text: text, url: url)
+      end
+
+      def twitter_share(opts = {})
+        "#{TWITTER_URL}%s" % opts.slice(*TWITTER_KEYS).to_query
+      end
+
+      private
+
+      TWITTER_URL = 'https://twitter.com/intent/tweet?'.freeze
+      TWITTER_KEYS = %i(text url).freeze
+
+      private_constant :TWITTER_URL, :TWITTER_KEYS
+    end
+  end
+end

--- a/app/views/submissions/show.erb
+++ b/app/views/submissions/show.erb
@@ -13,8 +13,24 @@
         <%= erb :"submissions/user_actions", locals: { submission: submission, exercise: submission.user_exercise } %>
 
         <% if current_user.owns?(submission) %>
+          <%
+            twitt_params =
+              { text: Rack::Utils.escape_path(<<-TEXT.chomp.gsub(/^\s+/, '')),
+                  I just submitted the #{submission.problem.language} 
+                  #{submission.slug} exercise at @exercism_io - 
+                  Leave me a nitpick at 
+                TEXT
+                url: Rack::Utils.escape_path(
+                       URI.join('http://exercism.io/submissions/',
+                                submission.key))
+              }
+            url = <<-URL.chomp.gsub(/^\s+/, '')
+              https://twitter.com/intent/tweet?
+              #{Rack::Utils.build_query(twitt_params)}
+            URL
+          %>
           <a
-            href="https://twitter.com/intent/tweet?text=I just submitted the #<%= submission.problem.language %> <%= submission.slug %> exercise at @exercism_io - Leave me a nitpick at http://exercism.io/submissions/<%= submission.key %>"
+            href="<%= url %>"
             class="btn btn-default"
             data-toggle="tooltip"
             data-placement="bottom"

--- a/test/app/helpers/twitter_intent.rb
+++ b/test/app/helpers/twitter_intent.rb
@@ -1,0 +1,61 @@
+require 'active_support/all'
+require_relative '../../test_helper'
+require_relative '../../../app/helpers/twitter_intent'
+
+class TwitterIntentTest < Minitest::Test
+  TWITTER_URL = 'https://twitter.com/intent/tweet?'.freeze
+
+  def test_no_params
+    assert_equal TWITTER_URL, helper.twitter_share
+  end
+
+  def test_using_text
+    text = 'A #hashtag for @you http://exercism.io'
+    expected_uri =
+      "#{TWITTER_URL}%s" %
+      'text=A+%23hashtag+for+%40you+http%3A%2F%2Fexercism.io'
+
+    assert_equal expected_uri, helper.twitter_share(text: text)
+  end
+
+  def test_using_text_and_url
+    text = 'A #hashtag for @you'
+    url = 'http://exercism.io'
+    expected_uri =
+      "#{TWITTER_URL}%s" %
+      'text=A+%23hashtag+for+%40you&url=http%3A%2F%2Fexercism.io'
+
+    assert_equal expected_uri, helper.twitter_share(text: text, url: url)
+  end
+
+  def test_using_url
+    url = 'http://exercism.io'
+    expected_uri = "#{TWITTER_URL}%s" % 'url=http%3A%2F%2Fexercism.io'
+
+    assert_equal expected_uri, helper.twitter_share(url: url)
+  end
+
+  def test_other_params_are_ignored
+    text = 'Go for it!'
+    expected_uri = "#{TWITTER_URL}text=Go+for+it%21"
+    assert_equal expected_uri, helper.twitter_share(text: text, go: 'No go')
+  end
+
+  def test_from_submission
+    expected_uri = "#{TWITTER_URL}text=I+just+submitted+the+%23Elixir+raindrops"\
+    "+exercise+at+%40exercism_io+-+Leave+me+a+nitpick+at+"\
+    "&url=http%3A%2F%2Fexercism.io%2Fsubmissions%2F0b7122bb15044990a62717315ea68dd6"
+    problem = OpenStruct.new(language: 'Elixir')
+    submission =
+      OpenStruct.new(problem: problem,
+                     slug: 'raindrops',
+                     key: '0b7122bb15044990a62717315ea68dd6')
+    assert_equal expected_uri, helper.twitter_share_from_submission(submission)
+  end
+
+  private
+
+  def helper
+    @helper ||= Object.new.extend(ExercismWeb::Helpers::TwitterIntent)
+  end
+end


### PR DESCRIPTION
Proposal to fix the issue on broken twitter share functionality.
This first attempt is asking for extraction, but need to know what Exercism project preffer.
I think this should be done on at least 3 different parts.
- a method to generate only the hash for parameters (this is all about submission) - testable with unit test.
- from the controller send that hash to the view
- the view should use a helper having the hash ready and apply the Rack::Utils - the helper can have a unit test also

Fixes #3285