### PR TITLE
Show errors in development

### DIFF
--- a/app/routes/core.rb
+++ b/app/routes/core.rb
@@ -21,7 +21,7 @@ module ExercismWeb
         enable :show_exceptions
       end
 
-      unless settings.test?
+      unless settings.test? || settings.development?
         error 500 do
           metadata = {
             user: {


### PR DESCRIPTION
If we want to test the error page, I think it's worth having to comment out code. Most of the time in development we actually want to see the exceptions that are being raised.