### PR TITLE
removes letsencrypt temp route

### DIFF
--- a/app/routes/static.rb
+++ b/app/routes/static.rb
@@ -73,10 +73,6 @@ module ExercismWeb
       get '/teams/about' do
         erb :'site/teams'
       end
-
-      get '/.well-known/acme-challenge/D533vaLocBelpPqZczM6EUq2subn5jarX1B_-a66AyM' do
-        "D533vaLocBelpPqZczM6EUq2subn5jarX1B_-a66AyM.Q0_BNqHpf4NmKK5vvJwbO4KBimS1tdy9FH6TtJd91io"
-      end
     end
   end
 end


### PR DESCRIPTION
Closes #3470, which suggests removing the temp route for Let's Encrypt -- this minor PR makes that change. :) 