### PR TITLE
Fix Linux set-up instructions

### DIFF
--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -73,7 +73,7 @@ These instructions assume you're using a package manager for your OS:
 
   ```
   $ sudo apt-get update
-  $ sudo apt-get rbenv ruby-build
+  $ sudo apt-get install rbenv ruby-build
   $ rbenv install X.Y.Z
   ```
 

--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -94,7 +94,7 @@ These instructions assume you're using a package manager for your OS:
 
   ```
   $ sudo apt-get update
-  $ apt-get install postgresql postgresql-contrib
+  $ sudo apt-get install postgresql postgresql-contrib
   ```
 
 #### Installing Node.js (and npm)


### PR DESCRIPTION
When I was setting up my dev environment I noticed the word "install" was missing from here:

```
$ sudo apt-get update
$ sudo apt-get rbenv ruby-build
$ rbenv install X.Y.Z
```
So I changed it to this, which is runnable and works:

```
$ sudo apt-get update
$ sudo apt-get install rbenv ruby-build
$ rbenv install X.Y.Z
```

Also added a "sudo" to the Postgre-SQL instructions cause it needs that (just in case someone's not as Linux-savvy as they think they are 😄 )