### PR TITLE
Add feature flag support with flipper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,8 @@ gem 'activerecord', '~> 4.2.1'
 
 gem 'bugsnag'
 gem 'faraday'
+gem 'flipper-active_record'
+gem 'flipper-ui'
 gem 'loofah'
 gem 'petroglyph'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,10 +60,20 @@ GEM
     database_cleaner (1.5.1)
     docile (1.1.5)
     dotenv (2.1.1)
+    erubis (2.7.0)
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
+    flipper (0.10.2)
+    flipper-active_record (0.10.2)
+      activerecord (>= 3.2, < 6)
+      flipper (~> 0.10.2)
+    flipper-ui (0.10.2)
+      erubis (~> 2.7.0)
+      flipper (~> 0.10.2)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, < 2.1.0)
     font-awesome-sass (4.5.0)
       sass (>= 3.2)
     foreman (0.78.0)
@@ -186,6 +196,8 @@ DEPENDENCIES
   database_cleaner
   dotenv
   faraday
+  flipper-active_record
+  flipper-ui
   font-awesome-sass
   foreman
   kss
@@ -220,4 +232,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/app.rb
+++ b/app.rb
@@ -15,9 +15,11 @@ require_relative './app/helpers'
 require_relative './app/routes'
 
 module ExercismWeb
+  DEFAULT_SESSION_KEY = "Need to know only."
+
   class App < Sinatra::Base
     configure do
-      use Rack::Session::Cookie, secret: ENV.fetch('SESSION_SECRET') { "Need to know only." }
+      use Rack::Session::Cookie, secret: ENV.fetch('SESSION_SECRET', DEFAULT_SESSION_KEY)
     end
 
     if settings.development?

--- a/config.ru
+++ b/config.ru
@@ -20,18 +20,19 @@ if ENV['RACK_ENV'] != 'production'
 end
 
 require 'app'
+require 'flipper_app'
 require 'api/v1'
 
 ENV['RACK_ENV'] ||= 'development'
 
+$flipper = Flipper.new(Flipper::Adapters::ActiveRecord.new)
+
 use ActiveRecord::ConnectionAdapters::ConnectionManagement
 use Rack::MethodOverride
-flipper = Flipper.new(Flipper::Adapters::ActiveRecord.new)
-flipper_app = lambda do |builder|
-  builder.use Rack::Session::Cookie, secret: ENV.fetch('SESSION_SECRET', 'not-so-secret')
-end
-run Rack::URLMap.new("/" => ExercismWeb::App,
-                     "/flipper" => Flipper::UI.app(flipper, &flipper_app))
+run Rack::URLMap.new(
+  "/" => ExercismWeb::App,
+  "/flipper" => Flipper::UI.app($flipper, &FlipperApp.generator)
+)
 
 map '/api/v1/' do
   run ExercismAPI::App

--- a/config.ru
+++ b/config.ru
@@ -26,7 +26,12 @@ ENV['RACK_ENV'] ||= 'development'
 
 use ActiveRecord::ConnectionAdapters::ConnectionManagement
 use Rack::MethodOverride
-run ExercismWeb::App
+flipper = Flipper.new(Flipper::Adapters::ActiveRecord.new)
+flipper_app = lambda do |builder|
+  builder.use Rack::Session::Cookie, secret: ENV.fetch('SESSION_SECRET', 'not-so-secret')
+end
+run Rack::URLMap.new("/" => ExercismWeb::App,
+                     "/flipper" => Flipper::UI.app(flipper, &flipper_app))
 
 map '/api/v1/' do
   run ExercismAPI::App

--- a/db/migrate/20170313231200_create_flipper_tables.rb
+++ b/db/migrate/20170313231200_create_flipper_tables.rb
@@ -1,0 +1,22 @@
+class CreateFlipperTables < ActiveRecord::Migration
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/docs/flipper-feature-flags.md
+++ b/docs/flipper-feature-flags.md
@@ -2,7 +2,7 @@ Feature Flags
 =============
 
 Feature flags allow specific features to be turned on and off at runtime for a
-percentage of users or the enitire site. Feature flags enable:
+percentage of users or the entire site. Feature flags enable:
 
 - Testing out new features on a limited portion of our users
 - Quick rollback when we discover a problem in production

--- a/docs/flipper-feature-flags.md
+++ b/docs/flipper-feature-flags.md
@@ -7,6 +7,9 @@ percentage of users or the entire site. Feature flags enable:
 - Testing out new features on a limited portion of our users
 - Quick rollback when we discover a problem in production
 
