### PR TITLE
Get rid of dead link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,7 +279,6 @@ Behind the scenes we also have:
 
 ### Contributing
 
-We curate issues that we think are good for starting out into [exercism/todo](https://github.com/exercism/todo/labels/start-here).
 
 If you want to work on the exercism.io website codebase, then continue reading this guide.
 


### PR DESCRIPTION
Referencing #3483. Dead link from dead repository. Will keep in mind about PR Hijacking. 
