### PR TITLE
Reference a language on a profile page

### DIFF
--- a/app/views/user/_track_progress.erb
+++ b/app/views/user/_track_progress.erb
@@ -1,7 +1,11 @@
 <div class="track-info col-xs-4 col-sm-4 col-md-4 col-lg-4">
   <%= track_icon(track_info.track.id, '60') %>
   <div class="track-text">
-    <h5><%= track_info.track.language %></h5>
+    <h5>
+      <a href="/languages/<%= track_info.track.id %>">
+        <%= track_info.track.language %>
+      </a>
+    </h5>
     <% if track_info.completed? %>
       <p>Completed: <%= track_info.completed %> <%= 'Problem'.pluralize(track_info.completed) %></p>
     <% end %>


### PR DESCRIPTION
<img width="1128" alt="screen shot 2017-05-23 at 10 06 58 am" src="https://cloud.githubusercontent.com/assets/3624712/26342347/6ec61290-3fa0-11e7-803c-52f87b684c4a.png">

This looks logically to me to have a reference to the language within profile page, so the user can easily jump to it and continue to work on exercises. At least I tried to click it intuitively few times. 


