### PR TITLE
docs: add explanation of inviting new maintainers

### DIFF
--- a/docs/inviting-new-maintainers.md
+++ b/docs/inviting-new-maintainers.md
@@ -1,0 +1,11 @@
+The maintainers of a track should feel free to extend invitations to contributors asking them to join the team.
+
+You may invite new maintainers using whatever medium feels most appropriate, including but not limited to email or Gitter.
+
+In general, we would like to keep these invitations short, to make it clear that we are not asking for a huge and/or overwhelming commitment.
+
+General topics that we feel are good to touch on in the invitation:
+
+* **Thank you** for your past contributions. Be specific on points that we like, for positive reinforcement.
+* https://github.com/exercism/exercism.io/blob/master/docs/maintaining-a-track.md
+* **No pressure** regarding how much to commit to (you can commit to as much or as little as you like!), or even to say yes at all! Either way, you are still welcome to contribute as you already have been!


### PR DESCRIPTION
This stems from https://github.com/exercism/discussions/issues/105

The summary of my motivation for adding this document is that it's up to
us (existing maintainers) to invite new maintainers. However, I had
always been reluctant to in the past, because I did not know how to do 
it or what to say!

This file records what we agreed upon in the discussion to fix the 
problem of "I don't know what to say when inviting a new maintainer!"