### PR TITLE
Revert "Add crazyegg experimentally"

### DIFF
--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -31,12 +31,6 @@
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
-    <script type="text/javascript">
-	    setTimeout(function(){var a=document.createElement("script");
-			    var b=document.getElementsByTagName("script")[0];
-			    a.src=document.location.protocol+"//script.crazyegg.com/pages/scripts/0044/0216.js?"+Math.floor(new Date().getTime()/3600000);
-			    a.async=true;a.type="text/javascript";b.parentNode.insertBefore(a,b)}, 1);
-	    </script>
   </head>
   <body>
     <%= erb :"application/_navbar" %>


### PR DESCRIPTION
CrazyEgg is no longer being used.

This reverts commit 6b6b34bbf2536ebb081d4272bf070d349816839f.

From the discussion on github about the change:

@Insti
> Have we learned anything from crazyegg?

@kytrinyx
> I'm pretty sure I deleted it when the free month was up. Or at least the
> account. But yeah, we did: most people go straight to the /languages
> page, so we should show what languages we have available on the
> homepage.

Ref: https://github.com/exercism/exercism.io/commit/6b6b34bbf2536ebb081d4272bf070d349816839f