### PR TITLE
Follow flipper-suggested feature name convention

### DIFF
--- a/api/v1/routes/iterations.rb
+++ b/api/v1/routes/iterations.rb
@@ -140,7 +140,7 @@ module ExercismAPI
       private
 
       def what_next_instructions(attempt)
-        return '' unless $flipper['cli-call-to-action'].enabled?(attempt.user)
+        return '' unless $flipper['cli_call_to_action'].enabled?(attempt.user)
 
         track    = attempt.iteration.track_id
         exercise = attempt.iteration.slug

--- a/test/api/assignments_test.rb
+++ b/test/api/assignments_test.rb
@@ -12,7 +12,7 @@ class AssignmentsApiTest < Minitest::Test
   attr_reader :alice
   def setup
     super
-    $flipper['cli-call-to-action'].enable
+    $flipper['cli_call_to_action'].enable
     @alice = User.create(username: 'alice', github_id: 1)
     Language.instance_variable_set(:"@by_track_id", "fake" => "Fake")
   end


### PR DESCRIPTION
> Recommended naming conventions: lower case, snake case, underscores over dashes. 
> Good: foo_bar, foo.
> Bad: FooBar, Foo Bar, foo bar, foo-bar.

—/flipper/features/new