+We use the [Flipper][1] library for feature flags. This document covers its basic
+usage in Exercism, but see its [documentation][1] for more.
+
 Process
 -------
 
@@ -29,3 +32,5 @@ Process
    your feature flag. Leaving enabled feature flags in the code increases complexity
    and is unacceptable. The feature flag admin will delete the feature flag in the UI
    after the PR is merged and deployed successfully.
+
+   [1]: https://github.com/jnunemaker/flipper

--- a/docs/flipper-feature-flags.md
+++ b/docs/flipper-feature-flags.md
@@ -1,0 +1,31 @@
+Feature Flags
+=============
+
+Feature flags allow specific features to be turned on and off at runtime for a
+percentage of users or the enitire site. Feature flags enable:
+
+- Testing out new features on a limited portion of our users
+- Quick rollback when we discover a problem in production
+
+Process
+-------
+
+1. Surround the new feature's code with a conditional:
+
+    ```ruby
+    if $flipper[:a_name_for_your_feature].enabled?(current_user)
+      # do the new thing
+    else
+      # do the old thing, or maybe nothing
+    end
+    ```
+
+2. In development, enable the feature in the UI (http://localhost:4567/flipper/)
+3. Get your feature deployed, ensuring you mention the feature flag in the Pull
+   Request. Ask a flipper admin (@kytrinyx) to enable your feature.
+4. Ensure everything is working in production.
+5. **Important**: Create a new pull request that removes all your feature flipper's
+   conditionals, removing any old code the new feature replaced and all references to
+   your feature flag. Leaving enabled feature flags in the code increases complexity
+   and is unacceptable. The feature flag admin will delete the feature flag in the UI
+   after the PR is merged and deployed successfully.

--- a/docs/flipper-feature-flags.md
+++ b/docs/flipper-feature-flags.md
@@ -26,9 +26,10 @@ Process
 2. In development, enable the feature in the UI (http://localhost:4567/flipper/)
 3. Get your feature deployed, ensuring you mention the feature flag in the Pull
    Request. Ask a flipper admin (@kytrinyx) to enable your feature.
-4. Ensure everything is tested and working in production for a reasonable amount of
+4. Create an issue for the removal of the feature flag, to ensure it isn't forgotten.
+5. Ensure everything is tested and working in production for a reasonable amount of
    time.
-5. **Important**: Create a new pull request that removes all your feature flipper's
+6. **Important**: Create a new pull request that removes all your feature flipper's
    conditionals, removing any old code the new feature replaced and all references to
    your feature flag. Leaving enabled feature flags in the code increases complexity
    and is unacceptable. The feature flag admin will delete the feature flag in the UI

--- a/docs/flipper-feature-flags.md
+++ b/docs/flipper-feature-flags.md
@@ -26,7 +26,8 @@ Process
 2. In development, enable the feature in the UI (http://localhost:4567/flipper/)
 3. Get your feature deployed, ensuring you mention the feature flag in the Pull
    Request. Ask a flipper admin (@kytrinyx) to enable your feature.
-4. Ensure everything is working in production.
+4. Ensure everything is tested and working in production for a reasonable amount of
+   time.
 5. **Important**: Create a new pull request that removes all your feature flipper's
    conditionals, removing any old code the new feature replaced and all references to
    your feature flag. Leaving enabled feature flags in the code increases complexity

--- a/lib/exercism/guest.rb
+++ b/lib/exercism/guest.rb
@@ -3,6 +3,7 @@ require 'exercism/user_exercise'
 class Guest
   def id
   end
+  alias_method :flipper_id, :id
 
   def username
     'guest'

--- a/lib/exercism/guest.rb
+++ b/lib/exercism/guest.rb
@@ -3,11 +3,11 @@ require 'exercism/user_exercise'
 class Guest
   def id
   end
-  alias_method :flipper_id, :id
 
   def username
     'guest'
   end
+  alias_method :flipper_id, :username
 
   def fetched?
     false

--- a/lib/exercism/user.rb
+++ b/lib/exercism/user.rb
@@ -99,6 +99,11 @@ class User < ActiveRecord::Base
     submissions.order('id DESC').where(language: problem.track_id, slug: problem.slug)
   end
 
+  # Some unique identifier
+  def flipper_id
+    username
+  end
+
   def guest?
     false
   end

--- a/lib/flipper_app.rb
+++ b/lib/flipper_app.rb
@@ -1,0 +1,10 @@
+require 'flipper_app/authorize'
+
+module FlipperApp
+  def self.generator
+    lambda do |builder|
+      builder.use Rack::Session::Cookie, secret: ENV.fetch('SESSION_SECRET', ExercismWeb::DEFAULT_SESSION_KEY)
+      builder.use FlipperApp::Authorize
+    end
+  end
+end

--- a/lib/flipper_app/authorize.rb
+++ b/lib/flipper_app/authorize.rb
@@ -1,0 +1,50 @@
+require 'active_record'
+require 'exercism/user'
+
+module FlipperApp
+  class Authorize
+    def initialize(app, options = {})
+      @app = app
+    end
+
+    def call(env)
+      if authorized?(env)
+        @app.call(env)
+      else
+        forbidden
+      end
+    end
+
+    private
+
+    def authorized_usernames
+      %w(kytrinyx nilbus)
+    end
+
+    def authorized_github_ids
+      @authorized_github_ids ||=
+        User.where(username: authorized_usernames).map(&:github_id)
+    end
+
+    def authorized?(env)
+      development? || authorized_user?(env)
+    end
+
+    def authorized_user?(env)
+      session = env['rack.session'] || {}
+      authorized_github_ids.include? session['github_id']
+    end
+
+    def development?
+      ENV['RACK_ENV'] == 'development'
+    end
+
+    def forbidden
+      [403, {"Content-Type" => "text/html"}, [deny_markup]]
+    end
+
+    def deny_markup
+      '<html><body><img src="https://octodex.github.com/images/bouncercat.png"></body></html>'
+    end
+  end
+end

--- a/lib/flipper_app/authorize.rb
+++ b/lib/flipper_app/authorize.rb
@@ -23,7 +23,7 @@ module FlipperApp
 
     def authorized_github_ids
       @authorized_github_ids ||=
-        User.where(username: authorized_usernames).map(&:github_id)
+        User.where(username: authorized_usernames).pluck(:github_id)
     end
 
     def authorized?(env)

--- a/test/exercism/guest_test.rb
+++ b/test/exercism/guest_test.rb
@@ -18,9 +18,9 @@ class GuestTest < Minitest::Test
     assert_equal 'guest', subject.username
   end
 
-  def test_flipper_id_nil_for_guests
+  def test_flipper_id_is_username_for_guests
     subject = Guest.new
-    assert_nil subject.flipper_id
+    assert_equal subject.username, subject.flipper_id
   end
 
   def test_show_dailies?

--- a/test/exercism/guest_test.rb
+++ b/test/exercism/guest_test.rb
@@ -18,6 +18,11 @@ class GuestTest < Minitest::Test
     assert_equal 'guest', subject.username
   end
 
+  def test_flipper_id_nil_for_guests
+    subject = Guest.new
+    assert_nil subject.flipper_id
+  end
+
   def test_show_dailies?
     subject = Guest.new
     refute subject.show_dailies?

--- a/test/exercism/user_test.rb
+++ b/test/exercism/user_test.rb
@@ -13,6 +13,11 @@ class UserTest < Minitest::Test
     refute user.guest?
   end
 
+  def test_flipper_id_is_username
+    user = User.new(username: 'spocktocat')
+    assert_equal 'spocktocat', user.flipper_id
+  end
+
   def test_create_user_from_github
     user = User.from_github(23, 'alice', 'alice@example.com', 'avatar_url', 'polyglot')
     assert_equal 1, User.count

--- a/test/flipper_app/authorize_test.rb
+++ b/test/flipper_app/authorize_test.rb
@@ -62,7 +62,7 @@ class AssignmentsApiTest < Minitest::Test
   end
 
   def authorized_users
-    [OpenStruct.new(github_id: admin_github_id)]
+    stub('User ActiveRecord::Relation', pluck: [admin_github_id])
   end
 
   def force_development_env

--- a/test/flipper_app/authorize_test.rb
+++ b/test/flipper_app/authorize_test.rb
@@ -1,0 +1,74 @@
+require_relative '../test_helper'
+require 'mocha/setup'
+require 'flipper_app/authorize'
+
+class AssignmentsApiTest < Minitest::Test
+  def setup
+    User.stubs(:where).returns(authorized_users)
+  end
+
+  def test_unauthenticated_users_rejected
+    env = {'rack.session' => {}}
+    response = middleware_response(env)
+    assert_forbidden(response)
+  end
+
+  def test_nil_session_rejected
+    env = {'rack.session' => nil}
+    response = middleware_response(env)
+    assert_forbidden(response)
+  end
+
+  def test_unauthorized_users_rejected
+    env = {'rack.session' => {'github_id' => normal_user_github_id}}
+    response = middleware_response(env)
+    assert_forbidden(response)
+  end
+
+  def test_authorized_user_allowed
+    env = {'rack.session' => {'github_id' => admin_github_id}}
+    response = middleware_response(env)
+    assert_allowed(response)
+  end
+
+  def test_development_env_allowed
+    env = {'rack.session' => nil}
+    response = force_development_env { middleware_response(env) }
+    assert_allowed(response)
+  end
+
+  private
+
+  def assert_forbidden(response)
+    assert_equal 403, response[0]
+  end
+
+  def assert_allowed(response)
+    assert_equal 200, response[0]
+  end
+
+  def middleware_response(env)
+    noop_app = ->(_) { [200, 'text/plain', ['']] }
+    FlipperApp::Authorize.new(noop_app).call(env)
+  end
+
+  def admin_github_id
+    123
+  end
+
+  def normal_user_github_id
+    admin_github_id + 1
+  end
+
+  def authorized_users
+    [OpenStruct.new(github_id: admin_github_id)]
+  end
+
+  def force_development_env
+    original_env = ENV['RACK_ENV']
+    ENV['RACK_ENV'] = 'development'
+    yield
+  ensure
+    ENV['RACK_ENV'] = original_env
+  end
+end

--- a/test/flipper_app/authorize_test.rb
+++ b/test/flipper_app/authorize_test.rb
@@ -2,36 +2,36 @@ require_relative '../test_helper'
 require 'mocha/setup'
 require 'flipper_app/authorize'
 
-class AssignmentsApiTest < Minitest::Test
-  def test_unauthenticated_users_rejected
+class FlipperApp::AuthorizeTest < Minitest::Test
+  def test_refuse_flipper_management_for_unauthenticated_users
     User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => {}}
     response = middleware_response(env)
     assert_forbidden(response)
   end
 
-  def test_nil_session_rejected
+  def test_refuse_flipper_management_for_nil_session
     User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => nil}
     response = middleware_response(env)
     assert_forbidden(response)
   end
 
-  def test_unauthorized_users_rejected
+  def test_refuse_flipper_management_for_unauthorized_users
     User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => {'github_id' => normal_user_github_id}}
     response = middleware_response(env)
     assert_forbidden(response)
   end
 
