### PR TITLE
Fix typo in Zsh completion instructions

### DIFF
--- a/x/docs/md/cli/completion.md
+++ b/x/docs/md/cli/completion.md
@@ -29,7 +29,7 @@ First download the script [[view source]](http://cli.exercism.io/exercism_comple
 
 ```zsh
 mkdir -p ~/.config/exercism/
-curl http://cli.exercism.io/exercism_completion.bash > ~/.config/exercism/exercism_completion.bash
+curl http://cli.exercism.io/exercism_completion.zsh > ~/.config/exercism/exercism_completion.zsh
 ```
 
 Load up the completion in your `.zshrc`, `.zsh_profile` or `.profile` by adding the following snippet:


### PR DESCRIPTION
I made a typo in my original PR that included documentation about how to set up Zsh completion, and @felixbig kindly pointed it out here: https://github.com/exercism/exercism.io/pull/3415#discussion_r107943395