### PR TITLE
Fix link to sequence diagram image

### DIFF
--- a/docs/overview-architecture.md
+++ b/docs/overview-architecture.md
@@ -20,7 +20,7 @@ We have developed some domain concepts in order to communicate effectively. Thes
 
 The system is broken into smaller components which represent different areas of concern.
 
-![Core flow sequence diagram](docs/img/core_flow_sequence_diagram.png)
+![Core flow sequence diagram](img/core_flow_sequence_diagram.png)
 
 The components that make up Exercism are:
 


### PR DESCRIPTION
The link to the [sequence_diagram](https://github.com/exercism/exercism.io/blob/master/docs/img/core_flow_sequence_diagram.png) introduced with https://github.com/exercism/exercism.io/pull/3411 is broken.

![exercism io-overview-architecture md](https://cloud.githubusercontent.com/assets/16028784/24167973/67034c80-0e81-11e7-90dd-b8d4a535dc46.png)

With this PR we fix the link.