### PR TITLE
Fix help launch view for new tracks

### DIFF
--- a/app/views/languages/_launch.erb
+++ b/app/views/languages/_launch.erb
@@ -1,1 +1,25 @@
-<%= md docs.launch %>
+<h3>Help Us Launch!</h3>
+
+<h5>Launching a track takes a lot of work and we'd love your help!</h5>
+
+<p>
+  In order to launch we need:
+</p>
+
+<ul>
+  <li>At least 10 problems.</li>
+  <li>Add a language icon or logo.</li>
+  <li>Documentation to cover things like documentation and tests.</li>
+  <li>
+    At least one person who is willing to check exercism regularly to review new solutions that people submit.<br />
+    This will ensure that the track gets off on the right foot.
+  </li>
+  <li>Add track implementors and other designated code reviewers as mentors to the track.</li>
+  <li>Toggle <code>active</code> to <code>true</code> in <code>config.json</code></li>
+</ul>
+
+<h5>We always welcome help to get a new track up and running.</h5>
+
+<p>
+  Check out the <a href="<%= track.repository %>/issues/<%= track.checklist_issue %>">Launch Checklist</a> to see what still needs to be done.
+</p>


### PR DESCRIPTION
This fixes #3351 .
I choosed to hard-code `LAUNCH.md` into the erb template.