### PR TITLE
Clarify setup on local machine

### DIFF
--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -42,7 +42,7 @@ Exercism.io depends on the following:
 
 These instructions present two options:
 
-1. Run exercism.io on your computer directly by [installing the required software](#running-exercism-io-directly-on-your-computer).
+1. Run exercism.io on your computer directly by installing the required software as listed in the following section (Running exercism.io directly on your computer).
 2. Run exercism.io [with Docker](#running-exercism-io-with-docker).
 
 ### Running exercism.io directly on your computer


### PR DESCRIPTION
Line 45 previously stated this:
`1. Run exercism.io on your computer directly by [installing the required software](#running-exercism-io-directly-on-your-computer).`
And linked to the section immediately below it.  I thought the link was broken until I saw it was just referencing the section directly below the current one. I think it would clarify this if the line was changed as proposed, to just reference the following section.