### PR TITLE
Add quick preview of other iterations

### DIFF
--- a/app/views/submissions/show.erb
+++ b/app/views/submissions/show.erb
@@ -68,7 +68,8 @@
         <span class="label label-default">Iterations</span>
       </li>
       <% submission.user_exercise.submissions.each do |s| %>
-        <li class="<%= "active" if s == submission %>">
+        <li class="iterations-nav-item <%= "active" if s == submission %>"
+            data-solution="<%= h s.solution.to_a.to_json %>">
           <a href="/submissions/<%= s.key %>">
             <% unless submission.user_exercise.archived? %>
               <i class="fa"></i>

--- a/frontend/app/js/preview.js
+++ b/frontend/app/js/preview.js
@@ -1,0 +1,33 @@
+(function () {
+  "use strict";
+
+  var codeBlockCache,
+      $codeBlocks,
+      $codeWindows,
+      $iterationsNavItem;
+
+  $(function () {
+
+    codeBlockCache = [];
+    $codeWindows = $('.submission-code-body .highlight');
+    $codeBlocks = $codeWindows.find('td.code > pre');
+    $iterationsNavItem = $('.iterations-nav-item');
+
+    $codeBlocks.each(function () {
+      codeBlockCache.push($(this).html());
+    });
+
+    $iterationsNavItem.hover(function () {
+      $(this).data('solution').forEach(function (file, index) {
+        $codeBlocks.eq(index).text(file[1]);
+      });
+      $codeWindows.addClass('preview');
+    }, function () {
+      $codeBlocks.each(function (index) {
+        $(this).html(codeBlockCache[index]);
+      });
+      $codeWindows.removeClass('preview');
+    });
+
+  });
+})();

--- a/public/sass/layouts/submission.scss
+++ b/public/sass/layouts/submission.scss
@@ -142,6 +142,16 @@
       border-bottom-width: 0;
     }
   }
+  .highlight {
+    td.gutter, td.code {
+      vertical-align: top;
+    }
+    &.preview {
+      $preview-color: scale-color($exercism-red, $lightness: 50%);
+      border-color: $preview-color;
+      border-style: dashed;
+    }
+  }
   .comments {
     h3 {
       margin-top: 0px;


### PR DESCRIPTION
When viewing a submission with multiple iterations, hovering the mouse over an iteration's tab will cause that iterations code to be displayed in the code view window(s). This is a way to quickly see the differences between iterations by hovering back and forth between tabs.

Starting with an exercise with two iterations:
![selection_003](https://cloud.githubusercontent.com/assets/2099793/21437977/de20879c-c854-11e6-8a23-f9472570fc75.png)
Hover over the tabs to quickly see the changes:
![selection_004](https://cloud.githubusercontent.com/assets/2099793/21438038/1946c368-c855-11e6-84ec-cc4b74c9b670.png)
![selection_005](https://cloud.githubusercontent.com/assets/2099793/21438041/1ebb9eb8-c855-11e6-9e81-06acc97acf44.png)

Related to #3307