### PR TITLE
Use fallback when language is missing topic content

### DIFF
--- a/app/presenters.rb
+++ b/app/presenters.rb
@@ -5,6 +5,7 @@ module ExercismWeb
       Setup: 'setup',
       Dashboard: 'dashboard',
       Profile: 'profile',
+      Track: 'track',
     }.each do |name, file|
       autoload name, Exercism.relative_to_root('app', 'presenters', file)
     end

--- a/app/presenters/track.rb
+++ b/app/presenters/track.rb
@@ -7,7 +7,11 @@ module ExercismWeb
       end
 
       def method_missing(method, *args)
-        trackler_track.send(method, *args)
+        if trackler_track.respond_to?(method)
+          trackler_track.send(method, *args)
+        else
+          super
+        end
       end
 
       def docs
@@ -16,10 +20,8 @@ module ExercismWeb
         track_docs.each_pair do |topic_name, topic_content|
           track_docs[topic_name] = if topic_content.present?
                                      topic_content
-                                   elsif default_topic_content(topic_name).present?
-                                     default_topic_content(topic_name)
                                    else
-                                     ''
+                                     default_topic_content(topic_name)
                                    end
         end
 
@@ -30,7 +32,8 @@ module ExercismWeb
 
       def default_topic_content(topic_name)
         filepath = "./x/docs/md/track/#{topic_name.upcase}.md"
-        File.read(filepath) if File.exist?(filepath)
+        return '' unless File.exist?(filepath)
+        File.read(filepath)
       end
 
       def trackler_track

--- a/app/presenters/track.rb
+++ b/app/presenters/track.rb
@@ -1,0 +1,39 @@
+module ExercismWeb
+  module Presenters
+    class Track
+
+      def initialize(track_id)
+        @track_id = track_id
+        @track = Trackler.tracks[track_id]
+      end
+
+      def method_missing(method, *args)
+        @track.send(method, *args)
+      end
+
+      def docs
+        track_docs = @track.docs("/api/v1/tracks/%s/images/docs/img" % @track_id)
+
+        track_docs.each_pair do |topic_name, topic_content|
+          track_docs[topic_name] = if topic_content.present?
+                                     topic_content
+                                   elsif default_topic_content(topic_name).present?
+                                     default_topic_content(topic_name)
+                                   else
+                                     ''
+                                   end
+        end
+
+        track_docs
+      end
+
+      private
+
+      def default_topic_content(topic_name)
+        filepath = "./x/docs/md/track/#{topic_name.upcase}.md"
+        File.read(filepath) if File.exist?(filepath)
+      end
+
+    end
+  end
+end

--- a/app/presenters/track.rb
+++ b/app/presenters/track.rb
@@ -4,15 +4,14 @@ module ExercismWeb
 
       def initialize(track_id)
         @track_id = track_id
-        @track = Trackler.tracks[track_id]
       end
 
       def method_missing(method, *args)
-        @track.send(method, *args)
+        trackler_track.send(method, *args)
       end
 
       def docs
-        track_docs = @track.docs("/api/v1/tracks/%s/images/docs/img" % @track_id)
+        track_docs = trackler_track.docs("/api/v1/tracks/%s/images/docs/img" % @track_id)
 
         track_docs.each_pair do |topic_name, topic_content|
           track_docs[topic_name] = if topic_content.present?
@@ -32,6 +31,10 @@ module ExercismWeb
       def default_topic_content(topic_name)
         filepath = "./x/docs/md/track/#{topic_name.upcase}.md"
         File.read(filepath) if File.exist?(filepath)
+      end
+
+      def trackler_track
+        Trackler.tracks[@track_id]
       end
 
     end

--- a/app/routes/languages.rb
+++ b/app/routes/languages.rb
@@ -41,13 +41,13 @@ module ExercismWeb
           template = "topic_not_found"
         end
 
-        track = Trackler.tracks[track_id]
+        track = Presenters::Track.new(track_id)
         if track.exists?
           erb :"languages/language", locals: {
             track: track,
             topic: topic,
             template: template,
-            docs: track.docs("/api/v1/tracks/%s/images/docs/img" % track_id)
+            docs: track.docs
           }
         else
           language_not_found(track_id)

--- a/test/app/presenters/track_test.rb
+++ b/test/app/presenters/track_test.rb
@@ -1,0 +1,30 @@
+require_relative '../../test_helper'
+require_relative '../../../app/presenters/track'
+require_relative '../../api_helper'
+require 'mocha/setup'
+
+class PresentersTrackTest < Minitest::Test
+  def setup
+    @track = ExercismWeb::Presenters::Track.new("test_track")
+    @trackler_track = Object.new
+    @track.stubs(:trackler_track).returns(@trackler_track)
+    @track.stubs(:default_topic_content).returns("Default topic content")
+  end
+
+  def test_docs_with_trackler_content
+    trackler_docs = OpenStruct.new(test_topic: "Track-specific content from Trackler")
+    @trackler_track.stubs(:docs).returns(trackler_docs)
+    assert_equal @track.docs["test_topic"], "Track-specific content from Trackler"
+  end
+
+  def test_docs_without_trackler_content
+    trackler_docs = OpenStruct.new(test_topic: "")
+    @trackler_track.stubs(:docs).returns(trackler_docs)
+    assert_equal @track.docs["test_topic"], "Default topic content"
+  end
+
+  def test_method_delegated_to_trackler_track
+    @trackler_track.stubs(:exists?).returns(true)
+    assert_equal @track.exists?, true
+  end
+end


### PR DESCRIPTION
https://github.com/exercism/exercism.io/issues/3356 highlighted that when a language topic page is missing content, it shows a blank page instead of the fallback content in [x/docs/md/track](https://github.com/exercism/exercism.io/tree/master/x/docs/md/track). This functionality likely broke when we switched over to using Trackler to grab content for these pages.

Since the normal content for these pages lives in Trackler but the fallback content lives in this repo, this PR creates a wrapper around tracks returned by Trackler and inserts the fallback topic content when Trackler doesn't have any. The wrapper delegates everything else back to the Trackler track.

This could use some polishing and tests (could be a little tricky since we'll want to stub out Trackler), but I wanted to get a proof of concept out for feedback to check to see if this is the right direction or if there's a better approach out there.