### PR TITLE
Monkeypatch Flipper to provide a consistent control group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'activerecord', '~> 4.2.1'
 
 gem 'bugsnag'
 gem 'faraday'
+gem 'flipper', '0.10.2' # locked due to monkey patch
 gem 'flipper-active_record'
 gem 'flipper-ui'
 gem 'loofah'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,7 @@ DEPENDENCIES
   database_cleaner
   dotenv
   faraday
+  flipper (= 0.10.2)
   flipper-active_record
   flipper-ui
   font-awesome-sass

--- a/config/flipper.rb
+++ b/config/flipper.rb
@@ -1,3 +1,4 @@
+require 'monkey_patches/flipper/gates/percentage_of_actors'
 require 'flipper/adapters/active_record'
 
 adapter = Flipper::Adapters::ActiveRecord.new

--- a/lib/monkey_patches/flipper/gates/percentage_of_actors.rb
+++ b/lib/monkey_patches/flipper/gates/percentage_of_actors.rb
@@ -1,0 +1,25 @@
+require 'flipper'
+
+module Flipper
+  module Gates
+    class PercentageOfActors
+      # Override to consider only the actor value (GitHub username), not the feature
+      # name, to provide a consistent control group across features, rather than a
+      # different 50% for each feature.
+      #
+      # Original: https://git.io/vSkAP
+      #
+      def open?(context)
+        percentage = context.values[key]
+
+        if Types::Actor.wrappable?(context.thing)
+          actor = Types::Actor.wrap(context.thing)
+          key = actor.value ## modified
+          Zlib.crc32(key) % 100 < percentage
+        else
+          false
+        end
+      end
+    end
+  end
+end

--- a/test/monkey_patches/flipper/gates/percentage_of_actors_test.rb
+++ b/test/monkey_patches/flipper/gates/percentage_of_actors_test.rb
@@ -1,0 +1,28 @@
+require_relative '../../../test_helper'
+require 'ostruct'
+require 'monkey_patches/flipper/gates/percentage_of_actors'
+require 'mocha/mini_test'
+
+class FlipperPercentageOfActorsTest < Minitest::Test
+  def test_control_group_consistent_across_features
+    50.times do |user_id|
+      github_username = "user#{user_id}"
+      actor = OpenStruct.new(flipper_id: github_username)
+      base_case_enabled = enabled_for?(actor, :base_feature)
+      50.times do |feature_id|
+        feature = "feature_#{feature_id}"
+        assert_equal base_case_enabled, enabled_for?(actor, feature)
+      end
+    end
+  end
+
+  def enabled_for?(actor, feature_id)
+    context = OpenStruct.new(
+      values: {percentage_of_actors: 50},
+      thing: actor,
+      feature_name: "feature#{feature_id}"
+    )
+    gate = Flipper::Gates::PercentageOfActors.new
+    gate.open?(context)
+  end
+end


### PR DESCRIPTION
This is for the exercism/discussions#123 experiment.

Override to consider only the actor value (GitHub username), not the feature name, to provide a consistent control group across features, rather than a different 50% for each feature.

This new test fails without the monkey patch. Considering the boolean output and the random-like nature of Zlib.crc32 output ([the hashing algorithm used][crc32]), 250 iterations should more than cover it. The test completes in 40ms on my machine.

[crc32]: https://github.com/jnunemaker/flipper/blob/v0.10.2/lib/flipper/gates/percentage_of_actors.rb#L33