### PR TITLE
Push footer to bottom of the screen.

### DIFF
--- a/app/views/application/_footer.erb
+++ b/app/views/application/_footer.erb
@@ -1,4 +1,4 @@
-<footer id="footer" role="contentinfo">
+<footer id="footer" role="contentinfo" class="navbar navbar-fixed-bottom">
   <div class="container">
     <div class="row">
       <div class="col-xs-6 col-sm-3 col-md-2 footer-logo">

--- a/public/sass/base/components/main.scss
+++ b/public/sass/base/components/main.scss
@@ -2,7 +2,7 @@
 
 body {
   padding-top: 50px;
-  padding-bottom: 0px;
+  padding-bottom: 300px;
 }
 
 .contain-centered {


### PR DESCRIPTION
fixes #3465

## Why was this change necessary?
The footer is static and hence if the page that the user is viewing
doesn't take up the entire viewport, the footer appears somewhere in the
middle of the page. This is not the expected behaviour, ideally we want
the footer to appear at the very end of the viewport.

## How does it address the problem?
The `.navbar-fixed-bottom` class from Bootstrap was utilized to fix the
footer to the bottom of the page. Additionally, to make sure that the
footer didn't overlap any content on the page, a `padding-bottom: 300px`
was applied to the `body`.

## Are there any side effects?
I noticed that we have a media query that increases the `height` of the
footer by `20px` somewhere in the 1000 - 1200px range (tablet range).
This makes the additional `padding-bottom` that was applied to the body,
appear inconsistent across all screen sizes. For example, the spacing
between the footer and body in tablet mode is more than desktop
mode.

Unfortunately I don't have the required css skills to come up with a
much needed robust and scalable solution so please feel free to 
suggest alternatives and pull in others who you feel might be able
to help!

## Visuals

<details><summary>Please see graphic (motion) example in this detail section:</summary>

![screen recording 2017-04-29 at 06 22 pm](https://cloud.githubusercontent.com/assets/6236828/25559567/57b69c66-2d0b-11e7-9291-e51d7114a137.gif)

![screen recording 2017-04-29 at 06 21 pm](https://cloud.githubusercontent.com/assets/6236828/25559568/5ed98cf6-2d0b-11e7-8557-1e7cfca4108d.gif)

![screen recording 2017-04-29 at 06 20 pm](https://cloud.githubusercontent.com/assets/6236828/25559571/63d43a3a-2d0b-11e7-8c4f-fc7b57698267.gif)
</details>

</br>
please review @kytrinyx @rootulp