### PR TITLE
Add missing team stream route for user by track

### DIFF
--- a/app/routes/teams.rb
+++ b/app/routes/teams.rb
@@ -156,6 +156,35 @@ module ExercismWeb
         end
       end
 
+      get '/teams/:slug/streams/users/:username/tracks/:id' do |slug, username, track_id|
+        please_login
+        only_with_existing_team(slug) do |team|
+          unless team.includes?(current_user)
+            flash[:error] = "You may only view team pages for teams that you are a member of, or that you manage."
+            redirect '/'
+          end
+
+          user = ::User.find_by_username(username)
+          stream = TeamStream.new(team, current_user.id, params['page'] || 1)
+          stream.track_id = track_id.downcase
+
+          unless user.present? && stream.user_ids.include?(user.id)
+            flash[:error] = "You may only view activity for existing team members."
+            redirect '/'
+          end
+
+          stream.user = user
+
+          locals = {
+            team: team,
+            stream: stream,
+            active: 'stream',
+          }
+
+          erb :"teams/stream", locals: locals
+        end
+      end
+
       get '/teams/:slug/directory' do |slug|
         please_login
         only_with_existing_team(slug) do |team|

--- a/app/routes/teams.rb
+++ b/app/routes/teams.rb
@@ -164,9 +164,9 @@ module ExercismWeb
             redirect '/'
           end
 
-          user = ::User.find_by_username(username)
+          user = ::User.find_by(username: username)
           stream = TeamStream.new(team, current_user.id, params['page'] || 1)
-          stream.track_id = track_id.downcase
+          stream.track_id = track_id
 
           unless user.present? && stream.user_ids.include?(user.id)
             flash[:error] = "You may only view activity for existing team members."

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -369,7 +369,6 @@ class TeamsTest < Minitest::Test
     assert_response_status 302
     assert_equal "http://example.org/", last_response.location
 
-
     get '/teams/awesome/streams/tracks/ruby', {}, login(bob)
     assert_response_status 302
     assert_equal "http://example.org/", last_response.location
@@ -412,6 +411,8 @@ class TeamsTest < Minitest::Test
     assert_response_status 200
   end
 
+  private
+
   def create_exercise_with_submission(user, language, slug, ts=1.day.ago)
     exercise = UserExercise.create!(user_id: user.id, language: language, slug: slug, iteration_count: 1, last_activity_at: ts)
     attributes = {
@@ -425,4 +426,3 @@ class TeamsTest < Minitest::Test
     Submission.create!(attributes)
   end
 end
-

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -356,4 +356,73 @@ class TeamsTest < Minitest::Test
     assert_equal "http://example.org/teams/condor/manage", last_response.location
     assert_equal [alice.id], team.reload.managers.map(&:id)
   end
+
+  def test_view_streams_as_non_member
+    team = Team.by(alice).defined_with(slug: 'awesome', usernames: charlie.username)
+    team.save
+    TeamMembershipInvite.pending.find_by(user: charlie, team: team).accept!
+
+    # Charlie has submitted one exercise, but Bob is not the same team.
+    create_exercise_with_submission(charlie, 'fake', 'hello-world')
+
+    get '/teams/awesome/streams', {}, login(bob)
+    assert_response_status 302
+    assert_equal "http://example.org/", last_response.location
+
+
+    get '/teams/awesome/streams/tracks/ruby', {}, login(bob)
+    assert_response_status 302
+    assert_equal "http://example.org/", last_response.location
+
+    get '/teams/awesome/streams/tracks/ruby/exercises/bob', {}, login(bob)
+    assert_response_status 302
+    assert_equal "http://example.org/", last_response.location
+
+    get '/teams/awesome/streams/users/charlie', {}, login(bob)
+    assert_response_status 302
+    assert_equal "http://example.org/", last_response.location
+
+    get '/teams/awesome/streams/users/charlie/tracks/ruby', {}, login(bob)
+    assert_response_status 302
+    assert_equal "http://example.org/", last_response.location
+  end
+
+  def test_view_streams_as_member
+    team = Team.by(alice).defined_with(slug: 'awesome', usernames: "#{bob.username},#{charlie.username}")
+    team.save
+    TeamMembershipInvite.pending.find_by(user: bob, team: team).accept!
+    TeamMembershipInvite.pending.find_by(user: charlie, team: team).accept!
+
+    # Charlie has submitted one exercise, and Bob is in the same team.
+    create_exercise_with_submission(charlie, 'fake', 'hello-world')
+
+    get '/teams/awesome/streams', {}, login(bob)
+    assert_response_status 200
+
+    get '/teams/awesome/streams/tracks/fake', {}, login(bob)
+    assert_response_status 200
+
+    get '/teams/awesome/streams/tracks/fake/exercises/charlie', {}, login(bob)
+    assert_response_status 200
+
+    get '/teams/awesome/streams/users/charlie', {}, login(bob)
+    assert_response_status 200
+
+    get '/teams/awesome/streams/users/charlie/tracks/fake', {}, login(bob)
+    assert_response_status 200
+  end
+
+  def create_exercise_with_submission(user, language, slug, ts=1.day.ago)
+    exercise = UserExercise.create!(user_id: user.id, language: language, slug: slug, iteration_count: 1, last_activity_at: ts)
+    attributes = {
+      user_id: exercise.user_id,
+      user_exercise_id: exercise.id,
+      language: exercise.language,
+      slug: exercise.slug,
+      created_at: ts,
+      updated_at: ts,
+    }
+    Submission.create!(attributes)
+  end
 end
+


### PR DESCRIPTION
## Route missing on team stream.

### Description

If you try to open a team stream on a specifi user for instance : 
[/teams/baconesia/streams/users/beth](http://localhost:4567/teams/baconesia/streams/users/beth) you'll see that the last part of the sidebar contains a list of links. One link for each track the user's worked on.

For example:
[/teams/baconesia/streams/users/beth/tracks/coffeescript](http://localhost:4567/teams/baconesia/streams/users/beth/tracks/coffeescript)

This link is built by a `TeamStream::UserFilter` object but the relative url this object returns does not match with an existing route.

### Solution
Add the relative route on `app/routes/team.rb`file