### PR TITLE
Fix transposed method names

### DIFF
--- a/lib/exercism/client_version.rb
+++ b/lib/exercism/client_version.rb
@@ -24,7 +24,7 @@ module ExercismWeb
     private
 
     def dismissed?
-      user.guest? || user.client_update_version_notification_dismissed_at.present?
+      user.guest? || user.client_version_update_notification_dismissed_at.present?
     end
   end
 end

--- a/test/exercism/client_version_test.rb
+++ b/test/exercism/client_version_test.rb
@@ -9,7 +9,7 @@ module ExercismWeb
     def test_notice_when_client_outdated_not_dismissed
       dismissed_at = nil
       user = stub(:user)
-      user.stubs(username: 'been', guest?: false, client_update_version_notification_dismissed_at: dismissed_at)
+      user.stubs(username: 'been', guest?: false, client_version_update_notification_dismissed_at: dismissed_at)
       client_version = ClientVersion.new(user: user)
       assert client_version.notice_when_client_outdated.present?, "Expected a notice when not dismissed"
     end
@@ -17,7 +17,7 @@ module ExercismWeb
     def test_notice_when_client_outdated_dismissed
       dismissed_at = Time.now
       user = stub(:user)
-      user.stubs(username: 'been', guest?: false, client_update_version_notification_dismissed_at: dismissed_at)
+      user.stubs(username: 'been', guest?: false, client_version_update_notification_dismissed_at: dismissed_at)
       client_version = ClientVersion.new(user: user)
       assert client_version.notice_when_client_outdated.blank?, "Expected no notice after dismissed"
     end


### PR DESCRIPTION
This was a quick-edit and no manual test, verifying doubles, or integration test failure.

It was a win for feature flags though. Even though the bug was merged to master, it would never be noticed without the feature flag being enabled.