### PR TITLE
Add documentation about CLI completion scripts

### DIFF
--- a/x/docs/cli.rb
+++ b/x/docs/cli.rb
@@ -10,7 +10,7 @@ module X
       private
 
       def read(topic)
-        File.read("./x/docs/md/cli/#{topic}.md")
+        File.read("./x/docs/md/cli/#{topic}.md").gsub('COMPLETION_SECTION', File.read('./x/docs/md/cli/completion.md'))
       end
     end
   end

--- a/x/docs/md/cli/completion.md
+++ b/x/docs/md/cli/completion.md
@@ -1,0 +1,46 @@
+### Setting up Exercism CLI completion (optional)
+
+#### Bash
+
+If you use a Bash shell, you can use the CLI Bash-completion script.
+
+First download the script [[view source]](http://cli.exercism.io/exercism_completion.bash):
+
+```bash
+mkdir -p ~/.config/exercism/
+curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
+```
+
+Load up the completion in your `.bashrc`, `.bash_profile` or `.profile` by adding the following snippet:
+
+```bash
+if [ -f ~/.config/exercism/exercism_completion.bash ]; then
+  . ~/.config/exercism/exercism_completion.bash
+fi
+```
+
+After opening a new Bash shell, you should be able to type `exercism s` and Bash completion will give you `exercism submit`.
+
+#### Zsh
+
+If you use a Zsh shell, you can use the CLI Zsh-completion script.
+
+First download the script [[view source]](http://cli.exercism.io/exercism_completion.zsh):
+
+```zsh
+mkdir -p ~/.config/exercism/
+curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
+```
+
+Load up the completion in your `.zshrc`, `.zsh_profile` or `.profile` by adding the following snippet:
+
+```zsh
+if [ -f ~/.config/exercism/exercism_completion.zsh ]; then
+  . ~/.config/exercism/exercism_completion.zsh
+fi
+```
+
+If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your Zsh plugins,
+you don't need to add the above snippet, all you need to do is create a file `exercism_completion.zsh` inside `~/.oh-my-zsh/custom`.
+
+After opening a new Zsh shell, you should be able to type `exercism s` and Zsh completion will give you `exercism submit`.

--- a/x/docs/md/cli/linux.md
+++ b/x/docs/md/cli/linux.md
@@ -65,52 +65,7 @@ You can configure a different directory by passing the `--dir` option:
 exercism configure --dir=~/some/other/place
 ```
 
-### Setting up Exercism CLI completion (optional)
-
-#### Bash
-
-If you use a Bash shell, you can use the CLI Bash-completion script.
-
-First download the script [[view source]](http://cli.exercism.io/exercism_completion.bash):
-
-```bash
-mkdir -p ~/.config/exercism/
-curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
-```
-
-Load up the completion in your `.bashrc`, `.bash_profile` or `.profile` by adding the following snippet:
-
-```bash
-if [ -f ~/.config/exercism/exercism_completion.bash ]; then
-  . ~/.config/exercism/exercism_completion.bash
-fi
-```
-
-After opening a new Bash shell, you should be able to type `exercism s` and Bash completion will give you `exercism submit`.
-
-#### Zsh
-
-If you use a Zsh shell, you can use the CLI Zsh-completion script.
-
-First download the script [[view source]](http://cli.exercism.io/exercism_completion.zsh):
-
-```zsh
-mkdir -p ~/.config/exercism/
-curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
-```
-
-Load up the completion in your `.zshrc`, `.zsh_profile` or `.profile` by adding the following snippet:
-
-```zsh
-if [ -f ~/.config/exercism/exercism_completion.zsh ]; then
-  . ~/.config/exercism/exercism_completion.zsh
-fi
-```
-
-If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your Zsh plugins,
-you don't need to add the above snippet, all you need to do is create a file `exercism_completion.zsh` inside `~/.oh-my-zsh/custom`.
-
-After opening a new Zsh shell, you should be able to type `exercism s` and Zsh completion will give you `exercism submit`.
+COMPLETION_SECTION
 
 ### Continue
 You can now continue by [choosing a language](http://exercism.io/languages).

--- a/x/docs/md/cli/linux.md
+++ b/x/docs/md/cli/linux.md
@@ -65,6 +65,53 @@ You can configure a different directory by passing the `--dir` option:
 exercism configure --dir=~/some/other/place
 ```
 
+### Setting up Exercism CLI completion (optional)
+
+#### Bash
+
+If you use a Bash shell, you can use the CLI Bash-completion script.
+
+First download the script [[view source]](http://cli.exercism.io/exercism_completion.bash):
+
+```bash
+mkdir -p ~/.config/exercism/
+curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
+```
+
+Load up the completion in your `.bashrc`, `.bash_profile` or `.profile` by adding the following snippet:
+
+```bash
+if [ -f ~/.config/exercism/exercism_completion.bash ]; then
+  . ~/.config/exercism/exercism_completion.bash
+fi
+```
+
+After opening a new Bash shell, you should be able to type `exercism s` and Bash completion will give you `exercism submit`.
+
+#### Zsh
+
+If you use a Zsh shell, you can use the CLI Zsh-completion script.
+
+First download the script [[view source]](http://cli.exercism.io/exercism_completion.zsh):
+
+```zsh
+mkdir -p ~/.config/exercism/
+curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
+```
+
+Load up the completion in your `.zshrc`, `.zsh_profile` or `.profile` by adding the following snippet:
+
+```zsh
+if [ -f ~/.config/exercism/exercism_completion.zsh ]; then
+  . ~/.config/exercism/exercism_completion.zsh
+fi
+```
+
+If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your Zsh plugins,
+you don't need to add the above snippet, all you need to do is create a file `exercism_completion.zsh` inside `~/.oh-my-zsh/custom`.
+
+After opening a new Zsh shell, you should be able to type `exercism s` and Zsh completion will give you `exercism submit`.
+
 ### Continue
 You can now continue by [choosing a language](http://exercism.io/languages).
 

--- a/x/docs/md/cli/mac.md
+++ b/x/docs/md/cli/mac.md
@@ -69,52 +69,7 @@ You can configure a different directory by passing the `--dir` option:
 exercism configure --dir=~/some/other/place
 ```
 
-### Setting up Exercism CLI completion (optional)
-
-#### Bash
-
-If you use a Bash shell, you can use the CLI Bash-completion script.
-
-First download the script [[view source]](http://cli.exercism.io/exercism_completion.bash):
-
-```bash
-mkdir -p ~/.config/exercism/
-curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
-```
-
-Load up the completion in your `.bashrc`, `.bash_profile` or `.profile` by adding the following snippet:
-
-```bash
-if [ -f ~/.config/exercism/exercism_completion.bash ]; then
-  . ~/.config/exercism/exercism_completion.bash
-fi
-```
-
-After opening a new Bash shell, you should be able to type `exercism s` and Bash completion will give you `exercism submit`.
-
-#### Zsh
-
-If you use a Zsh shell, you can use the CLI Zsh-completion script.
-
-First download the script [[view source]](http://cli.exercism.io/exercism_completion.zsh):
-
-```zsh
-mkdir -p ~/.config/exercism/
-curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
-```
-
-Load up the completion in your `.zshrc`, `.zsh_profile` or `.profile` by adding the following snippet:
-
-```zsh
-if [ -f ~/.config/exercism/exercism_completion.zsh ]; then
-  . ~/.config/exercism/exercism_completion.zsh
-fi
-```
-
-If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your Zsh plugins,
-you don't need to add the above snippet, all you need to do is create a file `exercism_completion.zsh` inside `~/.oh-my-zsh/custom`.
-
-After opening a new Zsh shell, you should be able to type `exercism s` and Zsh completion will give you `exercism submit`.
+COMPLETION_SECTION
 
 ### Continue
 

--- a/x/docs/md/cli/mac.md
+++ b/x/docs/md/cli/mac.md
@@ -69,6 +69,53 @@ You can configure a different directory by passing the `--dir` option:
 exercism configure --dir=~/some/other/place
 ```
 
+### Setting up Exercism CLI completion (optional)
+
+#### Bash
+
+If you use a Bash shell, you can use the CLI Bash-completion script.
+
+First download the script [[view source]](http://cli.exercism.io/exercism_completion.bash):
+
+```bash
+mkdir -p ~/.config/exercism/
+curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
+```
+
+Load up the completion in your `.bashrc`, `.bash_profile` or `.profile` by adding the following snippet:
+
+```bash
+if [ -f ~/.config/exercism/exercism_completion.bash ]; then
+  . ~/.config/exercism/exercism_completion.bash
+fi
+```
+
+After opening a new Bash shell, you should be able to type `exercism s` and Bash completion will give you `exercism submit`.
+
+#### Zsh
+
+If you use a Zsh shell, you can use the CLI Zsh-completion script.
+
+First download the script [[view source]](http://cli.exercism.io/exercism_completion.zsh):
+
+```zsh
+mkdir -p ~/.config/exercism/
+curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
+```
+
+Load up the completion in your `.zshrc`, `.zsh_profile` or `.profile` by adding the following snippet:
+
+```zsh
+if [ -f ~/.config/exercism/exercism_completion.zsh ]; then
+  . ~/.config/exercism/exercism_completion.zsh
+fi
+```
+
+If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your Zsh plugins,
+you don't need to add the above snippet, all you need to do is create a file `exercism_completion.zsh` inside `~/.oh-my-zsh/custom`.
+
+After opening a new Zsh shell, you should be able to type `exercism s` and Zsh completion will give you `exercism submit`.
+
 ### Continue
 
 You can now continue by [choosing a language](http://exercism.io/languages).

--- a/x/docs/md/cli/windows.md
+++ b/x/docs/md/cli/windows.md
@@ -66,52 +66,7 @@ This will fetch your exercises to `C:\Users\your-user-name\my-exercism-exercises
 exercism configure --dir=C:\exercism
 ```
 
-### Setting up Exercism CLI completion (optional)
-
-#### Bash
-
-If you use a Bash shell, you can use the CLI Bash-completion script.
-
-First download the script [[view source]](http://cli.exercism.io/exercism_completion.bash):
-
-```bash
-mkdir -p ~/.config/exercism/
-curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
-```
-
-Load up the completion in your `.bashrc`, `.bash_profile` or `.profile` by adding the following snippet:
-
-```bash
-if [ -f ~/.config/exercism/exercism_completion.bash ]; then
-  . ~/.config/exercism/exercism_completion.bash
-fi
-```
-
-After opening a new Bash shell, you should be able to type `exercism s` and Bash completion will give you `exercism submit`.
-
-#### Zsh
-
-If you use a Zsh shell, you can use the CLI Zsh-completion script.
-
-First download the script [[view source]](http://cli.exercism.io/exercism_completion.zsh):
-
-```zsh
-mkdir -p ~/.config/exercism/
-curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
-```
-
-Load up the completion in your `.zshrc`, `.zsh_profile` or `.profile` by adding the following snippet:
-
-```zsh
-if [ -f ~/.config/exercism/exercism_completion.zsh ]; then
-  . ~/.config/exercism/exercism_completion.zsh
-fi
-```
-
-If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your Zsh plugins,
-you don't need to add the above snippet, all you need to do is create a file `exercism_completion.zsh` inside `~/.oh-my-zsh/custom`.
-
-After opening a new Zsh shell, you should be able to type `exercism s` and Zsh completion will give you `exercism submit`.
+COMPLETION_SECTION
 
 ### Continue
 You can now continue by [choosing a language](http://exercism.io/languages).

--- a/x/docs/md/cli/windows.md
+++ b/x/docs/md/cli/windows.md
@@ -66,6 +66,53 @@ This will fetch your exercises to `C:\Users\your-user-name\my-exercism-exercises
 exercism configure --dir=C:\exercism
 ```
 
+### Setting up Exercism CLI completion (optional)
+
+#### Bash
+
+If you use a Bash shell, you can use the CLI Bash-completion script.
+
+First download the script [[view source]](http://cli.exercism.io/exercism_completion.bash):
+
+```bash
+mkdir -p ~/.config/exercism/
+curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
+```
+
+Load up the completion in your `.bashrc`, `.bash_profile` or `.profile` by adding the following snippet:
+
+```bash
+if [ -f ~/.config/exercism/exercism_completion.bash ]; then
+  . ~/.config/exercism/exercism_completion.bash
+fi
+```
+
+After opening a new Bash shell, you should be able to type `exercism s` and Bash completion will give you `exercism submit`.
+
+#### Zsh
+
+If you use a Zsh shell, you can use the CLI Zsh-completion script.
+
+First download the script [[view source]](http://cli.exercism.io/exercism_completion.zsh):
+
+```zsh
+mkdir -p ~/.config/exercism/
+curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
+```
+
+Load up the completion in your `.zshrc`, `.zsh_profile` or `.profile` by adding the following snippet:
+
+```zsh
+if [ -f ~/.config/exercism/exercism_completion.zsh ]; then
+  . ~/.config/exercism/exercism_completion.zsh
+fi
+```
+
+If you are using the popular [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) framework to manage your Zsh plugins,
+you don't need to add the above snippet, all you need to do is create a file `exercism_completion.zsh` inside `~/.oh-my-zsh/custom`.
+
+After opening a new Zsh shell, you should be able to type `exercism s` and Zsh completion will give you `exercism submit`.
+
 ### Continue
 You can now continue by [choosing a language](http://exercism.io/languages).
 


### PR DESCRIPTION
This addresses https://github.com/exercism/exercism.io/issues/3402, which pointed out that the CLI completion scripts that are documented on http://cli.exercism.io/ aren't mentioned on [the main CLI pages](http://exercism.io/cli).

I made some slight copy tweaks from the original on http://cli.exercism.io that I think match the style of the surrounding content. The content is the same for Mac, Windows, and Linux, but I opted to include it on each individual page instead of creating a new tab to make sure that new users would see it as they installed the CLI on their OS. (I'm on a Mac, and the instructions worked well for setting up Bash completion on my machine, although I didn't test out Zsh or anything on Windows or Linux.)