### PR TITLE
Update links in cli docs

### DIFF
--- a/x/docs/md/cli/mac.md
+++ b/x/docs/md/cli/mac.md
@@ -2,7 +2,7 @@
 
 Below are instructions for install using the most common method - using Homebrew. For further help and instructions, see:
 
-1. [Install Alternatives for instructions on installing without Homebrew](/cli/install)
+1. [Install Alternatives for instructions on installing without Homebrew](/clients/cli/install)
 2. [exercism.io general help](http://exercism.io/help)
 3. [join the exercism.io chat on gitter](https://gitter.im/exercism/support): [![Join the chat at https://gitter.im/exercism/support](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/exercism/support)
 
@@ -28,7 +28,7 @@ Homebrew/homebrew-core (git revision 3b4c; last commit 2016-05-09)
 If Homebrew isn't installed, you can:
 
 1. install via [Homebrew's brew.sh site](http://brew.sh/)
-2. see [Install Alternatives for instructions on installing without Homebrew](/cli/install)
+2. see [Install Alternatives for instructions on installing without Homebrew](/clients/cli/install)
 
 ### Installing the Exercism CLI <a name="install-exercism-cli"></a>
 

--- a/x/docs/md/cli/overview.md
+++ b/x/docs/md/cli/overview.md
@@ -5,5 +5,5 @@ Exercism takes place in two places: the discussions happen on the website, and y
 
 This is a stand-alone binary, which means that you don't need to install any particular language or environment in order to use it.
 
-Choose your operating system: [mac](/cli/mac) | [windows](/cli/windows) | [linux](/cli/linux)
+Choose your operating system: [mac](/clients/cli/mac) | [windows](/clients/cli/windows) | [linux](/clients/cli/linux)
 

--- a/x/docs/md/cli/windows.md
+++ b/x/docs/md/cli/windows.md
@@ -2,7 +2,7 @@
 
 Below are installation instructions, using the most common method, the Chocolately Package Manager. For further help and instructions, see the following:
 
-1. [Install Alternatives for instructions on installing manually on windows](/cli/install)
+1. [Install Alternatives for instructions on installing manually on windows](/clients/cli/install)
 2. [exercism.io general help](http://exercism.io/help)
 3. [join the exercism.io chat on gitter](https://gitter.im/exercism/support): [![Join the chat at https://gitter.im/exercism/support](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/exercism/support)
 
@@ -30,11 +30,11 @@ choco install exercism-io-cli
 
 Type 'Y' to accept any prompts during the installation. If the installation was successful you should have output similar to the following:
 
-![Exercism CLI installation](/public/img/cli/win-exercism-installation.png "Exercism CLI installation")
+![Exercism CLI installation](/img/cli/win-exercism-installation.png "Exercism CLI installation")
 
 You now have access to the `exercism` command. You can type in `exercism --version` to get the current version of the Exercism CLI, or `exercism --help` to show the help menu.
 
-![Exercism command](/public/img/cli/win-exercism-command.png "Exercism command")
+![Exercism command](/img/cli/win-exercism-command.png "Exercism command")
 
 ### Upgrading the Exercism CLI
 
@@ -84,15 +84,15 @@ choco uninstall exercism-io-cli
 
 To open the Windows Command Prompt; access the Windows menu, by either clicking on the Windows logo in the Taskbar, or pressing the Windows key on the keyboard. In the search bar that comes up, type in `cmd`, which will bring up the `cmd.exe` program.
 
-![cmd.exe in the Windows menu](/public/img/cli/win-menu-cmd.png "The cmd program in the windows menu")
+![cmd.exe in the Windows menu](/img/cli/win-menu-cmd.png "The cmd program in the windows menu")
 
 To install Chocolately we need to use Administrator privileges. This is important, if you don't use Administrator privileges our computer won't let you install Chocolatey. To do this *right-click* on `cmd.exe` and in the menu that appears choose `Run as administrator`.
 
-![Run cmd.exe as Administrator](/public/img/cli/win-run-cmd-as-admin.png "Run the cmd program as Administrator")
+![Run cmd.exe as Administrator](/img/cli/win-run-cmd-as-admin.png "Run the cmd program as Administrator")
 
 You will be asked if you want to allow the program to make changes to your computer. You can safely click *Yes* here. The Command Prompt program should then start, and look something similar to this:
 
-![cmd.exe](/public/img/cli/win-cmd.png "The Windows command Prompt")
+![cmd.exe](/img/cli/win-cmd.png "The Windows command Prompt")
 
 You can now continue to the [Chocolatey installation](#chocolatey)
 
@@ -100,11 +100,11 @@ You can now continue to the [Chocolatey installation](#chocolatey)
 
 If your installation of Chocolatey has gone well, you should see output in your Windows shell similar to the following:
 
-![Successful Chocolatey installation](/public/img/cli/win-successful-choco-install.png "Successful Chocolatey installation")
+![Successful Chocolatey installation](/img/cli/win-successful-choco-install.png "Successful Chocolatey installation")
 
 You should now be able to use the `choco` command. Type in `choco`, this should return the version of Chocolatey you have installed.
 
-![Chocolatey version](/public/img/cli/win-choco-version.png "Chocolatey version")
+![Chocolatey version](/img/cli/win-choco-version.png "Chocolatey version")
 
 If this command fails, you may need to restart your Windows Command Prompt. Close it down, and reopen it. Please note that you now don't need to open it with Administrator privileges, so instead of right-clicking on the `cmd.exe` program, you can just click on it.
 
@@ -114,6 +114,6 @@ If Chocolatey has been installed correctly you can now continue to [install the 
 
 If you experience any problems installing the Exercism CLI, please don't hesitate to reach out for further help and assistance. Chances are, someone else has had the same problem.
 
-1. [Install Alternatives for instructions on installing manually on windows](/cli/install)
+1. [Install Alternatives for instructions on installing manually on windows](/clients/cli/install)
 2. [exercism.io general help](http://exercism.io/help)
 3. [join the exercism.io chat on gitter](https://gitter.im/exercism/support): [![Join the chat at https://gitter.im/exercism/support](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/exercism/support)


### PR DESCRIPTION
This fixes two issues with the content of cli docs: 

- Fix broken image links by removing /public
- Fix links in content of some of the cli docs by updating to new /clients routes