### PR TITLE
Exclude archived exercises from activity stream

### DIFF
--- a/lib/exercism/track_stream_filters.rb
+++ b/lib/exercism/track_stream_filters.rb
@@ -105,6 +105,8 @@ class TrackStream
           AND ex.slug=mark.slug
           AND acls.user_id=mark.user_id
         WHERE acls.user_id=#{viewer_id}
+          AND ex.archived='f'
+          AND ex.iteration_count > 0
           AND mark.at > ex.last_activity_at
         GROUP BY ex.language
       SQL


### PR DESCRIPTION
The `unread` badges in the activity stream sidebar menu disappear after clicking `mark all as read`. Even after new submissions and iterations are added, the badges don't reappear if there are any (unlocked) archived submissions anywhere in that track. After clicking `mark all as read` the `watermarked` query returns every submission in the track-unlocked-problem group, even archived ones. So if there are 10 archived submissions the number unread is calculated as -10. The `unread` badge is hidden when its less than one. It will stay hidden until 11 new submissions are added, and then it will display 1 instead of 11.

Excluding the archived submissions from the `watermarked query` seems to fix the issue, at least in my testing in the development environment. 

Resolves: #3295