### PR TITLE
Add feature to dismiss invitations as a manager.

### DIFF
--- a/app/routes/invitations.rb
+++ b/app/routes/invitations.rb
@@ -12,6 +12,16 @@ module ExercismWeb
         end
       end
 
+      delete '/teams/:slug/invitation/:username' do |slug, username|
+        please_login
+        only_for_team_managers(slug, "You are not allowed to add team members.") do |team|
+          team.dismiss_invitation(username)
+
+          flash[:success] = "#{username} removed from team #{slug} invitations"
+          redirect "/teams/#{slug}/manage"
+        end
+      end
+
       post '/teams/:slug/invitation/accept' do |slug|
         please_login
         only_with_existing_team(slug) do |team|

--- a/app/views/teams/manage.erb
+++ b/app/views/teams/manage.erb
@@ -138,7 +138,7 @@
         <% team.member_invites.each do |member| %>
           <div class="col-sm-3">
             <a href="#" data-username="<%= member.username %>" data-team="<%= team.slug %>"
-            class="btn btn-xs btn-danger member_delete" style="margin: 10px 10px 10px 0">X</a>
+            class="btn btn-xs btn-danger invite_dismiss" style="margin: 10px 10px 10px 0">X</a>
             <%= gravatar_tag member.avatar_url, size: 20 %>
             <a href="/<%= member.username %>"><%= member.username %></a>
           </div>

--- a/frontend/app/js/app.coffee
+++ b/frontend/app/js/app.coffee
@@ -33,6 +33,13 @@ $ ->
     if confirm("Are you sure you want to remove #{username} as a member?")
       dismissTeamMember(username, slug)
 
+  $('.invite_dismiss').on 'click', ->
+    username = $(@).data('username')
+    slug = $(@).data('team')
+
+    if confirm("Are you sure you want to dismiss invitation to #{username}?")
+      dismissInvitation(username, slug)
+
   $('#destroy_team').on 'click', ->
     slug = $(@).data('team')
 
@@ -74,9 +81,16 @@ destroyTeam = (slug) ->
   form.hide().append(method_input).appendTo('body')
   form.submit()
 
-
 dismissTeamMember = (username, slug) ->
   href = "/teams/#{slug}/members/#{username}"
+  form = $('<form method="post" action="' + href + '"></form>')
+  method_input = '<input name="_method" value="delete" type="hidden"/>'
+
+  form.hide().append(method_input).appendTo('body')
+  form.submit()
+
+dismissInvitation = (username, slug) ->
+  href = "/teams/#{slug}/invitation/#{username}"
   form = $('<form method="post" action="' + href + '"></form>')
   method_input = '<input name="_method" value="delete" type="hidden"/>'
 

--- a/lib/exercism/team.rb
+++ b/lib/exercism/team.rb
@@ -80,6 +80,13 @@ class Team < ActiveRecord::Base
     end
   end
 
+  def dismiss_invitation(username)
+    user = User.find_by(username: username)
+    return if user.nil?
+
+    TeamMembershipInvite.where(user: user, team: self).destroy_all
+  end
+
   def dismiss(username)
     user = User.find_by_username(username)
     return if user.nil?

--- a/test/exercism/team_membership_invite_test.rb
+++ b/test/exercism/team_membership_invite_test.rb
@@ -37,4 +37,20 @@ class TeamMembershipInviteTest < Minitest::Test
     membership_invite.refuse!
     assert membership_invite.refused?
   end
+
+  def test_retract_invitation
+    team = Team.by(alice).defined_with(slug: 'retract')
+    team.save
+
+    membership_invite = TeamMembershipInvite.new(team: team, user: bob, inviter: alice)
+    membership_invite.save
+
+    assert_equal 1, TeamMembershipInvite.count
+    assert_equal 1, bob.team_membership_invites.count
+
+    team.dismiss_invitation('bob')
+
+    assert_equal 0, TeamMembershipInvite.count
+    assert_equal 0, bob.team_membership_invites.count
+  end
 end


### PR DESCRIPTION
We currently list invitations, but don't allow dismissing them. This PR
aims to solve this and add the ability dismiss invitations before they are
accepted.

Fixes #3185 

**The full credit goes to @MohanL.** ❤️ 