### PR TITLE
[Docs] Update docs for Exercism CLI on Windows

### DIFF
--- a/x/docs/md/cli/windows.md
+++ b/x/docs/md/cli/windows.md
@@ -30,11 +30,11 @@ choco install exercism-io-cli
 
 Type 'Y' to accept any prompts during the installation. If the installation was successful you should have output similar to the following:
 
-![Exercism CLI installation](/img/cli/win-exercism-installation.png "Exercism CLI installation")
+![Exercism CLI installation](/public/img/cli/win-exercism-installation.png "Exercism CLI installation")
 
 You now have access to the `exercism` command. You can type in `exercism --version` to get the current version of the Exercism CLI, or `exercism --help` to show the help menu.
 
-![Exercism command](/img/cli/win-exercism-command.png "Exercism command")
+![Exercism command](/public/img/cli/win-exercism-command.png "Exercism command")
 
 ### Upgrading the Exercism CLI
 
@@ -75,15 +75,15 @@ You can now continue by [choosing a language](http://exercism.io/languages).
 
 To open the Windows Command Prompt; access the Windows menu, by either clicking on the Windows logo in the Taskbar, or pressing the Windows key on the keyboard. In the search bar that comes up, type in `cmd`, which will bring up the `cmd.exe` program.
 
-![cmd.exe in the Windows menu](/img/cli/win-menu-cmd.png "The cmd program in the windows menu")
+![cmd.exe in the Windows menu](/public/img/cli/win-menu-cmd.png "The cmd program in the windows menu")
 
 To install Chocolately we need to use Administrator privileges. This is important, if you don't use Administrator privileges our computer won't let you install Chocolatey. To do this *right-click* on `cmd.exe` and in the menu that appears choose `Run as administrator`.
 
-![Run cmd.exe as Administrator](/img/cli/win-run-cmd-as-admin.png "Run the cmd program as Administrator")
+![Run cmd.exe as Administrator](/public/img/cli/win-run-cmd-as-admin.png "Run the cmd program as Administrator")
 
 You will be asked if you want to allow the program to make changes to your computer. You can safely click *Yes* here. The Command Prompt program should then start, and look something similar to this:
 
-![cmd.exe](/img/cli/win-cmd.png "The Windows command Prompt")
+![cmd.exe](/public/img/cli/win-cmd.png "The Windows command Prompt")
 
 You can now continue to the [Chocolatey installation](#chocolatey)
 
@@ -91,11 +91,11 @@ You can now continue to the [Chocolatey installation](#chocolatey)
 
 If your installation of Chocolatey has gone well, you should see output in your Windows shell similar to the following:
 
-![Successful Chocolatey installation](/img/cli/win-successful-choco-install.png "Successful Chocolatey installation")
+![Successful Chocolatey installation](/public/img/cli/win-successful-choco-install.png "Successful Chocolatey installation")
 
 You should now be able to use the `choco` command. Type in `choco`, this should return the version of Chocolatey you have installed.
 
-![Chocolatey version](/img/cli/win-choco-version.png "Chocolatey version")
+![Chocolatey version](/public/img/cli/win-choco-version.png "Chocolatey version")
 
 If this command fails, you may need to restart your Windows Command Prompt. Close it down, and reopen it. Please note that you now don't need to open it with Administrator privileges, so instead of right-clicking on the `cmd.exe` program, you can just click on it.
 

--- a/x/docs/md/cli/windows.md
+++ b/x/docs/md/cli/windows.md
@@ -69,6 +69,13 @@ exercism configure --dir=C:\exercism
 ### Continue
 You can now continue by [choosing a language](http://exercism.io/languages).
 
+### Uninstalling the Exercism CLI
+
+You can use Chocolately to uninstall the package for you.
+```
+choco uninstall exercism-io-cli
+```
+
 ### Help
 
 #### Opening the Windows Command Prompt with Administrator Privileges <a name="open-win-cmd"></a>


### PR DESCRIPTION
Issue #1844 highlights the missing information of how to uninstall the Exercism CLI tool.

This change adds a small section on how to uninstall the package using Chocolately, the package manager already used in the docs. It shows the use how to use the `uninstall` command.

Another change made here was to fix the broken images on the page. When I first loaded the page I saw these broken links:

<img width="986" alt="exercism_io_windows_md_at_master_ _exercism_exercism_io" src="https://cloud.githubusercontent.com/assets/1518902/23931230/6be17bac-08ee-11e7-8bd4-d1f56fcba4e6.png">



