### PR TITLE
Configure track documentation image path

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     tilt (2.0.5)
     timecop (0.8.0)
     tins (1.6.0)
-    trackler (2.0.3.9)
+    trackler (2.0.5.0)
       org-ruby (~> 0.9.0)
       rubyzip (~> 1.1)
     tzinfo (1.2.2)

--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -47,7 +47,7 @@ module ExercismWeb
             track: track,
             topic: topic,
             template: template,
-            docs: track.docs
+            docs: track.docs("/api/v1/tracks/%s/images/docs/img" % track_id)
           }
         else
           language_not_found(track_id)

--- a/app/views/languages/_installing.erb
+++ b/app/views/languages/_installing.erb
@@ -1,1 +1,1 @@
-<%= md track.docs.installation %>
+<%= md docs.installation %>


### PR DESCRIPTION
The track documentation often needs to contain images, and those images live in the track repository. This means that when the documentation refers to "/docs/img/test.png", that is in the track repository, not in the Exercism repository.
    
When we parse the markdown, the HTML creates an image with a source that has a URL which is relative to the Exercism site.
    
We need to rewrite the image path to use the API endpoint which serves track images.

See https://github.com/exercism/xswift/pull/212