### PR TITLE
Make track-id(language) & slug(problem) lowercase

### DIFF
--- a/api/v1/routes/iterations.rb
+++ b/api/v1/routes/iterations.rb
@@ -74,13 +74,13 @@ module ExercismAPI
           data['path'] = segments[2..-1].join("/")
         end
 
-        track = Trackler.tracks[data['language']]
+        track = Trackler.tracks[data['language'].downcase]
 
         unless track.exists?
           halt 400, { error: "Unknown language track %s" % data['language'] }.to_json
         end
 
-        unless track.implementations[data['problem'].to_s].exists?
+        unless track.implementations[data['problem'].to_s.downcase].exists?
           halt 400, { error: "Unknown problem '%s' in %s track" % [data['problem'], track.language] }.to_json
         end
 

--- a/lib/exercism/iteration.rb
+++ b/lib/exercism/iteration.rb
@@ -2,8 +2,8 @@ class Iteration
   attr_reader :solution, :comment, :track_id, :slug
 
   def initialize(solution, track_id, slug, comment: nil)
-    @track_id = track_id
-    @slug = slug
+    @track_id = track_id.downcase
+    @slug = slug.downcase
     @comment = comment
 
     @solution = {}

--- a/test/api/iterations_test.rb
+++ b/test/api/iterations_test.rb
@@ -141,4 +141,21 @@ class IterationsApiTest < Minitest::Test
     assert_equal expected, submission.solution
     assert_equal "fake", submission.language
   end
+
+  def test_language_and_track_id_case_insensitive
+    submission = {
+      key: @alice.key,
+      "path" => "/FAKE/TwO/two.ext",
+      "code" => "Hello, World!",
+      "dir" => "/path/to/exercism/dir",
+    }
+
+    post '/user/assignments', submission.to_json
+
+    submission = Submission.first
+    assert_equal "fake", submission.language
+    assert_equal "two", submission.slug
+    expected = { "two.ext" => "Hello, World!" }
+    assert_equal expected, submission.solution
+  end
 end


### PR DESCRIPTION
Fixes #3390.

Previously if a user renamed a directory with non-lowercase characters,
submission would fail because Trackler would fail to find a matching
track.

This fixes just the endpoints mentioned in the issue. Do we need any URLs to be capitalized? I'm wondering if a better solution would be to normalize casing across all endpoints?