-  def test_authorized_user_allowed
+  def test_allow_flipper_management_for_authorized_user
     User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => {'github_id' => admin_github_id}}
     response = middleware_response(env)
     assert_allowed(response)
   end
 
-  def test_development_env_allowed
+  def test_allow_flipper_management_in_development_env
     User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => nil}
     response = force_development_env { middleware_response(env) }

--- a/test/flipper_app/authorize_test.rb
+++ b/test/flipper_app/authorize_test.rb
@@ -3,35 +3,36 @@ require 'mocha/setup'
 require 'flipper_app/authorize'
 
 class AssignmentsApiTest < Minitest::Test
-  def setup
-    User.stubs(:where).returns(authorized_users)
-  end
-
   def test_unauthenticated_users_rejected
+    User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => {}}
     response = middleware_response(env)
     assert_forbidden(response)
   end
 
   def test_nil_session_rejected
+    User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => nil}
     response = middleware_response(env)
     assert_forbidden(response)
   end
 
   def test_unauthorized_users_rejected
+    User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => {'github_id' => normal_user_github_id}}
     response = middleware_response(env)
     assert_forbidden(response)
   end
 
   def test_authorized_user_allowed
+    User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => {'github_id' => admin_github_id}}
     response = middleware_response(env)
     assert_allowed(response)
   end
 
   def test_development_env_allowed
+    User.stubs(:where).returns(authorized_users)
     env = {'rack.session' => nil}
     response = force_development_env { middleware_response(env) }
     assert_allowed(response)


### PR DESCRIPTION
This patch introduces the [flipper][] gem, which satisfies all the requirements listed in #3407. I chose this over alternatives, because it's self-contained (no third party involved), works with ActiveRecord (keeping dev setup consistent), and does exactly what we want.

This will be used to turn on and off experiment features and roll out to a random 50% experiment group described in https://github.com/exercism/discussions/issues/123.

[flipper]: https://github.com/jnunemaker/flipper

Todo:

- [x] Alias User id to `flipper_id`
- [x] Create a globally accessible `Flipper` instance, and use it in `config.ru`
- [x] Restrict the rack-mounted /flipper/ UI to the right people™
- [x] Documentation for using feature flags in test, development, and production

For authentication, I imagine I could hard-code @kytrinyx and myself in production, but is there a more appropriate existing group?