### PR TITLE
Map Rouge highlighting for delphi to pascal

### DIFF
--- a/lib/exercism/syntax_highlighter.rb
+++ b/lib/exercism/syntax_highlighter.rb
@@ -12,6 +12,7 @@ module ExercismLib
       'ecmascript'  => 'javascript',
       'perl5'       => 'perl',
       'crystal'     => 'ruby',
+      'delphi'      => 'pascal',
     }.freeze
 
     attr_reader :lexer, :code


### PR DESCRIPTION
ref: #3450

Rouge doesn't know what delphi is so we need to map delphi to pascal.