### PR TITLE
Do not invite manager as member when creating a team.

### DIFF
--- a/app/routes/teams.rb
+++ b/app/routes/teams.rb
@@ -31,10 +31,14 @@ module ExercismWeb
       # Create a new team.
       post '/teams/new' do
         please_login
+
         team = Team.by(current_user).defined_with(params[:team], current_user)
+        usernames_invited = params[:team].fetch('usernames', '')
+
         if team.valid?
-          team.save
+          team.save!
           TeamMembership.create(team: team, user: current_user, inviter: current_user, confirmed: true)
+          team.invite_with_usernames(usernames_invited, current_user)
           redirect "/teams/#{team.slug}/directory"
         else
           erb :"teams/new", locals: { team: team }

--- a/lib/exercism/team.rb
+++ b/lib/exercism/team.rb
@@ -56,10 +56,6 @@ class Team < ActiveRecord::Base
     tags = [options[:slug], options[:name], options[:tags]].join(',')
     self.tags = Tag.create_from_text(tags)
 
-    users = User.find_or_create_in_usernames(potential_members(options[:usernames])) if options[:usernames]
-    users = options[:users] if options[:users]
-    invite(users, inviter)
-
     self
   end
 

--- a/test/acceptance/profile_test.rb
+++ b/test/acceptance/profile_test.rb
@@ -29,8 +29,10 @@ class ProfileTest < AcceptanceTestCase
 
   def test_display_team_invites_only_in_users_own_profile
     new_user = create_user(username: 'new_user', github_id: 456)
-    attributes = { slug: 'some-team', name: 'Some Name', usernames: 'new_user' }
-    Team.by(@user).defined_with(attributes, @user).save!
+
+    team = Team.by(@user).defined_with({ slug: 'some-team', name: 'Some Name' }, @user)
+    team.save!
+    team.invite_with_usernames(new_user.username, @user)
 
     with_login(@user) do
       visit "/#{new_user.username}"

--- a/test/acceptance/team_test.rb
+++ b/test/acceptance/team_test.rb
@@ -5,8 +5,10 @@ class TeamAcceptanceTest < AcceptanceTestCase
     creating_user = create_user(username: 'creating_user')
     joining_user = create_user(username: 'joining_user', github_id: 123)
 
-    attributes = { slug: 'some-team', name: 'Some Name', usernames: 'joining_user' }
-    Team.by(creating_user).defined_with(attributes, creating_user).save!
+    attributes = { slug: 'some-team', name: 'Some Name' }
+    team = Team.by(creating_user).defined_with(attributes, creating_user)
+    team.save!
+    team.invite_with_usernames(joining_user.username, creating_user)
 
     with_login(joining_user) do
       click_on 'Account'

--- a/test/app/invitations_test.rb
+++ b/test/app/invitations_test.rb
@@ -62,8 +62,10 @@ class InvitationsTest < Minitest::Test
   end
 
   def test_user_must_be_manager
-    team = Team.by(alice).defined_with(slug: 'abc', usernames: bob.username)
+    team = Team.by(alice).defined_with(slug: 'abc')
     team.save
+
+    team.invite_with_usernames(bob.username, alice)
     TeamMembershipInvite.pending.find_by(user: bob, team: team).accept!
 
     verb, path, action = [:post, '/teams/abc/invitations', "invite members"]
@@ -90,9 +92,10 @@ class InvitationsTest < Minitest::Test
   end
 
   def test_only_managers_can_invite_members
-    team = Team.by(alice).defined_with(slug: 'members', usernames: bob.username)
+    team = Team.by(alice).defined_with(slug: 'members')
     team.save
 
+    team.invite_with_usernames(bob.username, alice)
     post "/teams/#{team.slug}/invitations", { usernames: charlie.username }, login(bob)
 
     team.reload

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -89,11 +89,15 @@ class UserTest < Minitest::Test
     alice = User.create(username: 'alice')
     bob = User.create(username: 'bob')
 
-    team = Team.by(alice).defined_with({ slug: 'team a', usernames: bob.username }, alice)
-    other_team = Team.by(alice).defined_with({ slug: 'team b', usernames: bob.username }, alice)
+    team = Team.by(alice).defined_with({ slug: 'team a' }, alice)
+    other_team = Team.by(alice).defined_with({ slug: 'team b' }, alice)
 
     team.save
     other_team.save
+
+    team.invite_with_usernames(bob.username, alice)
+    other_team.invite_with_usernames(bob.username, alice)
+
     TeamMembershipInvite.where(user: bob).first.accept!
 
     assert TeamMembership.exists?(team: team, user: bob, inviter: alice), 'Confirmed TeamMembership for bob was created.'


### PR DESCRIPTION
Fixes #3110 

Right now the manager is already being added as a member, so we don't need to send the invite.

To solve the problem we have to make sure that the team is created properly and the manager is added as manager before inviting members from the usernames list.