### PR TITLE
I think we're not in beta anymore

### DIFF
--- a/app/views/site/index.erb
+++ b/app/views/site/index.erb
@@ -24,7 +24,7 @@
           </p>
           <p>
           <i class="fa fa-comment"></i>
-          Submit the solution to the site for feedback (<em>beta</em>).
+          Submit the solution to the site for feedback.
           </p>
           <p>
           <i class="fa fa-heart"></i>


### PR DESCRIPTION
Submitting solutions to the site for feedback is a core part of exercism. It's a well-used part of the exercism experience, and I hardly think we can call it beta any more. Time to remove the Beta™ branding? :tada:

Just a suggestion. Feel free to discuss! :smile:

![beta screenshot](https://cloud.githubusercontent.com/assets/64751/24338433/6566085e-1273-11e7-8361-88a3a0a4cd3c.png)