### PR TITLE
Fix broken anchor links

### DIFF
--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -43,7 +43,7 @@ Exercism.io depends on the following:
 These instructions present two options:
 
 1. Run exercism.io on your computer directly by installing the required software as listed in the following section (Running exercism.io directly on your computer).
-2. Run exercism.io [with Docker](#running-exercism-io-with-docker).
+2. Run exercism.io [with Docker](#running-exercismio-with-docker).
 
 ### Running exercism.io directly on your computer
 
@@ -147,7 +147,7 @@ The script will:
 
 NOTE: If you are running exercism.io in a Docker container, prepend all commands below with `docker-compose run app` (as described in [Docker and exercism.io: Other Tasks](https://github.com/exercism/exercism.io/tree/master/docker#other-tasks)).
 
-After you have [initialized exercism.io](#initialize-exercism-io) successfully, you're ready to fire it up:
+After you have [initialized exercism.io](#initialize-exercismio) successfully, you're ready to fire it up:
 
 1. Start the server:
 
@@ -161,7 +161,7 @@ After you have [initialized exercism.io](#initialize-exercism-io) successfully, 
 
 When exploring our debugging, you may find it useful to have a [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) that loads the exercism environment.  This is accomplished in Ruby environments through [`pry`](http://pryrepl.org/).
 
-After you have [initialized exercism.io](#initialize-exercism-io) successfully, you can start the REPL:
+After you have [initialized exercism.io](#initialize-exercismio) successfully, you can start the REPL:
 
 ```bash
 $ bundle exec bin/console
@@ -219,7 +219,7 @@ If you have created a user and are having `PG::Connection ...` or `Peer authenti
 
 ### Authenticate with GitHub
 
-When you [initialized your local copy of exercism.io](#initialize-exercism-io), it created a set of fake users.  You can log in as one of these faked users by selecting the from the dropdown in the header.  This skips the need to do the OAuth flow with GitHub.
+When you [initialized your local copy of exercism.io](#initialize-exercismio), it created a set of fake users.  You can log in as one of these faked users by selecting the from the dropdown in the header.  This skips the need to do the OAuth flow with GitHub.
 
 However, if you want to work on the login flow, itself, or for some reason want to log in as yourself, then you will need to setup client authentication OAuth with GitHub.
 


### PR DESCRIPTION
This fixes issues #3459 , 'Anchor links broken in setting-up-local-development.md.'

Removing the extra '-' in link fixes anchor links.