### PR TITLE
Handle trailing slashes in routes

### DIFF
--- a/app/routes/core.rb
+++ b/app/routes/core.rb
@@ -6,6 +6,7 @@ module ExercismWeb
         set :root, Exercism.relative_to_root('app')
         set :environment, ENV.fetch('RACK_ENV') { :development }.to_sym
         set :method_override, true
+        set :strict_paths, false
 
         enable :raise_errors
       end

--- a/app/routes/legacy.rb
+++ b/app/routes/legacy.rb
@@ -9,10 +9,6 @@ module ExercismWeb
         redirect "/submissions/#{key}"
       end
 
-      get '/help/?*' do
-        redirect '/help'
-      end
-
       get '/setup/?*' do
         redirect "/help"
       end

--- a/test/app/static_pages_test.rb
+++ b/test/app/static_pages_test.rb
@@ -32,6 +32,12 @@ class StaticPagesTest < Minitest::Test
     assert_match(/Help/, last_response.body)
   end
 
+  def test_route_help_with_trailing_slash
+    get '/help/'
+    assert_equal 200, last_response.status
+    assert_match(/Help/, last_response.body)
+  end
+
   def test_route_how_it_works
     get '/how-it-works'
     assert_equal 200, last_response.status

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -91,6 +91,17 @@ class TeamsTest < Minitest::Test
     end
   end
 
+  def test_logged_in_user_can_search_teams
+    [
+      [:get, '/teams'],
+      [:get, '/teams/']
+    ].each do |verb, endpoint|
+      send verb, endpoint, {}, login(alice)
+      assert_equal 200, last_response.status
+      assert_match(/teams/i, last_response.body)
+    end
+  end
+
   def test_user_must_be_on_team_to_view_team_page
     team = Team.by(alice).defined_with(slug: 'abc')
     team.save


### PR DESCRIPTION
Use sinatra 2.0 feature to allow trailing slashes. (ref: https://github.com/sinatra/sinatra/pull/1273/commits/2445a4994468aabe627f106341af79bfff24451e)

As per discussion in #3428.