### PR TITLE
Make titles for Mac OSX and Windows docs more consistent

### DIFF
--- a/x/docs/md/cli/mac.md
+++ b/x/docs/md/cli/mac.md
@@ -6,31 +6,33 @@ Below are instructions for install using the most common method - using Homebrew
 2. [exercism.io general help](http://exercism.io/help)
 3. [join the exercism.io chat on gitter](https://gitter.im/exercism/support): [![Join the chat at https://gitter.im/exercism/support](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/exercism/support)
 
-### Installing With Homebrew
+### Installing Homebrew
 
-#### 1: Check For Homebrew
+If you already have Homebrew installed, feel free to skip to the [Exercism CLI installation](#install-exercism-cli).
 
-Homebrew is a package manager for OS X which installs the stuff that Apple didn't.
-Find out if you have homebrew installed via the terminal.
+Homebrew is a package manager for OS X which installs the stuff that Apple didn't. Find out if you have Homebrew installed via the terminal.
 
-You can open a terminal using Spotlight with the keys: 'command + space', and then type 'terminal' in the space provided.
-On the command prompt, type in the command:
+You can open a terminal using Spotlight with the keys: 'command + space', and then type 'terminal' in the space provided. On the command prompt, type in the command:
 
 ```bash
 brew --version
 ```
 
-If homebrew is installed you may see output like the following (version numbers may vary):
+If Homebrew is installed you may see an output like the following (version numbers may vary):
+
 ```
 Homebrew 0.9.9 (git revision a5586; last commit 2016-05-09)
 Homebrew/homebrew-core (git revision 3b4c; last commit 2016-05-09)
 ```
-If homebrew isn't installed, you can:
-1. install via [homebrew's brew.sh site](http://brew.sh/)
-2. see [Install Alternatives for instructions on installing without homebrew](/cli/install)
 
-#### 2: Install Homebrew
-Install the CLI via homebrew with the following command:
+If Homebrew isn't installed, you can:
+
+1. install via [Homebrew's brew.sh site](http://brew.sh/)
+2. see [Install Alternatives for instructions on installing without Homebrew](/cli/install)
+
+### Installing the Exercism CLI <a name="install-exercism-cli"></a>
+
+Once you have Homebrew installed, you can install the Exercism CLI with the following command:
 
 ```bash
 brew update && brew install exercism
@@ -44,20 +46,13 @@ exercism --version
 
 If there was a problem you will get an error message saying command not found.
 
-#### 3: Verify Installation
-Verify that the binary was installed properly by running:
-
-```bash
-exercism --version
-```
-
 To see all the commands available to you, run `exercism` without any options:
 
 ```bash
 exercism
 ```
 
-#### 4: Configure the CLI
+### Configuring the Exercism CLI
 
 Configure the exercism client so that it knows which account to post your solutions to:
 
@@ -73,23 +68,22 @@ You can configure a different directory by passing the `--dir` option:
 ```bash
 exercism configure --dir=~/some/other/place
 ```
-#### 5: Continue
+
+### Continue
+
 You can now continue by [choosing a language](http://exercism.io/languages).
 
 ### Removing Exercism CLI
 
-With Homebrew
+#### With Homebrew
 
-If you wish to remove your exercism config file, you will need to
-locate it before uninstalling the cli
-
-You can locate it by running
+If you wish to remove your exercism config file, you will need to locate it before uninstalling the cli. You can locate it by running:
 
 ```bash
 exercism debug
 ```
 
-Then go ahead and remove this file with
+Then go ahead and remove this file with:
 
 ```bash
 rm /path/to/config/file
@@ -100,5 +94,3 @@ You can remove the exercism cli with:
 ```bash
 brew uninstall exercism
 ```
-
-


### PR DESCRIPTION
When looking at the docs for setting up the CLI in Mac OSX and Windows, I noticed that the titles in both pages were formatted differently and the phrasing for part of the content was slightly different as well. Additionally, some of the titles in the Mac OSX were a bit misleading (like `#### 2: Install Homebrew`) and some of the content was duplicated.

This PR is an attempt to remove these minor errors and bring both pages closer together.