### PR TITLE
Documentation: Elide "exercism configure --dir" with no value

### DIFF
--- a/x/docs/md/help/executable.md
+++ b/x/docs/md/help/executable.md
@@ -10,17 +10,21 @@ exercism -v
 
 The most recent version of the CLI can be found [on GitHub](https://github.com/exercism/cli/releases/latest).
 
-Next verify that the CLI is configured. Run:
+Next verify that the CLI is configured. Run `exercism configure`. It should look something like this
 
 ```bash
-exercism debug
+$ exercism configure
+
+Configuration written to /home/you/.exercism.json
+
+  --key=91a1cc34b03dbcc93d81603454087da526fcc6c5
+  --dir=/home/you/exercism
+  --host=http://exercism.io
+  --api=http://x.exercism.io
+
 ```
 
-Look at the API key, and compare it to the one in [your account](http://exercism.io/account/key). It will look something like this:
-
-```plain
-API Key: 91a1cc34b03dbcc93d81603454087da526fcc6c5
-```
+The `--key` should look like the API key in [your account](http://exercism.io/account/key).
 
 If the API key is incorrect, then re-run the `configure` command:
 
@@ -28,13 +32,7 @@ If the API key is incorrect, then re-run the `configure` command:
 exercism configure --key=YOUR_API_KEY
 ```
 
-Next look at the Exercises Directory. It will look something like this:
-
-```plain
-Exercises Directory: /home/you/exercism
-```
-
-To change the directory where exercises are downloaded, use the following command (Be sure to enclose the directory path inside double quotes):
+The `--dir` in the output of `exercism configure` is the directory where the exercises will be downloaded. To change it, use the following command (Be sure to enclose the directory path inside double quotes):
 
 ```bash
 exercism configure --dir="DIRECTORY PATH"

--- a/x/docs/md/help/executable.md
+++ b/x/docs/md/help/executable.md
@@ -28,10 +28,10 @@ If the API key is incorrect, then re-run the `configure` command:
 exercism configure --key=YOUR_API_KEY
 ```
 
-Next look at the `Exercises Directory`. The current directory which is being used to fetch exercises can be viewed using the following command:
+Next look at the Exercises Directory. It will look something like this:
 
-```bash
-exercism configure --dir
+```plain
+Exercises Directory: /home/you/exercism
 ```
 
 To change the directory where exercises are downloaded, use the following command (Be sure to enclose the directory path inside double quotes):


### PR DESCRIPTION
Running "exercism configure --dir" doesn't appear to work as described.

```bash
$ exercism configure --dir
Incorrect Usage.

NAME:
   exercism configure - Writes config values to a JSON file.

USAGE:
   exercism configure [command options] [arguments...]

OPTIONS:
   --dir value, -d value   path to exercises directory
   --host value, -u value  exercism api host
   --key value, -k value   exercism.io API key (see http://exercism.io/account/key)
   --api value, -a value   exercism xapi host
   
2017/01/14 08:43:05 flag needs an argument: -dir
```

In any case, it was right there in the debug output; why not do the same as the API Key above and just say look at it?