### PR TITLE
Reposition the remove buttons on team management page.

### DIFF
--- a/app/views/teams/manage.erb
+++ b/app/views/teams/manage.erb
@@ -71,7 +71,7 @@
     </div>
   </div>
 
-<hr>
+  <hr>
 
   <div id="managers">
     <h3>Managers</h3>
@@ -87,23 +87,29 @@
       <button type="submit" class="btn btn-primary">Add manager</button>
     </form>
 
-    <% team.managers.each do |manager| %>
-      <% if team.managers.count == 1 && team.managers.first == current_user %>
-        <button type="button" class="disabled btn btn-xs btn-danger manager_delete" data-toggle="tooltip" data-placement="bottom" title="You must add another manager before you can remove yourself as the last manager." style="margin: 10px 10px 10px 0">Remove</button>
-      <% else %>
-        <form accept-charset="UTF-8" action="/teams/<%= team.slug %>/managers" method="post">
-          <input type="hidden" name="_method" value="delete" />
-          <input type="hidden" name="username" value="<%= manager.username %>" />
-          <button type="submit" class="btn btn-xs btn-danger manager_delete" data-username="<%= manager.username %>" style="margin: 10px 10px 10px 0">Remove</button>
-        </form>
-      <% end %>
+    <br/>
 
-      <%= gravatar_tag manager.avatar_url, size: 20 %>
-      <a href="/<%= manager.username %>"><%= manager.username %></a>
-    <% end %>
+    <div class="row">
+      <% team.managers.each do |manager| %>
+        <% if team.managers.count == 1 && team.managers.first == current_user %>
+          <button type="button" class="disabled btn btn-xs btn-danger manager_delete" data-toggle="tooltip" data-placement="bottom" title="You must add another manager before you can remove yourself as the last manager." style="margin: 10px 10px 10px 0">Remove</button>
+        <% else %>
+          <div class="col-sm-3">
+            <form accept-charset="UTF-8" action="/teams/<%= team.slug %>/managers" method="post" style="display: inline">
+              <input type="hidden" name="_method" value="delete" />
+              <input type="hidden" name="username" value="<%= manager.username %>" />
+              <button type="submit" class="btn btn-xs btn-danger manager_delete" data-username="<%= manager.username %>" style="margin: 10px 10px 10px 0">X</button>
+            </form>
+          <% end %>
+
+          <%= gravatar_tag manager.avatar_url, size: 20 %>
+          <a href="/<%= manager.username %>"><%= manager.username %></a>
+          </div>
+        <% end %>
+    </div>
   </div>
 
-<hr>
+  <hr>
 
   <div id="members">
     <h3>Members</h3>
@@ -125,7 +131,7 @@
       <% team.members.each do |member| %>
         <div class="col-sm-3">
           <a href="#" data-username="<%= member.username %>" data-team="<%= team.slug %>"
-          class="btn btn-xs btn-danger member_delete" style="margin: 10px 10px 10px 0">X</a>
+            class="btn btn-xs btn-danger member_delete" style="margin: 10px 10px 10px 0">X</a>
           <%= gravatar_tag member.avatar_url, size: 20 %>
           <a href="/<%= member.username %>"><%= member.username %></a>
         </div>
@@ -138,7 +144,7 @@
         <% team.member_invites.each do |member| %>
           <div class="col-sm-3">
             <a href="#" data-username="<%= member.username %>" data-team="<%= team.slug %>"
-            class="btn btn-xs btn-danger invite_dismiss" style="margin: 10px 10px 10px 0">X</a>
+               class="btn btn-xs btn-danger invite_dismiss" style="margin: 10px 10px 10px 0">X</a>
             <%= gravatar_tag member.avatar_url, size: 20 %>
             <a href="/<%= member.username %>"><%= member.username %></a>
           </div>


### PR DESCRIPTION
This PR addresses #3477 

## What does this PR do?
The remove buttons under the Managers section do not line up with the
ones under the Members section. For consistency, this commit applies
similar styles to all remove buttons under the sections mentions above.

## How was the issue addressed?
The form that renders the remove button and the manager's gravatar
was wrapped in a `col-*` class that aligns with the one used under the
members. The css classes on the button were also changed to be similar
to the ones under the members.

## Does this cause any side effects?
No however I feel that since we are using the same class on both buttons,
we can perhaps remove the duplicate class (i.e. we can remove either one
of `.manager_delete` or `.member_delete` and remove the other to
something more generic such as `.person_delete`, I am open to
suggestions on the class name)

## Further discussions
1. While I was in there, I noticed that we have inline styles on some elements,
is this intentional? Can we pull these out into a stylesheet? Perhaps there is a
chance for some refactor since this is a smell?

2. We have the same component (i.e. person gravatar + remove button) being
rendered under both Members and Managers yet they have been done using
two different approach. Under Managers, we are using a form to issue a `post`
request whereas under members we are issuing an AJAX request. Can we
perhaps pick on method and then extract this component into a partial?

<img width="279" alt="screen shot 2017-04-26 at 4 58 04 am" src="https://cloud.githubusercontent.com/assets/6236828/25427175/bfd64fc2-2a3f-11e7-82a7-b83591b925f6.png">
<img width="875" alt="screen shot 2017-04-26 at 4 58 41 am" src="https://cloud.githubusercontent.com/assets/6236828/25427180/c1db49c6-2a3f-11e7-89f8-059f2d3bc312.png">

please review @tejasbubane @Insti 
