### PR TITLE
Force rollback on failed data cleanup

### DIFF
--- a/lib/exercism/team_membership_invite.rb
+++ b/lib/exercism/team_membership_invite.rb
@@ -16,7 +16,7 @@ class TeamMembershipInvite < ActiveRecord::Base
         confirmed: true
       )
 
-      destroy
+      destroy!
     end
   end
 


### PR DESCRIPTION
Sending a team invitation means creating a record in the database. As
long as that record exists, we will show a notification saying that
you're invited to a team.

Accepting a team invitation will create a new record, one that
references both the user_id and the team_id. We have a unique index on
this record.

In the case where (for some reason) the invite record fails to get
destroyed, we will be in the unfortunate situation of having (1) a
notification about being invited, and (2) a 500 error if you try to
accept it (because you've already accepted it).

This change forces a rollback of the database transaction if we fail to
delete the invite record.  This will remove the team membership record,
and allow them to try again.

Closes #3455