### PR TITLE
Follow project migration id naming convention

### DIFF
--- a/db/migrate/201703132312_create_flipper_tables.rb
+++ b/db/migrate/201703132312_create_flipper_tables.rb
@@ -1,5 +1,11 @@
 class CreateFlipperTables < ActiveRecord::Migration
   def self.up
+    # Migration may have already run with a different version before it was renamed
+    if table_exists? :flipper_features
+      execute "DELETE FROM schema_migrations WHERE version='20170313231200'"
+      return
+    end
+
     create_table :flipper_features do |t|
       t.string :key, null: false
       t.timestamps null: false


### PR DESCRIPTION
This migration was created following the rails convention of including
seconds digits in the id, rather than the project convention.

Since this migration may already have run in some environments, this
patch cleans up after the rename.

* The migration is renamed
* The old migration id is discarded in `schema_migrations`
* If the migration work was already done, return and do nothing.