### PR TITLE
Keep submission window in view when expanded

### DIFF
--- a/frontend/app/js/script.js
+++ b/frontend/app/js/script.js
@@ -22,6 +22,8 @@ $(function() {
     commentsDiv.addClass($(this).data("new-class"));
     $("a[data-action='enlarge']",codeDiv).hide();
     $("a[data-action='shrink']",codeDiv).show();
+    window.scrollBy(0, $('.code').offset().top -
+                       $('.theiaStickySidebar').offset().top);
   });
 
   $(".code a[data-action='shrink']").on("click",function() {


### PR DESCRIPTION
Toggling the current submission layout between side-by-side
code/comments and full-width code/comments scrolls the browser
window as necessary to keep the code in view.

Resolves #3288