### PR TITLE
Use Flexbox instead of Bootstrap’s grid for languages list

### DIFF
--- a/app/views/languages/index.erb
+++ b/app/views/languages/index.erb
@@ -3,34 +3,28 @@
     <section class="page-header">
       <h1>Languages</h1>
     </section>
-    <% active.each_slice(6) do |tracks| %>
-      <div class="row">
-        <% tracks.each do |t| %>
-          <%= erb :'languages/_block', locals: { track: t } %>
-        <% end %>
-      </div>
-    <% end %>
+    <div class="languages-list">
+      <% active.each do |t| %>
+        <%= erb :'languages/_block', locals: { track: t } %>
+      <% end %>
+    </div>
 
     <section class="page-header">
       <h3>Upcoming</h3>
     </section>
-    <% upcoming.each_slice(6) do |tracks| %>
-      <div class="row">
-        <% tracks.each do |t| %>
-          <%= erb :'languages/_block', locals: { track: t } %>
-        <% end %>
-      </div>
-    <% end %>
+    <div class="languages-list">
+      <% upcoming.each do |t| %>
+        <%= erb :'languages/_block', locals: { track: t } %>
+      <% end %>
+    </div>
 
     <section class="page-header">
       <h3>Planned</h3>
     </section>
-    <% planned.each_slice(6) do |tracks| %>
-      <div class="row">
-        <% tracks.each do |t| %>
-          <%= erb :'languages/_block', locals: { track: t } %>
-        <% end %>
-      </div>
-    <% end %>
+    <div class="languages-list">
+      <% planned.each do |t| %>
+        <%= erb :'languages/_block', locals: { track: t } %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/public/sass/base/components/languages.scss
+++ b/public/sass/base/components/languages.scss
@@ -1,9 +1,20 @@
+@import "compass/css3/flexbox";
 @import '../mixins/track_link';
 
-#languages, #contribute{
+#contribute{
   .row{
-    display: flex;
-    flex-wrap: wrap;
+    @include display-flex();
+    @include flex-wrap(wrap);
+  }
+  @include track_link;
+}
+
+#languages{
+  .languages-list{
+    @include display-flex();
+    @include flex-wrap(wrap);
+    margin-left: -15px;
+    margin-right: -15px;
   }
   @include track_link;
 }


### PR DESCRIPTION
Fixes #3325.

**BEFORE:**

![safari-bug-before](https://cloud.githubusercontent.com/assets/11782/26284076/3bfb9c2c-3e33-11e7-8f07-33b4ba4970ac.png)

**AFTER:**

![safari-bug-after](https://cloud.githubusercontent.com/assets/11782/26284078/4194c76c-3e33-11e7-8db8-a02dbefdbe01.png)
