### PR TITLE
Remove extra 'an' from front page

### DIFF
--- a/app/views/site/index.erb
+++ b/app/views/site/index.erb
@@ -95,7 +95,7 @@
 
         <p>
         You’re used to being productive.
-        Now you feel hamstrung with one hand tied behind your back and an an unfair suspicion that you should already know this.
+        Now you feel hamstrung with one hand tied behind your back and an unfair suspicion that you should already know this.
         </p>
 
         <p>


### PR DESCRIPTION
There is an extra an in the index page that I took out.

Fixes: #3321