### PR TITLE
Fix inconsistent labels on profile

### DIFF
--- a/app/views/user/_archived_exercises_table.erb
+++ b/app/views/user/_archived_exercises_table.erb
@@ -8,11 +8,11 @@
     </tr>
   </thead>
   <tbody>
-    <% profile.archived_grouped_exercises.keys.each do |language| %>
+    <% profile.archived_grouped_exercises.keys.each do |track_id| %>
       <tr>
-        <td><%= language.capitalize %></td>
+        <td><%= Language.of(track_id) %></td>
         <td>
-          <% exercises = profile.archived_grouped_exercises[language] %>
+          <% exercises = profile.archived_grouped_exercises[track_id] %>
           <% exercises.each do |exercise| %>
             <% if profile.access?(exercise) %>
               <a href="/exercises/<%= exercise.key %>">


### PR DESCRIPTION
The profile page has a separate section for archived exercises, which was using the
capitalized track ID instead of the language name. This resulted in things like 'Cpp'
and 'Fsharp' instead of 'C++' and 'F#'.

Tested locally by looking at a profile with C++ and F# exercises on it.

Fixes #3399