### PR TITLE
Show time in 24h format

### DIFF
--- a/frontend/app/js/script.js
+++ b/frontend/app/js/script.js
@@ -119,7 +119,7 @@ $(function() {
       var timeZoneAbbrevation = moment.tz(localizedTime.format("YYYY-MM-DD"), timeZone).format('z');
       // PST or PDT
 
-      var formattedTime = localizedTime.format("D MMMM YYYY [at] h:mm ");
+      var formattedTime = localizedTime.format("D MMMM YYYY [at] H:mm ");
       return formattedTime + timeZoneAbbrevation;
     }
 


### PR DESCRIPTION
`h:mm` displays the time in 12 hour format. There is no distinction between AM/PM here, so changing to `H:mm` for 24 hour format.