### PR TITLE
Make Flipper available in all environments

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -25,8 +25,6 @@ require 'api/v1'
 
 ENV['RACK_ENV'] ||= 'development'
 
-$flipper = Flipper.new(Flipper::Adapters::ActiveRecord.new)
-
 use ActiveRecord::ConnectionAdapters::ConnectionManagement
 use Rack::MethodOverride
 run Rack::URLMap.new(

--- a/config/flipper.rb
+++ b/config/flipper.rb
@@ -1,0 +1,4 @@
+require 'flipper/adapters/active_record'
+
+adapter = Flipper::Adapters::ActiveRecord.new
+$flipper = Flipper.new(adapter)

--- a/lib/exercism.rb
+++ b/lib/exercism.rb
@@ -2,6 +2,8 @@ require 'active_support' # Must be required before active_record
 require 'active_record'
 require 'faraday'
 
+require_relative '../config/flipper'
+
 require 'exercism/acl'
 require 'exercism/assumable_user'
 require 'exercism/named'


### PR DESCRIPTION
This is a followup to #3408.

Previously, it was defined only for the app server, not the console or tests.