### PR TITLE
Use send for method that was made private

### DIFF
--- a/app/views/contribute/canonical_data.erb
+++ b/app/views/contribute/canonical_data.erb
@@ -67,7 +67,7 @@
             <% implementations.each do |implementation| %>
               <ul>
                 <li>
-                <a href="<%= [implementation.repo, implementation.exercise_dir].join("/") %>">
+                <a href="<%= [implementation.track.repository, implementation.send(:exercise_dir)].join("/") %>">
                     <%= Trackler.tracks[implementation.track_id].language %>
                   </a>
                 </li>


### PR DESCRIPTION
When the new site gets designed we'll take the time to design all of the dynamic
contributing documentation, probably in a separate site.

At that point I will likely need to overhaul trackler a bit to make it possible
to generate the contributing documentation.