### PR TITLE
user should know that link leads to install page

### DIFF
--- a/app/views/application/footer/links.erb
+++ b/app/views/application/footer/links.erb
@@ -16,7 +16,7 @@
   </li>
   <li>
     <a href="/cli">
-      The Command-Line Client
+      Install the Command-Line Client
     </a>
   </li>
   <li>


### PR DESCRIPTION
This should take care of #3332.
I just changed the link text to 'Install the Command-Line Client', instead of 'Download and Install the Command-Line Client', since the act of installing means that you will have to download the CLI.