### PR TITLE
Fix mis-aligned copy/expand buttons

### DIFF
--- a/app/views/submissions/current_submission.erb
+++ b/app/views/submissions/current_submission.erb
@@ -32,7 +32,9 @@
     <div class="clearfix"></div>
     </div>
 
+    <div class="submission-code-body">
       <%= syntax(code, submission.track_id) %>
+    </div>
 
       <div id="submission-code-<%= idx %>" class="hidden" ng-non-bindable><%= h code %></div>
     <% end %>

--- a/public/sass/layouts/submission.scss
+++ b/public/sass/layouts/submission.scss
@@ -94,6 +94,7 @@
     margin-top: 10px;
     .code {
       .highlight {
+        border-top-right-radius: 0;
         padding: 0px;
       }
 
@@ -127,17 +128,18 @@
     @include blockquote_style;
   }
   .submission-code-header {
-    position: relative;
+    margin-top: 25px;
   }
   .submission-code-filename {
-    display: block;
+    display: inline;
+    h4 {
+      display: inline;
+    }
   }
   .submission-code-actions {
-    position: absolute;
-    right: 0;
-    bottom: -1.25px;
     .btn {
       border-radius: 0px;
+      border-bottom-width: 0;
     }
   }
   .comments {


### PR DESCRIPTION
In #3287 I shouldn't have used absolute positioning for the buttons because it doesn't play nice when the browser window is zoomed.
![miss](https://cloud.githubusercontent.com/assets/2099793/20867760/ff48dda0-ba19-11e6-8bf4-3699341f0470.png)

![missed](https://cloud.githubusercontent.com/assets/2099793/20867768/085557fc-ba1a-11e6-8798-7d38f6961037.png)
I removed the absolute positioning and the bottom border of the buttons, so it will align correctly at any zoom level.

This is the before:  
![before](https://cloud.githubusercontent.com/assets/2099793/20867771/11b621be-ba1a-11e6-814f-6cd111ce9662.png)

This is after:  
![after](https://cloud.githubusercontent.com/assets/2099793/20867774/16ea8562-ba1a-11e6-8572-e1a6490d7925.png)

Here is a close up. I also removed the little radius on the top right corner of the code block window.
![fixed](https://cloud.githubusercontent.com/assets/2099793/20867787/4170f0e6-ba1a-11e6-90e3-60a69f0d9e24.png)

Let me know if this looks okay or if you have any suggestions.
Thanks!