### PR TITLE
Add endpoint supporting arbitrary track images

### DIFF
--- a/api/v1/routes/tracks.rb
+++ b/api/v1/routes/tracks.rb
@@ -20,6 +20,15 @@ module ExercismAPI
           halt 500, { error: "Something went wrong, and it's not clear what it was. The error has been sent to our tracker. If you want to get involved, post an issue to GitHub so we can figure it out! https://github.com/exercism/exercism.io/issues" }.to_json
         end
       end
+
+      get '/tracks/:id/images/*' do |id, path|
+        image = Trackler.tracks[id].img(path)
+        if image.exists?
+          send_file image.path, type: image.type
+        else
+          halt 404
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
At the moment we've got broken images in the track documentation pages. We've been working around it by referencing the full path to the x-api endpoint that can serve them, which is kind of awful.

This lets us serve the track images directly from the exercism.io API. The next step is to use the new support for configuring the actual track documentation image paths when calling the trackler documentation function.

See:
- https://github.com/exercism/exercism.io/issues/3312
- https://github.com/exercism/trackler/pull/15