### PR TITLE
Use trackler-provided URLs in /contribute/canonical-data

### DIFF
--- a/app/routes/contribute.rb
+++ b/app/routes/contribute.rb
@@ -6,6 +6,7 @@ module ExercismWeb
       end
 
       get '/contribute/canonical-data/?:slug?' do |slug|
+        slug ||= ''
         problem = Trackler.problems[slug]
 
         erb :"contribute/canonical_data", locals: {

--- a/app/routes/contribute.rb
+++ b/app/routes/contribute.rb
@@ -12,6 +12,8 @@ module ExercismWeb
         erb :"contribute/canonical_data", locals: {
           current_problem: problem,
           problems: Trackler.problems.reject(&:deprecated?).reject(&:canonical_data_url).sort_by(&:name),
+          active_problems_count: Trackler.problems.reject(&:deprecated?).size,
+          canonical_problems_count: Trackler.problems.select(&:canonical_data_url).size,
           implementations: Trackler.implementations[slug],
         }
       end

--- a/app/routes/contribute.rb
+++ b/app/routes/contribute.rb
@@ -7,14 +7,16 @@ module ExercismWeb
 
       get '/contribute/canonical-data/?:slug?' do |slug|
         slug ||= ''
-        problem = Trackler.problems[slug]
+
+        active_problems = Trackler.problems.reject(&:deprecated?).sort_by(&:name)
+        need_canonical  = active_problems.reject(&:canonical_data_url)
 
         erb :"contribute/canonical_data", locals: {
-          current_problem: problem,
-          problems: Trackler.problems.reject(&:deprecated?).reject(&:canonical_data_url).sort_by(&:name),
-          active_problems_count: Trackler.problems.reject(&:deprecated?).size,
-          canonical_problems_count: Trackler.problems.select(&:canonical_data_url).size,
+          current_problem: Trackler.problems[slug],
           implementations: Trackler.implementations[slug],
+          problems: need_canonical,
+          active_problems_count: active_problems.size,
+          canonical_problems_count: [active_problems - need_canonical].size
         }
       end
     end

--- a/app/views/contribute/canonical_data.erb
+++ b/app/views/contribute/canonical_data.erb
@@ -81,15 +81,13 @@
 
         <% else %>
 
-          <% active_problems = Trackler.problems.reject(&:deprecated?) %>
-
-          <p>We have a total of <%= active_problems.count %> problems on Exercism. Some are implemented in many language tracks, others are implemented in just a few.</p>
+          <p>We have a total of <%= active_problems_count %> problems on Exercism. Some are implemented in many language tracks, others are implemented in just a few.</p>
 
           <p>
           To make it easier to port exercises to new language tracks, we're in the process of creating canonical test data for each problem.
           This gets implemented into a file called <code>canonical-data.json</code>. The file lives in <a href="https://github.com/exercism/x-common">exercism/x-common</a> repository, alongside the other common data for the problem.</p>
 
-          <p>So far we've extracted canonical data for <%= active_problems.select(&:canonical_data_url).count %> of the <%= active_problems.count %> problems. Just <%= problems.count %> more to go!</p>
+          <p>So far we've extracted canonical data for <%= canonical_problems_count %> of the <%= active_problems_count %> problems. Just <%= problems.count %> more to go!</p>
 
           <p>Want to help out? Pick an exercise from the list in the sidebar, and check out the documentation in <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#improving-consistency-by-extracting-shared-test-data">the contributing guide</a>.</p>
 

--- a/app/views/contribute/canonical_data.erb
+++ b/app/views/contribute/canonical_data.erb
@@ -46,7 +46,7 @@
         <% if current_problem.exists? %>
 
           <% if !!current_problem.canonical_data_url %>
-            <p>This problem already has a <code>canonical-data.json</code> file. You can view it <a href="https://github.com/exercism/x-common/blob/master/exercises/<%= current_problem.slug %>/canonical-data.json">here</a>.</p>
+            <p>This problem already has a <code>canonical-data.json</code> file. You can view it <a href="<%= current_problem.canonical_data_url %>">here</a>.</p>
 
           <% else %>
 

--- a/app/views/contribute/canonical_data.erb
+++ b/app/views/contribute/canonical_data.erb
@@ -45,7 +45,7 @@
       <div class="tab-pane active" id="problem-<%= current_problem.slug %>">
         <% if current_problem.exists? %>
 
-          <% if !!current_problem.canonical_data_url %>
+          <% if current_problem.canonical_data_url %>
             <p>This problem already has a <code>canonical-data.json</code> file. You can view it <a href="<%= current_problem.canonical_data_url %>">here</a>.</p>
 
           <% else %>

--- a/app/views/contribute/canonical_data.erb
+++ b/app/views/contribute/canonical_data.erb
@@ -50,13 +50,15 @@
 
           <% else %>
 
+            <p><%= current_problem.blurb %></p>
+            <p>
+            View the full problem description <a href="<%= current_problem.description_url %>">here</a>.
+            </p>
+
             <p>
               The process for extracting canonical data is described in the <a href="https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md#improving-consistency-by-extracting-shared-test-data">Contributing Guide</a>.
             </p>
 
-            <p>
-            View the problem description <a href="<%= current_problem.description_url %>">here</a>.
-            </p>
 
             <h2>Implementations</h2>
 

--- a/app/views/contribute/canonical_data.erb
+++ b/app/views/contribute/canonical_data.erb
@@ -67,7 +67,7 @@
             <% implementations.each do |implementation| %>
               <ul>
                 <li>
-                <a href="<%= [implementation.repo, implementation.exercise_dir].join("/") %>">
+                <a href="<%= implementation.git_url %>">
                     <%= Trackler.tracks[implementation.track_id].language %>
                   </a>
                 </li>

--- a/app/views/contribute/canonical_data.erb
+++ b/app/views/contribute/canonical_data.erb
@@ -70,7 +70,7 @@
               <ul>
                 <li>
                 <a href="<%= implementation.git_url %>">
-                    <%= Trackler.tracks[implementation.track_id].language %>
+                    <%= implementation.track.language %>
                   </a>
                 </li>
 

--- a/app/views/contribute/canonical_data.erb
+++ b/app/views/contribute/canonical_data.erb
@@ -55,7 +55,7 @@
             </p>
 
             <p>
-              View the problem description <a href="https://github.com/exercism/x-common/blob/master/exercises/accumulate/description.md">here</a>.
+            View the problem description <a href="<%= current_problem.description_url %>">here</a>.
             </p>
 
             <h2>Implementations</h2>

--- a/test/app/routes/contribute_test.rb
+++ b/test/app/routes/contribute_test.rb
@@ -1,0 +1,48 @@
+require_relative '../../app_helper'
+
+class ContributeRoutesTest < Minitest::Test
+  include Rack::Test::Methods
+
+  BASE_URL = "http://#{Rack::Test::DEFAULT_HOST}".freeze
+
+  def app
+    ExercismWeb::App
+  end
+
+  def test_route_index
+    get '/contribute'
+    assert_equal 200, last_response.status
+    assert_match 'Contribute to Exercism', last_response.body
+  end
+
+  def test_route_canonical_data
+    get '/contribute/canonical-data'
+    assert_equal 200, last_response.status
+    assert_match 'Canonical Data', last_response.body
+  end
+
+  # Trackler fixture data dependency
+  def test_route_canonical_data_with_slug
+    get '/contribute/canonical-data/hello-world'
+    assert_equal 200, last_response.status
+    assert_match 'Hello World', last_response.body
+    refute_match 'We have a total of', last_response.body
+  end
+
+  # Trackler fixture data dependency
+  def test_route_canonical_data_with_invalid_slug
+    get '/contribute/canonical-data/invalid'
+    assert_equal 200, last_response.status
+    assert_match 'Canonical Data', last_response.body
+    assert_match 'We have a total of', last_response.body
+  end
+
+  # Trackler fixture data dependency
+  def test_route_canonical_data_slug_with_canonical_data
+    get '/contribute/canonical-data/fish'
+    assert_equal 200, last_response.status
+    assert_match 'Canonical Data', last_response.body
+    assert_match 'This problem already has a', last_response.body
+  end
+end
+


### PR DESCRIPTION
Supersedes: #3514

Trackler already provides all the repository URLs we need to use in the `erb` template.
Use them instead of constructing our own.

Fixes hardcoded link to `accumulate` description.

Use a default value for slug so that the page still renders correctly when no slug is provided.

Use other Trackler supplied instance methods rather than fetching them again.

Add blurb so we know what the problem is about.

:tada: Added tests 🎉 
