### PR TITLE
Upgrade lineman to latest version 0.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "grunt": "~0.4.1",
     "grunt-concat-sourcemap": "^0.4.3",
     "grunt-ngmin": "~0.0.2",
-    "lineman": ">=0.11.1"
+    "lineman": "~0.37.0"
   },
   "engines": {
     "node": "~>0.10.5",


### PR DESCRIPTION
Previous lineman was using old version of `grunt-contrib-jshint` package which had [an issue](https://github.com/linemanjs/lineman/issues/391). Also lock lineman to specific version instead of using `>=`.

Fixes #3120.