### PR TITLE
Serve minified JS + a little ❤️ for lineman

### DIFF
--- a/frontend/config/application.coffee
+++ b/frontend/config/application.coffee
@@ -8,8 +8,8 @@
 
 module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application', {
   removeTasks:
-    common: ["copy:dev", "webfonts:dev", "images:dev"]
-    dist: ["images:dist", "webfonts:dist", "pages:dist"]
+    common: ["copy:dev", "webfonts:dev", "images:dev", "concat_sourcemap", "pages:dev"]
+    dist: ["images:dist", "webfonts:dist", "pages:dist", "cssmin"]
 
   server:
     apiProxy:
@@ -27,6 +27,9 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
     dev: ["copy:dev"]
     dist: ["ngmin"]         # ngmin should run in dist only
 
+  appendTasks:
+    common: ["concat_sourcemap:js", "concat_sourcemap:spec"],
+
   watch:
     scripts:
       files: ["generated/**"],
@@ -34,8 +37,8 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
 
   copy:
     dev:
-      files: [expand: true, cwd: 'generated', src: ['css/**', 'js/**', '!**/spec.js',
-              '!**/*.less*', '!**/*.coffee*', '!**/spec.js.map'], dest: '../public' ]
+      files: [expand: true, cwd: 'generated', src: ['js/**', '!**/spec.js',
+              '!**/*.coffee*', '!**/spec.js.map'], dest: '../public' ]
     dist:
       files: [expand: true, cwd: 'dist', src: ['js/**'], dest: '../public']
 

--- a/frontend/config/application.coffee
+++ b/frontend/config/application.coffee
@@ -32,21 +32,28 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
 
   watch:
     scripts:
-      files: ['generated/**'],
+      files: ['generated/**']
       tasks: ['copy:dev']
 
   copy:
     dev:
-      files: [expand: true, cwd: 'generated', src: ['js/**', '!**/spec.js',
-              '!**/*.coffee*', '!**/spec.js.map'], dest: '../public' ]
+      files: [
+        expand: true
+        cwd: 'generated'
+        src: ['js/**', '!**/spec.js', '!**/*.coffee*', '!**/spec.js.map']
+        dest: '../public'
+      ]
     dist:
-      files: [expand: true, cwd: 'dist', src: ['js/**'], dest: '../public']
+      files: [
+        expand: true
+        cwd: 'dist'
+        src: ['js/**']
+        dest: '../public'
+      ]
 
   # configuration for grunt-ngmin, this happens _after_ concat once, which is the ngmin ideal :)
-  ngmin: {
-    js: {
-      src: '<%= files.js.concatenated %>',
+  ngmin:
+    js:
+      src: '<%= files.js.concatenated %>'
       dest: '<%= files.js.concatenated %>'
-    }
-  },
 })

--- a/frontend/config/application.coffee
+++ b/frontend/config/application.coffee
@@ -56,4 +56,12 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
     js:
       src: '<%= files.js.concatenated %>'
       dest: '<%= files.js.concatenated %>'
+
+  uglify:
+    options:
+      banner: "<%= meta.banner %>"
+      sourceMap: "<%= files.js.minified %>.map"
+      sourceMapIn: "<%= files.js.concatenated %>.map"
+      sourceMappingURL: "<%= files.js.sourceMapUrl %>"
+
 })

--- a/frontend/config/application.coffee
+++ b/frontend/config/application.coffee
@@ -8,7 +8,7 @@
 
 module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application', {
   removeTasks:
-    common: [ "webfonts:dev", "images:dev"]
+    common: ["copy:dev", "webfonts:dev", "images:dev"]
     dist: ["images:dist", "webfonts:dist", "pages:dist"]
 
   server:
@@ -24,6 +24,7 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
 
   # task override configuration
   prependTasks:
+    dev: ["copy:dev"]
     dist: ["ngmin"]         # ngmin should run in dist only
 
   watch:

--- a/frontend/config/application.coffee
+++ b/frontend/config/application.coffee
@@ -8,8 +8,8 @@
 
 module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application', {
   removeTasks:
-    common: ["copy:dev", "webfonts:dev", "images:dev", "concat_sourcemap", "pages:dev"]
-    dist: ["images:dist", "webfonts:dist", "pages:dist", "cssmin"]
+    common: ['copy:dev', 'webfonts:dev', 'images:dev', 'concat_sourcemap', 'pages:dev']
+    dist: ['images:dist', 'webfonts:dist', 'pages:dist', 'cssmin']
 
   server:
     apiProxy:
