### PR TITLE
Introduce "what next instructions" to submission API response

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - 'frontend/**/*'
     - 'vendor/**/*'

--- a/api/v1/routes/core.rb
+++ b/api/v1/routes/core.rb
@@ -45,6 +45,10 @@ module ExercismAPI
         def find_user
           User.where(key: params[:key]).first if params[:key]
         end
+
+        def site_root
+          request.host_with_port + '/'
+        end
       end
     end
   end

--- a/api/v1/routes/iterations.rb
+++ b/api/v1/routes/iterations.rb
@@ -115,6 +115,7 @@ module ExercismAPI
         locals = {
           submission: attempt.submission,
           domain: request.url.gsub(/#{request.path}$/, ""),
+          what_next_instructions: what_next_instructions(attempt)
         }
         pg :attempt, locals: locals
       end
@@ -134,6 +135,28 @@ module ExercismAPI
         submissions = exercises.map { |e| e.submissions.last }.compact
 
         pg :iterations, locals: { submissions: submissions }
+      end
+
+      private
+
+      def what_next_instructions(attempt)
+        return '' unless $flipper['cli-call-to-action'].enabled?(attempt.user)
+
+        track    = attempt.iteration.track_id
+        exercise = attempt.iteration.slug
+        url = File.join('http://', site_root, 'tracks', track, 'exercises', exercise)
+        <<~INSTRUCTIONS
+          Your #{track} solution for #{exercise} has been submitted.
+
+          Programmers generally spend far more time reading code than writing it.
+          To benefit the most from this exercise, find 3 or more submissions that you can
+          learn something from, have questions about, or have suggestions for.
+          Post your thoughts and questions in the comments, and start a discussion.
+          Consider revising your solution to incorporate what you learn.
+
+          Yours and others' solutions to this problem:
+          #{url}
+        INSTRUCTIONS
       end
     end
   end

--- a/api/v1/views/attempt.pg
+++ b/api/v1/views/attempt.pg
@@ -4,6 +4,7 @@ node language: submission.problem.language
 node slug: submission.slug
 node name: submission.problem.name
 node iteration: submission.version
+node what_next_instructions: what_next_instructions
 
 # deprecated
 node id: submission.key

--- a/test/api/assignments_test.rb
+++ b/test/api/assignments_test.rb
@@ -12,6 +12,7 @@ class AssignmentsApiTest < Minitest::Test
   attr_reader :alice
   def setup
     super
+    $flipper['cli-call-to-action'].enable
     @alice = User.create(username: 'alice', github_id: 1)
     Language.instance_variable_set(:"@by_track_id", "fake" => "Fake")
   end

--- a/test/fixtures/approvals/api_multifile_submission_accepted.approved.json
+++ b/test/fixtures/approvals/api_multifile_submission_accepted.approved.json
@@ -5,6 +5,7 @@
   "slug": "one",
   "name": "One",
   "iteration": 1,
+  "what_next_instructions": "Your fake solution for one has been submitted.\n\nProgrammers generally spend far more time reading code than writing it.\nTo benefit the most from this exercise, find 3 or more submissions that you can\nlearn something from, have questions about, or have suggestions for.\nPost your thoughts and questions in the comments, and start a discussion.\nConsider revising your solution to incorporate what you learn.\n\nYours and others' solutions to this problem:\nhttp://example.org/tracks/fake/exercises/one\n",
   "id": "<id>",
   "status": "saved",
   "track": "fake",

--- a/test/fixtures/approvals/api_submission_accepted.approved.json
+++ b/test/fixtures/approvals/api_submission_accepted.approved.json
@@ -5,6 +5,7 @@
   "slug": "one",
   "name": "One",
   "iteration": 1,
+  "what_next_instructions": "Your fake solution for one has been submitted.\n\nProgrammers generally spend far more time reading code than writing it.\nTo benefit the most from this exercise, find 3 or more submissions that you can\nlearn something from, have questions about, or have suggestions for.\nPost your thoughts and questions in the comments, and start a discussion.\nConsider revising your solution to incorporate what you learn.\n\nYours and others' solutions to this problem:\nhttp://example.org/tracks/fake/exercises/one\n",
   "id": "<id>",
   "status": "saved",
   "track": "fake",

--- a/test/fixtures/approvals/api_submission_accepted_on_completed.approved.json
+++ b/test/fixtures/approvals/api_submission_accepted_on_completed.approved.json
@@ -5,6 +5,7 @@
   "slug": "one",
   "name": "One",
   "iteration": 1,
+  "what_next_instructions": "Your fake solution for one has been submitted.\n\nProgrammers generally spend far more time reading code than writing it.\nTo benefit the most from this exercise, find 3 or more submissions that you can\nlearn something from, have questions about, or have suggestions for.\nPost your thoughts and questions in the comments, and start a discussion.\nConsider revising your solution to incorporate what you learn.\n\nYours and others' solutions to this problem:\nhttp://example.org/tracks/fake/exercises/one\n",
   "id": "<id>",
   "status": "saved",
   "track": "fake",


### PR DESCRIPTION
This is paired with https://github.com/exercism/cli/pull/377 but does not need not need a synchronized release. This change forward/backward compatible, tested in all combinations of new & old exercism.io and new & old cli.

In clients that support it, the "what next instructions" will be displayed after a new iteration is submitted.

This allows us to modify the message anytime, without having to wait for users to update their cli version.

Part of the experiment outlined in https://github.com/exercism/discussions/issues/123.