### PR TITLE
Namespace all /cli routes under /clients

### DIFF
--- a/app/routes/static.rb
+++ b/app/routes/static.rb
@@ -36,25 +36,13 @@ module ExercismWeb
         erb :"site/how_it_works_newbie"
       end
 
-      get '/cli' do
+      %w(overview mac windows linux install).each do |topic|
         # Add OS detection logic & redirect here
-        erb :"site/cli", locals: { docs: X::Docs::CLI.new, page: :overview }
-      end
+        url_pattern = "/#{topic}" unless topic == 'overview'
 
-      get '/cli/mac' do
-        erb :"site/cli", locals: { docs: X::Docs::CLI.new, page: :mac }
-      end
-
-      get '/cli/windows' do
-        erb :"site/cli", locals: { docs: X::Docs::CLI.new, page: :windows }
-      end
-
-      get '/cli/linux' do
-        erb :"site/cli", locals: { docs: X::Docs::CLI.new, page: :linux }
-      end
-
-      get '/cli/install' do
-        erb :"site/cli", locals: { docs: X::Docs::CLI.new, page: :install }
+        get "/clients/cli#{url_pattern}" do
+          erb :"site/cli", locals: { docs: X::Docs::CLI.new, page: topic.to_sym }
+        end
       end
 
       get '/privacy' do

--- a/app/views/application/footer/links.erb
+++ b/app/views/application/footer/links.erb
@@ -15,7 +15,7 @@
     </a>
   </li>
   <li>
-    <a href="/cli">
+    <a href="/clients/cli">
       Install the Command-Line Client
     </a>
   </li>

--- a/app/views/languages/_about.erb
+++ b/app/views/languages/_about.erb
@@ -2,7 +2,7 @@
 
 <h3>Try It!</h3>
 <p>
-  If you've downloaded the <a href='/cli'>command-line client</a> and have <%= track.language %> installed
+  If you've downloaded the <a href='/clients/cli'>command-line client</a> and have <%= track.language %> installed
   on your machine, then go ahead and fetch the first problem.
 </p>
 <%= syntax "exercism fetch #{track.id}", "plain" %>

--- a/app/views/site/cli.erb
+++ b/app/views/site/cli.erb
@@ -7,20 +7,20 @@
 
     <ul class="nav nav-tabs">
         <li <%= 'class="active"' if page == :overview %>>
-        <a href="/cli">Overview</a>
+        <a href="/clients/cli">Overview</a>
       </li>
       <li <%= 'class="active"' if page == :mac %>>
-        <a href="/cli/mac">Mac OS X</a>
+        <a href="/clients/cli/mac">Mac OS X</a>
       </li>
       <li <%= 'class="active"' if page == :windows %>>
-        <a href="/cli/windows">Windows</a>
+        <a href="/clients/cli/windows">Windows</a>
       </li>
 
       <li <%= 'class="active"' if page == :linux %>>
-        <a href="/cli/linux">Linux</a>
+        <a href="/clients/cli/linux">Linux</a>
       </li>
      <li <%= 'class="active"' if page == :install %>>
-        <a href="/cli/install">Install Alternatives</a>
+        <a href="/clients/cli/install">Install Alternatives</a>
       </li>
     </ul>
     <%= md docs.send(page)  %>

--- a/app/views/site/how_it_works_newbie.erb
+++ b/app/views/site/how_it_works_newbie.erb
@@ -107,10 +107,10 @@
     <div class="col-md-8">
       <p>
       How you install the Exercism CLI depends on what kind of computer you have.
-      We've explained all of this in detail on <a href="/cli">the installation page</a>.
+      We've explained all of this in detail on <a href="/clients/cli">the installation page</a>.
       </p>
 
-      <p><a href="/cli">Installing the Command Line Interface</a></p>
+      <p><a href="/clients/cli">Installing the Command Line Interface</a></p>
     </div>
 
     <div class="col-md-4 hints text-muted">

--- a/test/app/static_pages_test.rb
+++ b/test/app/static_pages_test.rb
@@ -58,8 +58,8 @@ class StaticPagesTest < Minitest::Test
     assert_equal 'newbie', session[:target_profile]
   end
 
-  def test_route_cli
-    get '/cli'
+  def test_route_clients_cli
+    get '/clients/cli'
     assert_equal 200, last_response.status
     assert_match(/Command-Line Interface \(CLI\)/, last_response.body)
   end


### PR DESCRIPTION
This fixes issue #3442 to put '/cli' and future '/gui' routes under a namespace, ('/clients').

Changes:

- all '/cli' routes are now namespaced under '/clients'
- test for '/cli' in app/test/static_pages_test.rb has been updated with namespaced URL
- all links to cli docs have been updated with '/clients' prepended to URLS

Some questions: 
- We can make more changes, like conflate the routes using an array like this: 

`%w(mac windows linux install).each { |topic| get "/cli/#{topic}" do ... }`

Don't know if that makes it unclear to read, but may be worth it? 

- Should the filename of the erb  file in /app/views/site/ be changed from cli.erb to clients_cli.erb?
- There's only 1 test for the /clients/cli route; is it because testing the content of the pages, (/clients/cli/linux for example) isn't worthwhile to test?
