### PR TITLE
add robots nofollow/noindex meta tag to submission pages

### DIFF
--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -6,6 +6,9 @@
     <meta content='width=device-width, initial-scale=1.0' name='viewport'>
     <meta content='Practice having thoughtful conversations about code.' name='description'>
     <meta content='Exercism.io' name='author'>
+  <% if url.include?('/submissions/') %>
+    <meta content="noindex,nofollow" name="robots">
+  <% end %>
     <!-- Open Graph protocol http://ogp.me/ -->
     <meta property='og:site_name'   content='Exercism.io'/>
     <meta property='og:type'     content='website'/>


### PR DESCRIPTION
Fixes #3397. 

Essentially just adds a check in the layout.erb page - if the url includes `/submissions/` it will add the nofollow/noindex meta tag. I'm not sure if this is the best way to do it, but it certainly *appears* to be the simplest. Let me know if there are any changes you'd like me to make.