### PR TITLE
Improves wordmark in navbar.

### DIFF
--- a/public/sass/application.scss
+++ b/public/sass/application.scss
@@ -87,3 +87,10 @@ p.cta {
   display: -ms-flexbox;
   display:         flex;
 }
+
+.wordmark {
+  font-family: $font-family-sans-serif;
+  font-size: $font-size-small;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
Follow up to #3291. 

Minor fix to set apart the exercism wordmark from links in the sidebar without adding visual noise.

For convenience:

![](https://cloud.githubusercontent.com/assets/276834/20855790/73e51de2-b8bf-11e6-99f9-9ecd2ff441a7.png)
Before


![](https://cloud.githubusercontent.com/assets/1913615/20858603/cb31044c-b948-11e6-9832-eeaa4f4e13cc.png)
After