@@ -20,19 +20,19 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
   # enableSass: true
 
   # configure lineman to load additional angular related npm tasks
-  loadNpmTasks: [ "grunt-ngmin"]
+  loadNpmTasks: ['grunt-ngmin']
 
   # task override configuration
   prependTasks:
-    dev: ["copy:dev"]
-    dist: ["ngmin"]         # ngmin should run in dist only
+    dev: ['copy:dev']
+    dist: ['ngmin']         # ngmin should run in dist only
 
   appendTasks:
-    common: ["concat_sourcemap:js", "concat_sourcemap:spec"],
+    common: ['concat_sourcemap:js', 'concat_sourcemap:spec'],
 
   watch:
     scripts:
-      files: ["generated/**"],
+      files: ['generated/**'],
       tasks: ['copy:dev']
 
   copy:
@@ -45,8 +45,8 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
   # configuration for grunt-ngmin, this happens _after_ concat once, which is the ngmin ideal :)
   ngmin: {
     js: {
-      src: "<%= files.js.concatenated %>",
-      dest: "<%= files.js.concatenated %>"
+      src: '<%= files.js.concatenated %>',
+      dest: '<%= files.js.concatenated %>'
     }
   },
 })

--- a/frontend/config/application.coffee
+++ b/frontend/config/application.coffee
@@ -35,6 +35,8 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('application
     dev:
       files: [expand: true, cwd: 'generated', src: ['css/**', 'js/**', '!**/spec.js',
               '!**/*.less*', '!**/*.coffee*', '!**/spec.js.map'], dest: '../public' ]
+    dist:
+      files: [expand: true, cwd: 'dist', src: ['js/**'], dest: '../public']
 
   # configuration for grunt-ngmin, this happens _after_ concat once, which is the ngmin ideal :)
   ngmin: {

--- a/frontend/config/files.coffee
+++ b/frontend/config/files.coffee
@@ -2,7 +2,7 @@
  #  all of the paths & globs that the project
  #  is concerned with.
  #
- # The "configure" task will require this file and
+ # The 'configure' task will require this file and
  #  then re-initialize the grunt config such that
  #  directives like <config:files.js.app> will work
  #  regardless of the point you're at in the build
@@ -15,28 +15,28 @@
 module.exports = require(process.env['LINEMAN_MAIN']).config.extend('files', {
   js:
     vendor: [
-      "vendor/js/**/*jquery*",
-      "vendor/js/**/underscore.js",
-      "vendor/js/**/angular.js",
-      "vendor/js/**/moment.min.js",
-      "vendor/js/**/moment-timezone-with-data-2010-2020.min.js",
-      "vendor/js/**/*.js",
+      'vendor/js/**/*jquery*',
+      'vendor/js/**/underscore.js',
+      'vendor/js/**/angular.js',
+      'vendor/js/**/moment.min.js',
+      'vendor/js/**/moment-timezone-with-data-2010-2020.min.js',
+      'vendor/js/**/*.js',
     ]
     app: [
-      "app/js/namespace.js",
-      "app/js/**/*.js"
+      'app/js/namespace.js',
+      'app/js/**/*.js'
     ]
 
   coffee:
     app: [
-      "app/js/**/namespace.coffee",
-      "app/js/**/*.coffee"
+      'app/js/**/namespace.coffee',
+      'app/js/**/*.coffee'
     ]
 
   css:
     vendor: [
-      "vendor/css/bootstrap.css",
-      "vendor/css/bootstrap-responsive.css",
-      "vendor/css/**/*.css",
+      'vendor/css/bootstrap.css',
+      'vendor/css/bootstrap-responsive.css',
+      'vendor/css/**/*.css',
     ]
 })

--- a/frontend/config/files.coffee
+++ b/frontend/config/files.coffee
@@ -26,6 +26,7 @@ module.exports = require(process.env['LINEMAN_MAIN']).config.extend('files', {
       'app/js/namespace.js',
       'app/js/**/*.js'
     ]
+    sourceMapUrl: "/js/app.js.map"
 
   coffee:
     app: [


### PR DESCRIPTION
Should resolve: https://github.com/exercism/exercism.io/issues/3261

I noticed that that although the minified JS files are being generated they are not being copied into the /public directory. So I've set that up and turned off copying the dev assets as part of a dist build to stop that happening in future.

I've also done a bit of cleaning up in Lineman, by removing CSS (since compass is taking care of that) and cleaning up quotes and coffeescript.

There's scope for a fair bit more cleaning up and getting more out of lineman / asset set up.