### PR TITLE
Redirect user back to exercise page after (un)archiving

### DIFF
--- a/app/routes/user_exercises.rb
+++ b/app/routes/user_exercises.rb
@@ -38,13 +38,13 @@ module ExercismWeb
 
       post '/exercises/:key/archive' do |key|
         exercise = UserExercise.find_by_key(key)
-        unless current_user.owns?(exercise)
+        if current_user.owns?(exercise)
+          exercise.archive!
+          flash[:success] = "#{exercise.problem.name} in #{exercise.problem.track_id} is now archived."
+        else
           flash[:notice] = "Only the author may archive the exercise."
-          redirect "/exercises/#{key}"
         end
-        exercise.archive!
-        flash[:success] = "#{exercise.problem.name} in #{exercise.problem.track_id} is now archived."
-        redirect '/'
+        redirect "/exercises/#{key}"
       end
 
       post '/exercises/archive' do
@@ -57,13 +57,13 @@ module ExercismWeb
 
       post '/exercises/:key/unarchive' do |key|
         exercise = UserExercise.find_by_key(key)
-        unless current_user.owns?(exercise)
+        if current_user.owns?(exercise)
+          exercise.unarchive!
+          flash[:success] = "#{exercise.problem.name} in #{exercise.problem.track_id} is now reactivated."
+        else
           flash[:notice] = "Only the author may reactivate the exercise."
-          redirect "/exercises/#{key}"
         end
-        exercise.unarchive!
-        flash[:success] = "#{exercise.problem.name} in #{exercise.problem.track_id} is now reactivated."
-        redirect '/dashboard'
+        redirect "/exercises/#{key}"
       end
 
       post '/exercises/:key/request-for-help' do |key|

--- a/test/app/exercises_test.rb
+++ b/test/app/exercises_test.rb
@@ -31,11 +31,15 @@ class AppExercisesTest < Minitest::Test
   end
 
   def test_archive_and_unarchive
+    exercise_location = "http://example.org/exercises/#{exercise.key}"
+
     post "/exercises/#{exercise.key}/archive", {}, login(alice)
     assert exercise.reload.archived?
+    assert_equal exercise_location, last_response.location, "Archiving should redirect to the exercise page"
 
     post "/exercises/#{exercise.key}/unarchive", {}, login(alice)
     refute exercise.reload.archived?
+    assert_equal exercise_location, last_response.location, "Unarchiving should redirect to the exercise page"
   end
 
   def test_bulk_archive


### PR DESCRIPTION
This addresses https://github.com/exercism/exercism.io/issues/3381. Instead of redirecting a user to the dashboard after archiving or unarchiving an exercise, this redirects the user back to the exercise page for further review.