### PR TITLE
Split "setting up development" into a separate guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,12 +250,7 @@ Do you like mentoring people?
 
 * [Code of Conduct](#code-of-conduct)
 * [The Ecosystem](#the-ecosystem)
-* [Get Set Up](#setup)
-    - [Console](#console)
-    - [Testing](#testing)
-    - [Frontend Development Setup](#frontend-development-setup)
-    - [Deployment](#deployment)
-* [Write Some Code](#write-some-code)
+* [Submitting Code Changes](#submitting-code-changes)
     - [Workflow](#workflow)
     - [Issues](#issues)
     - [Good First Patch](#good-first-patch)
@@ -296,12 +291,14 @@ To contribute to one of the language tracks, check out the [Language Track Guide
 For details about working with the problems API, check out the [Problems API Guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md).
 
 
-## Write Some Code
+## Submitting Code Changes
 
 These instructions should get you closer to getting a commit into the
 repository.
 
-### Workflow
+See the [Setting up Local Development guide](docs/setting-up-local-development) for more information about how to run exercism.io locally.
+
+### Git Workflow
 
 1. Fork and clone.
 1. Add the upstream exercism.io repository as a new remote to your clone.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ We are working to improve this document, and if you find any part of it confusin
 - Check [`exercism/exercism.io`](https://github.com/exercism/exercism.io/issues?q=is%3Aissue+is%3Aopen+label%3Abug)'s repo for bugs; and while we might know there's an issue, any additional details sometimes can help.
 - If the website has a bug, you can help by [filing a bug report](docs/filing-a-bug-report.md) in the [`exercism/exercism.io` repository](https://github.com/exercism/exercism.io/issues/new).
   - if you have the time and the desire, you can help *even more* by [fixing it](#i-would-like-to-help-i-know--want-to-get-better-at-web-programming).
-  
+
 -
 
 ### I see a problem with the command-line client (CLI)
@@ -39,7 +39,7 @@ We are working to improve this document, and if you find any part of it confusin
 
 -
 
-### I see a problem getting started with a language 
+### I see a problem getting started with a language
 
 * If you're having trouble with the setup instructions, ask for help in our [online support chat](https://gitter.im/exercism/support).
 - If you see a problem with the setup instructions, you can help by [filing a bug report](docs/filing-a-bug-report.md) in the "Issues" section of the [corresponding language repository](http://exercism.io/repositories).
@@ -47,7 +47,7 @@ We are working to improve this document, and if you find any part of it confusin
 
 -
 
-### I see a problem with a specific exercise 
+### I see a problem with a specific exercise
 
 * If a particular exercise is giving you grief, ask for help in our [online support chat](https://gitter.im/exercism/support).
 - If there's a defect in the...
@@ -59,7 +59,7 @@ We are working to improve this document, and if you find any part of it confusin
   1. `exercism submit` the code you have;
   -  Follow the link that the CLI returns to view your new submission on the website;
   -  In the "**Manage**" pull-down (top-right), select "**Request Help**".
-  
+
   When you do this, your submission is highlighted, letting others know you're stuck.
 
 ----
@@ -67,12 +67,12 @@ We are working to improve this document, and if you find any part of it confusin
 ## I have an idea
 
 
-| [making the website better](#i-have-an-idea-about-making-the-website-better) | [improving the command-line client (CLI)](#i-have-an-idea-about-improving-the-command-line-client-cli) | [a brand-new exercise for Exercism](#i-have-an-idea-about-a-brand-new-exercise-for-exercism) | [improving an existing exercise](#i-have-an-idea-about-improving-an-existing-exercise) | 
+| [making the website better](#i-have-an-idea-about-making-the-website-better) | [improving the command-line client (CLI)](#i-have-an-idea-about-improving-the-command-line-client-cli) | [a brand-new exercise for Exercism](#i-have-an-idea-about-a-brand-new-exercise-for-exercism) | [improving an existing exercise](#i-have-an-idea-about-improving-an-existing-exercise) |
 |:---:|:---:|:---:|:---:|
 |[![Making the website better](docs/img/globe.png)](#i-have-an-idea-about-making-the-website-better) | [![Improving the command-line client](docs/img/prompt.png)](#i-have-an-idea-about-improving-the-command-line-client-cli) | [![A brand new exercise for Exercism](docs/img/target-a-track.png)](#i-have-an-idea-about-a-brand-new-exercise-for-exercism) | [![Improving an existing exercise](docs/img/computer-code.png)](#i-have-an-idea-about-improving-an-existing-exercise) |
 
 
-### I have an idea about making the website better 
+### I have an idea about making the website better
 
 Is it around a portion of the site we're currently talking about?  Jump in!
 
@@ -96,7 +96,7 @@ If the idea doesn't fit in one of those discussions, then if it relates to:
 
 -
 
-### I have an idea about improving the command-line client (CLI) 
+### I have an idea about improving the command-line client (CLI)
 
 Current specific discussions:
 
@@ -106,12 +106,12 @@ Here are some helpful starter searches in the two repositories that contain idea
 
 * [`exercism/cli?`](https://github.com/exercism/cli/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
 - [`exercism/discussions?cli`](https://github.com/exercism/discussions/issues?q=is%3Aissue+is%3Aopen+cli+sort%3Aupdated-desc)
-  
+
 If the idea isn't being discussed yet, kick it off in the [`exercism/cli`](https://github.com/exercism/cli/issues/new) repository.
 
 -
 
-### I have an idea about a brand-new exercise for Exercism 
+### I have an idea about a brand-new exercise for Exercism
 
 New exercise ideas are definitely welcome!  Here's how to ensure the idea lands in the right place:
 
@@ -126,7 +126,7 @@ New exercise ideas are definitely welcome!  Here's how to ensure the idea lands 
 
 -
 
-### I have an idea about improving an existing exercise 
+### I have an idea about improving an existing exercise
 
 - If the idea is to improve the...
   - **instructions** of the exercise, you can make a difference by making the suggestion in the [`exercism/x-common`](https://github.com/exercism/x-common/issues/new) repository.
@@ -178,7 +178,7 @@ This means helping maintain the code of the exercises and supporting tooling for
 ### I would like to help; I know / want to get better at web programming
 
 Do you have/want to have chops in HTML+CSS+JavaScript/CoffeeScript and want to improve the feel and function of the Exercism website?
-  
+
 1. [Setup your local development environment](docs/setting-up-local-development.md).
 -  Locate an feature/bug to work on:
    - [`exercism/exercism.io?label:good first patch`](https://github.com/exercism/exercism.io/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+patch%22)
@@ -195,7 +195,7 @@ You may also find these helpful:
 ### I would like to help; I know / want to get better at Ruby
 
 Do you have/want to have chops in Ruby or Sinatra and want to add to the website?
-  
+
 1. [Setup your local development environment](docs/setting-up-local-development.md).
 -  Locate an feature/bug to work on:
    - [`exercism/exercism.io?label:good first patch`](https://github.com/exercism/exercism.io/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+patch%22)
@@ -217,7 +217,7 @@ One of the more subtle but important parts of the Exercism experience is our CLI
 1. Setup your local development environment for the CLI: [`exercism/cli`](https://github.com/exercism/cli).
 -  Locate an feature/bug to work on: [`exercism/cli?`](https://github.com/exercism/cli/issues)
 -  Work the issue: [the contribution workflow](docs/the-contribution-workflow.md).
-   
+
 You may also find these helpful:
 
 - [Architecture Overview of Exercism](docs/overview-of-exercism.md)
@@ -229,7 +229,7 @@ You may also find these helpful:
 
 Do you love making enticing user experiences?  Help us [rethink our user experience](https://github.com/exercism/discussions/issues/34) (UX)!
 
-* the [profile](https://github.com/exercism/discussions/search?q=profile&state=open&type=Issues) or [account](https://github.com/exercism/discussions/search?q=account&state=open&type=Issues) pages. 
+* the [profile](https://github.com/exercism/discussions/search?q=profile&state=open&type=Issues) or [account](https://github.com/exercism/discussions/search?q=account&state=open&type=Issues) pages.
 - the [dashboard](https://github.com/exercism/discussions/search?q=dashboard&state=open&type=Issues).
 - the [homepage](https://github.com/exercism/discussions/search?q=homepage&state=open&type=Issues).
 - the [solutions page](https://github.com/exercism/discussions/issues/32).
@@ -238,9 +238,9 @@ Do you love making enticing user experiences?  Help us [rethink our user experie
 
 ### I would like to help; I know / want to get better at mentoring others
 
-Do you like mentoring people? 
+Do you like mentoring people?
 
-* Hang out in the support chat [support chat](https://gitter.im/exercism/support), or 
+* Hang out in the support chat [support chat](https://gitter.im/exercism/support), or
 * submit an exercise so you can [give feedback to people who have submitted it, too](http://exercism.io/inbox).
 
 
@@ -294,293 +294,6 @@ If you want to work on the exercism.io website codebase, then continue reading t
 To contribute to one of the language tracks, check out the [Language Track Guide](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md).
 
 For details about working with the problems API, check out the [Problems API Guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md).
-
-## Setup
-
-This section walks you through getting the exercism.io app running locally.
-
-### Prerequisites
-
-Backend:
-
-- Ruby
-- PostgreSQL
-
-Frontend:
-
-- Node.js
-
-To install Ruby, check out [RVM](https://rvm.io), [rbenv](https://github.com/sstephenson/rbenv) or [ruby-install](https://github.com/postmodern/ruby-install).
-
-PostgreSQL can be installed with [Homebrew](http://brew.sh) on Mac OS X: `brew install postgresql`
-If you're on a Linux system with apt-get then run: `apt-get install postgresql postgresql-contrib`
-
-Install Node.js and npm on Mac OS X with Homebrew:  `brew install node`
-On other systems see the [Node.js docs](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
-
-### GitHub OAuth
-
-If you seed your local database with fake users, then you can use these to "fake login" as
-one of them. There will be a dropdown with identities that you can assume in development mode.
-
-If you want to actually work on the login flow, or if you want to log in as yourself, then
-you will need keys on GitHub that the app can talk to.
-
-Go to https://github.com/settings/applications/new and enter the following:
-
-* Application name: You can name it whatever you want, e.g. _Exercism (Dev)_.
-* Homepage URL: http://localhost:4567
-* Authorization callback URL: http://localhost:4567/github/callback
-
-Click _Register application_, and you'll see something like this:
-
-![](/docs/img/oauth-client-secret.png)
-
-Hang on to those. You'll need to add the **Client ID** and **Client Secret** to a
-configuration file in just a moment.
-
-### The Code
-
-If you're unfamiliar with git and GitHub, don't worry. We'll gladly help you out if you get stuck. GitHub also has some [helpful guides](https://guides.github.com) for getting started.
-
-First, you need to get ahold of the code, so you have a copy of it locally that you can make changes to.
-
-* [Fork](https://github.com/exercism/exercism.io/fork) this codebase to your own GitHub account.
-* Clone your fork, and change directory into the root of the exercism.io project.
-
-### Configuration
-
-In most cases, it is easiest to run the `bin/setup` script to automatically setup the defaults for the application. Make sure you have PostgreSQL running in the background.
-
-The script will:
-
-* setup the `.ruby-version` file for your Ruby version manager such as RVM, rbenv or chruby
-* copy the environment config to `.env`
-* run bundler to install the required gems
-* create the development database using the credentials in `config/database.yml`
-* download and seed the database with a good starting set of data
-* create the test database
-* run the test suite
-
-Then you'll need to:
-
-* Open `.env` and add the **Client ID** and **Client Secret** from the previous GitHub OAuth steps.
-
-All the commented out values in `.env` can be left alone for now.
-
-You don't need to fill in the EXERCISES_API value unless you're going to be working on the x-api codebase.
-
-### Data
-
-If you ran `bin/setup` you should be all set.
-
-You can easily reset an existing database to its original state and add the fake data in one step:
-
-* `rake db:reseed`
-
-If you need to set PostgreSQL parameters like the user and/or database name to use during setup, set `PGUSER` and/or `PGDATABASE` environment values respectively. Example: `PGUSER=pgsql PGDATABASE=postgres rake db:reseed`
-
-#### Troubleshooting
-
-Note that you may have trouble running commands like `rake` or `pry` if your system has a different version of those gems than the Gemfile. In that case, you will need to prepend those commands with `bundle exec` so that bundler will execute that command in the context of the project's gems rather than your system's gems. If you would like to learn more about this topic and how to alias `bundle exec` (if you don't like typing it out each time), see [this article by Thoughtbot](https://robots.thoughtbot.com/but-i-dont-want-to-bundle-exec).
-
-To debug the database setup, do it step-by-step:
-
-* Create the PostgreSQL database: `rake db:setup`
-* Run the database migrations: `rake db:migrate`
-* Fetch the seed data: `rake db:seeds:fetch`
-* Seed the database: `rake db:seed`
-
-If you are having 'PG::Connection ...' or 'Peer authentication failed for user ...' issues you can follow these steps (this is assuming that you modified the database.yml file and your changes are not being accessed properly. Anywhere that it is stated "PGUSER=postgres" replace "postgres" with your specified username that you use for your postgresql databases):
-
-* Create the PostgreSQL database (this will prompt you to input a password allowing you to authenticate and create your databases that are specified in your database.yml file): `PGUSER=postgres rake db:create`
-* Run the database migrations: `rake db:migrate`
-* Fetch the seed data: `rake db:seeds:fetch`
-* Seed the database: `rake db:seed`
-
-The setup task will create a PostgreSQL user called exercism with super user permissions.
-If you want to avoid this you may create a user manually and add the needed extensions manually as well.
-
-The seed data gives you a bunch of fake user accounts with submissions in multiple languages as well
-as fake comments. In development mode there is an "Assume" menu item to the far right of the
-nav bar. This will let you easily assume different fake identities to see the site
-from their perspective.
-
-You may need to edit the `config/database.yml` file to specify non-default values. If you do, please edit (or create) a `.git/info/exclude` file so that your changes don't get committed. Unfortunately we have to commit the database.yml file, because heroku no longer creates a default one.
-
-Note that if you installed PostgreSQL on OS X with [Postgres.app](http://postgresapp.com/), you'll need to
-[configure your `$PATH`](http://postgresapp.com/documentation/cli-tools.html) in order for
-the database setup to complete successfully. `bin/setup` relies on PostgreSQL command line tools
-and as Postgres.app does not automatically add the application `bin` directory to your `$PATH`,
-you'll need to do this manually.
-
-### Run The Application
-
-* Start the server with: `foreman s -p 4567`
-* Sometimes you need to: `bundle exec foreman s -p 4567` (see [Troubleshooting](#troubleshooting) above)
-* Then you can access the local server at [localhost:4567](http://localhost:4567).
-* You can log in as a test user using the `assume` dropdown menu on the top right of the page without creating any new user for the app.
-
-To setup seed data to test out the application locally, use the rake
-tasks provided. You can get a list of all the rake tasks by running:
-
-    bundle exec rake -T
-
-To setup the seed data locally, run:
-
-    bundle exec rake db:seeds:fetch
-    bundle exec rake db:seed
-
-The first command fetches the seed file and places it under the `db/`
-folder as `seeds.sql`. Note that if you're deploying the application to
-Heroku, `db:seed` task might fail since the database config file won't
-contain the necessary details to access the database. To work around the
-problem, there's a task `db:heroku_seed` that can be used.
-
-
-### Running The Application In A Vagrant Environment
-_The following assumes your Vagrantfile is configured to forward port 3000 to 3030, adjust the port number to suit your environment_
-
-If you are using a different port than 3000 to forward outside of your Vagrant environment you will need to go into `Procfile_Vagrant` and adjust the port number that applies to your needs.
-
-* Copy the Vagrant Procfile example `cp Procfile_Vagrant.example Procfile_Vagrant`
-* Start the server with: `foreman s -f Procfile_Vagrant` (the `-f` explicitly states which Procfile to use and we don't want to use the original Procfile in our vagrant environments)
-* Sometimes you need to: `bundle exec foreman s -f Procfile_Vagrant`
-* Then you can access the local server at [localhost:3030](http://localhost:3030).
-* You can log in as a test user using the `assume` dropdown menu on the top right of the page without creating any new user for the app.
-
-_Again this is assuming you are forwarding port 3000 to 3030 in your Vagrantfile, adjust accordingly to your environment_
-
-### Console
-
-There's a script in `bin/console` that will load pry with the exercism environment loaded. You may need to run this file as `bundle exec bin/console` (see [Troubleshooting](#troubleshooting) above).
-This will let you poke around at the objects in the system, such as finding users and changing
-things about submissions or comments, making it easier to test specific things.
-
-```ruby
-user = User.find_by_username 'whatever'
-user.submissions
-```
-
-### Testing
-
-The test suite is comprised of various checks to ensure everything is working and styled as expected.
-
-Before any tests can be run, create and migrate a test database: `RACK_ENV=test bundle exec rake db:setup db:migrate`
-
-The entire test suite can then be run with `bundle exec rake test:everything` or just `bundle exec rake` since `test:everthing` is the default Rake task.
-
-The current checks include:
-
-- [MiniTest](https://github.com/seattlerb/minitest) `rake test` or `rake test:minitest` - Ruby unit and feature tests
-- [RuboCop](https://github.com/bbatsov/rubocop) - `rake rubocop` - Ruby style enforcement
-- [Lineman Spec](http://linemanjs.com/) - `rake test:lineman` - Front-end tests
-
-To run a single Ruby test, you can do so with:
-
-```bash
-ruby path/to/the_test.rb
-```
-
-If it complains about dependencies, then either we forgot to require the correct dependencies (a distinct possibility), or we are depending on a particular tag of a gem installed directly from GitHub (this happens on occasion).
-
-If there's a git dependency, you can do this:
-
-```bash
-bundle exec ruby path/to/the_test.rb
-```
-
-For the require, you'll need to figure out what the missing dependency is. Feel free to [open a GitHub
-issue](https://github.com/exercism/exercism.io/issues). It's likely that someone familiar with the codebase will be able to identify the problem immediately.
-
-#### Test Order
-
-The tests are run in a randomized order by default. If you have an
-intermittent failure, it could be useful to seed the test suite with
-a specific value, in order to reproduce the test run.
-
-When running minitest directly, you can pass the seed value:
-
-```
-ruby path/to/the_test.rb --seed 1234
-```
-
-If running the entire test suite with rake, then you need to pass the options
-as an environment variable:
-
-```
-TESTOPTS="--seed=44377" rake test
-```
-
-#### Code Coverage
-
-To enable code coverage run:
-
-```bash
-COVERAGE=1 rake test
-```
-
-Browse the results located in `coverage/index.html`
-
-### Frontend Development Setup
-
-[Lineman](http://linemanjs.com) watches for file changes and compiles them automatically. It is not
-required to be running for the server to run though.
-
-* Install Lineman with: `npm install -g lineman`
-* To run: `cd frontend` and start Lineman with `lineman run`
-
-Lineman will compile your javascripts when you run `lineman run`, but before
-committing your code, make sure everything is compiled using:
-
-```bash
-cd frontend && lineman build
-```
-
-#### SCSS
-
-We use [Compass](http://compass-style.org/) for compiling Sass files.
-During development, you can run the compass watcher to keep your compiled CSS files up to date as changes are made.
-
-```bash
-bundle exec compass watch
-```
-
-Before committing, tell `compass` to compile the stylesheets for production use.
-
-```bash
-bundle exec compass compile -e production --force
-```
-
-For CSS we are using Sass (with `.scss`). Feel free to use [Bootstrap 3](http://getbootstrap.com) components and mixins. Or if you want to use even more mixins you can use [Compass](http://compass-style.org/reference/compass/). Structure wise we try to separate components, mixins and layouts. Where layouts should be a single page (using an HTML id as a selector) and components should be reusable partials, which can look different by layout.
-
-You can find the Compass configuration in `config.rb` in the project's root directory.
-
-#### Styleguide
-
-Our styleguide is under [/styleguide](http://exercism.io/styleguide) and built with [KSS](https://github.com/kneath/kss), which enables you to write examples to `*.scss` files.
-
-### Deployment
-
-Let Heroku know that Lineman will be building our assets. From the command line:
-```bash
-heroku config:set BUILDPACK_URL=https://github.com/testdouble/heroku-buildpack-lineman-ruby.git
-```
-
-#### Live deployment
-
-Live deployment of changes is done periodically by @kytrinyx
-
-To see which version is currently live visit http://exercism.io/version
-
-This will return a json string that looks like this:
-```json
-{"repository":"https://github.com/exercism/exercism.io","contributing":"https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md","build_id":"0ad66d9"}
-```
-The "build_id" is the git id of the revision that is live, which you can find in the list of commits https://github.com/exercism/exercism.io/commits/master . Any commits above that in the list are still waiting to be released.
-You can also go directly to the commit by replacing \[build_id\] in: https://github.com/exercism/exercism.io/commit/[build_id] with the hex value from the json above.
-
-Whenever a new version is released a message will appear in the sidebar of: https://gitter.im/exercism/dev  This is done via a Heroku webhook to a Gitter api endpoint. (You probably don't need to know this.)
 
 
 ## Write Some Code

--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -97,7 +97,7 @@ you'll need to do this manually.
 ## Run The Application
 
 * Start the server with: `foreman s -p 4567`
-* Sometimes you need to: `bundle exec foreman s -p 4567` (see [Troubleshooting](#troubleshooting) above)
+* Sometimes you need to run `bundle exec foreman s -p 4567` instead (see [Troubleshooting](#troubleshooting) above)
 * Then you can access the local server at [localhost:4567](http://localhost:4567).
 * You can log in as a test user using the `assume` dropdown menu on the top right of the page without creating any new user for the app.
 
@@ -121,7 +121,7 @@ problem, there's a task `db:heroku_seed` that can be used.
 ## Configuration
 ### GitHub OAuth
 
-If you seed your local database with fake users, then you can use these to "fake login" as
+Providing you seeded your local database with fake users, then you can use these to "fake login" as
 one of them. There will be a dropdown with identities that you can assume in development mode.
 
 If you want to actually work on the login flow, or if you want to log in as yourself, then
@@ -171,7 +171,7 @@ The test suite is comprised of various checks to ensure everything is working an
 
 Before any tests can be run, create and migrate a test database: `RACK_ENV=test bundle exec rake db:setup db:migrate`
 
-The entire test suite can then be run with `bundle exec rake test:everything` or just `bundle exec rake` since `test:everthing` is the default Rake task.
+The entire test suite can then be run with `bundle exec rake test:everything` or just `bundle exec rake` since `test:everything` is the default Rake task.
 
 The current checks include:
 

--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -17,11 +17,14 @@ Frontend:
 
 To install Ruby, check out [RVM](https://rvm.io), [rbenv](https://github.com/sstephenson/rbenv) or [ruby-install](https://github.com/postmodern/ruby-install).
 
-PostgreSQL can be installed with [Homebrew](http://brew.sh) on Mac OS X: `brew install postgresql`
-If you're on a Linux system with apt-get then run: `apt-get install postgresql postgresql-contrib`
+To install PostgreSQL:
+- For Mac OS X with [Homebrew](http://brew.sh), run: `brew install postgresql`
+- For Linux systems with apt-get, run: `apt-get install postgresql postgresql-contrib`
+- For Windows, download an installer from the [PostgreSQL website](https://www.postgresql.org/download/windows/)
 
-Install Node.js and npm on Mac OS X with Homebrew:  `brew install node`
-On other systems see the [Node.js docs](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
+To install Node.js and npm:
+- For Mac OS X with Homebrew, run: `brew install node`
+- For other systems, see the [Node.js docs](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
 
 ### To run the application inside a Vagrant virtual machine
 

--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -1,1 +1,286 @@
-*(This page needs to be written.  See [exercism/exercism.io#3251](https://github.com/exercism/exercism.io/issues/3251) for details.)*
+# Setting up local development
+
+This section walks you through getting the exercism.io app running locally.
+
+## Prerequisites
+
+Backend:
+
+- Ruby
+- PostgreSQL
+
+Frontend:
+
+- Node.js
+
+To install Ruby, check out [RVM](https://rvm.io), [rbenv](https://github.com/sstephenson/rbenv) or [ruby-install](https://github.com/postmodern/ruby-install).
+
+PostgreSQL can be installed with [Homebrew](http://brew.sh) on Mac OS X: `brew install postgresql`
+If you're on a Linux system with apt-get then run: `apt-get install postgresql postgresql-contrib`
+
+Install Node.js and npm on Mac OS X with Homebrew:  `brew install node`
+On other systems see the [Node.js docs](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
+
+## GitHub OAuth
+
+If you seed your local database with fake users, then you can use these to "fake login" as
+one of them. There will be a dropdown with identities that you can assume in development mode.
+
+If you want to actually work on the login flow, or if you want to log in as yourself, then
+you will need keys on GitHub that the app can talk to.
+
+Go to https://github.com/settings/applications/new and enter the following:
+
+* Application name: You can name it whatever you want, e.g. _Exercism (Dev)_.
+* Homepage URL: http://localhost:4567
+* Authorization callback URL: http://localhost:4567/github/callback
+
+Click _Register application_, and you'll see something like this:
+
+![](/docs/img/oauth-client-secret.png)
+
+Hang on to those. You'll need to add the **Client ID** and **Client Secret** to a
+configuration file in just a moment.
+
+## The Code
+
+If you're unfamiliar with git and GitHub, don't worry. We'll gladly help you out if you get stuck. GitHub also has some [helpful guides](https://guides.github.com) for getting started.
+
+First, you need to get ahold of the code, so you have a copy of it locally that you can make changes to.
+
+* [Fork](https://github.com/exercism/exercism.io/fork) this codebase to your own GitHub account.
+* Clone your fork, and change directory into the root of the exercism.io project.
+
+## Configuration
+
+In most cases, it is easiest to run the `bin/setup` script to automatically setup the defaults for the application. Make sure you have PostgreSQL running in the background.
+
+The script will:
+
+* setup the `.ruby-version` file for your Ruby version manager such as RVM, rbenv or chruby
+* copy the environment config to `.env`
+* run bundler to install the required gems
+* create the development database using the credentials in `config/database.yml`
+* download and seed the database with a good starting set of data
+* create the test database
+* run the test suite
+
+Then you'll need to:
+
+* Open `.env` and add the **Client ID** and **Client Secret** from the previous GitHub OAuth steps.
+
+All the commented out values in `.env` can be left alone for now.
+
+You don't need to fill in the EXERCISES_API value unless you're going to be working on the x-api codebase.
+
+## Data
+
+If you ran `bin/setup` you should be all set.
+
+You can easily reset an existing database to its original state and add the fake data in one step:
+
+* `rake db:reseed`
+
+If you need to set PostgreSQL parameters like the user and/or database name to use during setup, set `PGUSER` and/or `PGDATABASE` environment values respectively. Example: `PGUSER=pgsql PGDATABASE=postgres rake db:reseed`
+
+### Troubleshooting
+
+Note that you may have trouble running commands like `rake` or `pry` if your system has a different version of those gems than the Gemfile. In that case, you will need to prepend those commands with `bundle exec` so that bundler will execute that command in the context of the project's gems rather than your system's gems. If you would like to learn more about this topic and how to alias `bundle exec` (if you don't like typing it out each time), see [this article by Thoughtbot](https://robots.thoughtbot.com/but-i-dont-want-to-bundle-exec).
+
+To debug the database setup, do it step-by-step:
+
+* Create the PostgreSQL database: `rake db:setup`
+* Run the database migrations: `rake db:migrate`
+* Fetch the seed data: `rake db:seeds:fetch`
+* Seed the database: `rake db:seed`
+
+If you are having 'PG::Connection ...' or 'Peer authentication failed for user ...' issues you can follow these steps (this is assuming that you modified the database.yml file and your changes are not being accessed properly. Anywhere that it is stated "PGUSER=postgres" replace "postgres" with your specified username that you use for your postgresql databases):
+
+* Create the PostgreSQL database (this will prompt you to input a password allowing you to authenticate and create your databases that are specified in your database.yml file): `PGUSER=postgres rake db:create`
+* Run the database migrations: `rake db:migrate`
+* Fetch the seed data: `rake db:seeds:fetch`
+* Seed the database: `rake db:seed`
+
+The setup task will create a PostgreSQL user called exercism with super user permissions.
+If you want to avoid this you may create a user manually and add the needed extensions manually as well.
+
+The seed data gives you a bunch of fake user accounts with submissions in multiple languages as well
+as fake comments. In development mode there is an "Assume" menu item to the far right of the
+nav bar. This will let you easily assume different fake identities to see the site
+from their perspective.
+
+You may need to edit the `config/database.yml` file to specify non-default values. If you do, please edit (or create) a `.git/info/exclude` file so that your changes don't get committed. Unfortunately we have to commit the database.yml file, because heroku no longer creates a default one.
+
+Note that if you installed PostgreSQL on OS X with [Postgres.app](http://postgresapp.com/), you'll need to
+[configure your `$PATH`](http://postgresapp.com/documentation/cli-tools.html) in order for
+the database setup to complete successfully. `bin/setup` relies on PostgreSQL command line tools
+and as Postgres.app does not automatically add the application `bin` directory to your `$PATH`,
+you'll need to do this manually.
+
+## Run The Application
+
+* Start the server with: `foreman s -p 4567`
+* Sometimes you need to: `bundle exec foreman s -p 4567` (see [Troubleshooting](#troubleshooting) above)
+* Then you can access the local server at [localhost:4567](http://localhost:4567).
+* You can log in as a test user using the `assume` dropdown menu on the top right of the page without creating any new user for the app.
+
+To setup seed data to test out the application locally, use the rake
+tasks provided. You can get a list of all the rake tasks by running:
+
+    bundle exec rake -T
+
+To setup the seed data locally, run:
+
+    bundle exec rake db:seeds:fetch
+    bundle exec rake db:seed
+
+The first command fetches the seed file and places it under the `db/`
+folder as `seeds.sql`. Note that if you're deploying the application to
+Heroku, `db:seed` task might fail since the database config file won't
+contain the necessary details to access the database. To work around the
+problem, there's a task `db:heroku_seed` that can be used.
+
+
+## Running The Application In A Vagrant Environment
+_The following assumes your Vagrantfile is configured to forward port 3000 to 3030, adjust the port number to suit your environment_
+
+If you are using a different port than 3000 to forward outside of your Vagrant environment you will need to go into `Procfile_Vagrant` and adjust the port number that applies to your needs.
+
+* Copy the Vagrant Procfile example `cp Procfile_Vagrant.example Procfile_Vagrant`
+* Start the server with: `foreman s -f Procfile_Vagrant` (the `-f` explicitly states which Procfile to use and we don't want to use the original Procfile in our vagrant environments)
+* Sometimes you need to: `bundle exec foreman s -f Procfile_Vagrant`
+* Then you can access the local server at [localhost:3030](http://localhost:3030).
+* You can log in as a test user using the `assume` dropdown menu on the top right of the page without creating any new user for the app.
+
+_Again this is assuming you are forwarding port 3000 to 3030 in your Vagrantfile, adjust accordingly to your environment_
+
+## Console
+
+There's a script in `bin/console` that will load pry with the exercism environment loaded. You may need to run this file as `bundle exec bin/console` (see [Troubleshooting](#troubleshooting) above).
+This will let you poke around at the objects in the system, such as finding users and changing
+things about submissions or comments, making it easier to test specific things.
+
+```ruby
+user = User.find_by_username 'whatever'
+user.submissions
+```
+
+## Testing
+
+The test suite is comprised of various checks to ensure everything is working and styled as expected.
+
+Before any tests can be run, create and migrate a test database: `RACK_ENV=test bundle exec rake db:setup db:migrate`
+
+The entire test suite can then be run with `bundle exec rake test:everything` or just `bundle exec rake` since `test:everthing` is the default Rake task.
+
+The current checks include:
+
+- [MiniTest](https://github.com/seattlerb/minitest) `rake test` or `rake test:minitest` - Ruby unit and feature tests
+- [RuboCop](https://github.com/bbatsov/rubocop) - `rake rubocop` - Ruby style enforcement
+- [Lineman Spec](http://linemanjs.com/) - `rake test:lineman` - Front-end tests
+
+To run a single Ruby test, you can do so with:
+
+```bash
+ruby path/to/the_test.rb
+```
+
+If it complains about dependencies, then either we forgot to require the correct dependencies (a distinct possibility), or we are depending on a particular tag of a gem installed directly from GitHub (this happens on occasion).
+
+If there's a git dependency, you can do this:
+
+```bash
+bundle exec ruby path/to/the_test.rb
+```
+
+For the require, you'll need to figure out what the missing dependency is. Feel free to [open a GitHub
+issue](https://github.com/exercism/exercism.io/issues). It's likely that someone familiar with the codebase will be able to identify the problem immediately.
+
+### Test Order
+
+The tests are run in a randomized order by default. If you have an
+intermittent failure, it could be useful to seed the test suite with
+a specific value, in order to reproduce the test run.
+
+When running minitest directly, you can pass the seed value:
+
+```
+ruby path/to/the_test.rb --seed 1234
+```
+
+If running the entire test suite with rake, then you need to pass the options
+as an environment variable:
+
+```
+TESTOPTS="--seed=44377" rake test
+```
+
+### Code Coverage
+
+To enable code coverage run:
+
+```bash
+COVERAGE=1 rake test
+```
+
+Browse the results located in `coverage/index.html`
+
+## Frontend Development Setup
+
+[Lineman](http://linemanjs.com) watches for file changes and compiles them automatically. It is not
+required to be running for the server to run though.
+
+* Install Lineman with: `npm install -g lineman`
+* To run: `cd frontend` and start Lineman with `lineman run`
+
+Lineman will compile your javascripts when you run `lineman run`, but before
+committing your code, make sure everything is compiled using:
+
+```bash
+cd frontend && lineman build
+```
+
+### SCSS
+
+We use [Compass](http://compass-style.org/) for compiling Sass files.
+During development, you can run the compass watcher to keep your compiled CSS files up to date as changes are made.
+
+```bash
+bundle exec compass watch
+```
+
+Before committing, tell `compass` to compile the stylesheets for production use.
+
+```bash
+bundle exec compass compile -e production --force
+```
+
+For CSS we are using Sass (with `.scss`). Feel free to use [Bootstrap 3](http://getbootstrap.com) components and mixins. Or if you want to use even more mixins you can use [Compass](http://compass-style.org/reference/compass/). Structure wise we try to separate components, mixins and layouts. Where layouts should be a single page (using an HTML id as a selector) and components should be reusable partials, which can look different by layout.
+
+You can find the Compass configuration in `config.rb` in the project's root directory.
+
+### Styleguide
+
+Our styleguide is under [/styleguide](http://exercism.io/styleguide) and built with [KSS](https://github.com/kneath/kss), which enables you to write examples to `*.scss` files.
+
+## Deployment
+
+Let Heroku know that Lineman will be building our assets. From the command line:
+```bash
+heroku config:set BUILDPACK_URL=https://github.com/testdouble/heroku-buildpack-lineman-ruby.git
+```
+
+### Live deployment
+
+Live deployment of changes is done periodically by @kytrinyx
+
+To see which version is currently live visit http://exercism.io/version
+
+This will return a json string that looks like this:
+```json
+{"repository":"https://github.com/exercism/exercism.io","contributing":"https://github.com/exercism/exercism.io/blob/master/CONTRIBUTING.md","build_id":"0ad66d9"}
+```
+The "build_id" is the git id of the revision that is live, which you can find in the list of commits https://github.com/exercism/exercism.io/commits/master . Any commits above that in the list are still waiting to be released.
+You can also go directly to the commit by replacing \[build_id\] in: https://github.com/exercism/exercism.io/commit/[build_id] with the hex value from the json above.
+
+Whenever a new version is released a message will appear in the sidebar of: https://gitter.im/exercism/dev  This is done via a Heroku webhook to a Gitter api endpoint. (You probably don't need to know this.)

--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -1,4 +1,4 @@
-# Setting up local development
+# Setting up Local Development
 
 This section walks you through getting the exercism.io app running locally.
 

--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -15,7 +15,7 @@ Frontend:
 
 - Node.js
 
-To install Ruby, check out [RVM](https://rvm.io), [rbenv](https://github.com/sstephenson/rbenv) or [ruby-install](https://github.com/postmodern/ruby-install).
+To install Ruby, check out [RVM](https://rvm.io/rvm/install), [rbenv](https://github.com/rbenv/rbenv#installation) or [ruby-install](https://github.com/postmodern/ruby-install#install).
 
 To install PostgreSQL:
 - For Mac OS X with [Homebrew](http://brew.sh), run: `brew install postgresql`

--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -4,6 +4,8 @@ This section walks you through getting the exercism.io app running locally.
 
 ## Prerequisites
 
+### To run the application locally
+
 Backend:
 
 - Ruby
@@ -21,26 +23,19 @@ If you're on a Linux system with apt-get then run: `apt-get install postgresql p
 Install Node.js and npm on Mac OS X with Homebrew:  `brew install node`
 On other systems see the [Node.js docs](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
 
-## GitHub OAuth
+### To run the application inside a Vagrant virtual machine
 
-If you seed your local database with fake users, then you can use these to "fake login" as
-one of them. There will be a dropdown with identities that you can assume in development mode.
+_Skip this step if you are not using Vagrant. The following assumes your Vagrantfile is configured to forward port 3000 to 3030, adjust the port number to suit your environment._
 
-If you want to actually work on the login flow, or if you want to log in as yourself, then
-you will need keys on GitHub that the app can talk to.
+If you are using a different port than 3000 to forward outside of your Vagrant environment you will need to go into `Procfile_Vagrant` and adjust the port number that applies to your needs.
 
-Go to https://github.com/settings/applications/new and enter the following:
+* Copy the Vagrant Procfile example `cp Procfile_Vagrant.example Procfile_Vagrant`
+* Start the server with: `foreman s -f Procfile_Vagrant` (the `-f` explicitly states which Procfile to use and we don't want to use the original Procfile in our vagrant environments)
+* Sometimes you need to: `bundle exec foreman s -f Procfile_Vagrant`
+* Then you can access the local server at [localhost:3030](http://localhost:3030).
+* You can log in as a test user using the `assume` dropdown menu on the top right of the page without creating any new user for the app.
 
-* Application name: You can name it whatever you want, e.g. _Exercism (Dev)_.
-* Homepage URL: http://localhost:4567
-* Authorization callback URL: http://localhost:4567/github/callback
-
-Click _Register application_, and you'll see something like this:
-
-![](/docs/img/oauth-client-secret.png)
-
-Hang on to those. You'll need to add the **Client ID** and **Client Secret** to a
-configuration file in just a moment.
+_Again this is assuming you are forwarding port 3000 to 3030 in your Vagrantfile, adjust accordingly to your environment_
 
 ## The Code
 
@@ -51,7 +46,7 @@ First, you need to get ahold of the code, so you have a copy of it locally that 
 * [Fork](https://github.com/exercism/exercism.io/fork) this codebase to your own GitHub account.
 * Clone your fork, and change directory into the root of the exercism.io project.
 
-## Configuration
+## Setup
 
 In most cases, it is easiest to run the `bin/setup` script to automatically setup the defaults for the application. Make sure you have PostgreSQL running in the background.
 
@@ -64,24 +59,6 @@ The script will:
 * download and seed the database with a good starting set of data
 * create the test database
 * run the test suite
-
-Then you'll need to:
-
-* Open `.env` and add the **Client ID** and **Client Secret** from the previous GitHub OAuth steps.
-
-All the commented out values in `.env` can be left alone for now.
-
-You don't need to fill in the EXERCISES_API value unless you're going to be working on the x-api codebase.
-
-## Data
-
-If you ran `bin/setup` you should be all set.
-
-You can easily reset an existing database to its original state and add the fake data in one step:
-
-* `rake db:reseed`
-
-If you need to set PostgreSQL parameters like the user and/or database name to use during setup, set `PGUSER` and/or `PGDATABASE` environment values respectively. Example: `PGUSER=pgsql PGDATABASE=postgres rake db:reseed`
 
 ### Troubleshooting
 
@@ -141,18 +118,41 @@ contain the necessary details to access the database. To work around the
 problem, there's a task `db:heroku_seed` that can be used.
 
 
-## Running The Application In A Vagrant Environment
-_The following assumes your Vagrantfile is configured to forward port 3000 to 3030, adjust the port number to suit your environment_
+## Configuration
+### GitHub OAuth
 
-If you are using a different port than 3000 to forward outside of your Vagrant environment you will need to go into `Procfile_Vagrant` and adjust the port number that applies to your needs.
+If you seed your local database with fake users, then you can use these to "fake login" as
+one of them. There will be a dropdown with identities that you can assume in development mode.
 
-* Copy the Vagrant Procfile example `cp Procfile_Vagrant.example Procfile_Vagrant`
-* Start the server with: `foreman s -f Procfile_Vagrant` (the `-f` explicitly states which Procfile to use and we don't want to use the original Procfile in our vagrant environments)
-* Sometimes you need to: `bundle exec foreman s -f Procfile_Vagrant`
-* Then you can access the local server at [localhost:3030](http://localhost:3030).
-* You can log in as a test user using the `assume` dropdown menu on the top right of the page without creating any new user for the app.
+If you want to actually work on the login flow, or if you want to log in as yourself, then
+you will need keys on GitHub that the app can talk to.
 
-_Again this is assuming you are forwarding port 3000 to 3030 in your Vagrantfile, adjust accordingly to your environment_
+Go to https://github.com/settings/applications/new and enter the following:
+
+* Application name: You can name it whatever you want, e.g. _Exercism (Dev)_.
+* Homepage URL: http://localhost:4567
+* Authorization callback URL: http://localhost:4567/github/callback
+
+Click _Register application_, and you'll see something like this:
+
+![](/docs/img/oauth-client-secret.png)
+
+Now you can open `.env` and add the **Client ID** and **Client Secret** values.
+
+All the commented out values in `.env` can be left alone for now.
+
+You don't need to fill in the EXERCISES_API value unless you're going to be working on the x-api codebase.
+
+## Data
+
+If you ran `bin/setup` you should be all set.
+
+You can easily reset an existing database to its original state and add the fake data in one step:
+
+* `rake db:reseed`
+
+If you need to set PostgreSQL parameters like the user and/or database name to use during setup, set `PGUSER` and/or `PGDATABASE` environment values respectively. Example: `PGUSER=pgsql PGDATABASE=postgres rake db:reseed`
+
 
 ## Console
 

--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -65,18 +65,13 @@ The script will:
 
 ### Troubleshooting
 
-Note that you may have trouble running commands like `rake` or `pry` if your system has a different version of those gems than the Gemfile. In that case, you will need to prepend those commands with `bundle exec` so that bundler will execute that command in the context of the project's gems rather than your system's gems. If you would like to learn more about this topic and how to alias `bundle exec` (if you don't like typing it out each time), see [this article by Thoughtbot](https://robots.thoughtbot.com/but-i-dont-want-to-bundle-exec).
+#### Command not found errors
+You may have trouble running commands like `rake` or `pry` if your system has a different version of those gems than the Gemfile. In that case, you will need to prepend those commands with `bundle exec` so that bundler will execute that command in the context of the project's gems rather than your system's gems. If you would like to learn more about this topic and how to alias `bundle exec` (if you don't like typing it out each time), see [this article by Thoughtbot](https://robots.thoughtbot.com/but-i-dont-want-to-bundle-exec).
 
+#### Database errors
 To debug the database setup, do it step-by-step:
 
-* Create the PostgreSQL database: `rake db:setup`
-* Run the database migrations: `rake db:migrate`
-* Fetch the seed data: `rake db:seeds:fetch`
-* Seed the database: `rake db:seed`
-
-If you are having 'PG::Connection ...' or 'Peer authentication failed for user ...' issues you can follow these steps (this is assuming that you modified the database.yml file and your changes are not being accessed properly. Anywhere that it is stated "PGUSER=postgres" replace "postgres" with your specified username that you use for your postgresql databases):
-
-* Create the PostgreSQL database (this will prompt you to input a password allowing you to authenticate and create your databases that are specified in your database.yml file): `PGUSER=postgres rake db:create`
+* Create the PostgreSQL database and user: `rake db:setup`
 * Run the database migrations: `rake db:migrate`
 * Fetch the seed data: `rake db:seeds:fetch`
 * Seed the database: `rake db:seed`
@@ -89,13 +84,21 @@ as fake comments. In development mode there is an "Assume" menu item to the far 
 nav bar. This will let you easily assume different fake identities to see the site
 from their perspective.
 
-You may need to edit the `config/database.yml` file to specify non-default values. If you do, please edit (or create) a `.git/info/exclude` file so that your changes don't get committed. Unfortunately we have to commit the database.yml file, because heroku no longer creates a default one.
-
 Note that if you installed PostgreSQL on OS X with [Postgres.app](http://postgresapp.com/), you'll need to
 [configure your `$PATH`](http://postgresapp.com/documentation/cli-tools.html) in order for
 the database setup to complete successfully. `bin/setup` relies on PostgreSQL command line tools
 and as Postgres.app does not automatically add the application `bin` directory to your `$PATH`,
 you'll need to do this manually.
+
+You need to edit the `config/database.yml` file to specify non-default values. If you do, please edit (or create) a `.git/info/exclude` file so that your changes don't get committed. Unfortunately we have to commit the `config/database.yml` file, because heroku no longer creates a default one.
+
+##### Changing the default database user
+If you have created a user and are having `PG::Connection ...` or `Peer authentication failed for user ...` issues, you can follow these steps (anywhere that it is stated `PGUSER=postgres` replace `postgres` with your specified username that you use for your postgresql databases):
+
+* Create the PostgreSQL database (this will prompt you to input the password): `PGUSER=postgres rake db:create`
+* Run the database migrations: `rake db:migrate`
+* Fetch the seed data: `rake db:seeds:fetch`
+* Seed the database: `rake db:seed`
 
 ## Run The Application
 


### PR DESCRIPTION
Move this from `CONTRIBUTING.md` to `docs/setting-up-development.md`, so that it's 
easier to understand and link to.

I've also reordered some of the sections in it to make it easier to get to the point where you have the app running.

See issue https://github.com/exercism/exercism.io/issues/3251
