### PR TITLE
Only store comment in localstorage if it has changed

### DIFF
--- a/frontend/app/js/app.coffee
+++ b/frontend/app/js/app.coffee
@@ -54,9 +54,12 @@ loadCommentFromStorage = () ->
   $('#submission_comment').val(localStorage.getItem(location.pathname))
 
 recordText = () ->
+  comment = localStorage.getItem(location.pathname)
   $('#submission_comment').keyup (event) ->
     text = $(this).val()
-    localStorage.setItem(location.pathname, text)
+    unless comment == text
+      comment = text
+      localStorage.setItem(location.pathname, text)
 
 initCommentMemory = () ->
   if localStorageHasKey(location.pathname)


### PR DESCRIPTION
A bug was identified (https://github.com/exercism/exercism.io/issues/3289) where a comment persists in localstorage after submitting. This occurs due to the keydown event to submit and clear localstorage, firing before the keyup event that stores the comment in localstorage. This is somewhat difficult to test locally as you need to insert a `sleep` method into `app/routes/comments.rb` to ensure the server takes sufficiently long to respond that `keyup` has time to execute.

To resolve this we only store a comment if it has changed, which is not the case with a submission.