### PR TITLE
Handle dirty membership data

### DIFF
--- a/lib/exercism/team_membership_invite.rb
+++ b/lib/exercism/team_membership_invite.rb
@@ -9,12 +9,10 @@ class TeamMembershipInvite < ActiveRecord::Base
 
   def accept!
     ActiveRecord::Base.transaction do
-      TeamMembership.create!(
-        team_id: team_id,
-        user_id: user_id,
-        inviter_id: inviter_id,
-        confirmed: true
-      )
+      membership = TeamMembership.find_or_initialize_by(team_id: team_id, user_id: user_id)
+      membership.confirmed = true
+      membership.inviter_id ||= inviter_id
+      membership.save!
 
       destroy!
     end

--- a/test/exercism/team_membership_invite_test.rb
+++ b/test/exercism/team_membership_invite_test.rb
@@ -26,6 +26,34 @@ class TeamMembershipInviteTest < Minitest::Test
     assert_equal 0, TeamMembershipInvite.count
   end
 
+  def test_accept_invitation_when_theres_an_unconfirmed_invite
+    team = Team.by(alice).defined_with(slug: 'purple')
+    team.save
+
+    membership = TeamMembership.create!(team: team, user: bob, inviter: alice)
+    invite = TeamMembershipInvite.create!(team: team, user: bob, inviter: alice)
+
+    refute membership.confirmed
+
+    invite.accept!
+
+    assert membership.reload.confirmed
+    assert_equal 0, TeamMembershipInvite.count
+  end
+
+  def test_accept_invitation_with_confirmed_invite
+    team = Team.by(alice).defined_with(slug: 'purple')
+    team.save
+
+    membership = TeamMembership.create!(team: team, user: bob, inviter: alice, confirmed: true)
+    invite = TeamMembershipInvite.create!(team: team, user: bob, inviter: alice)
+
+    invite.accept!
+
+    assert membership.reload.confirmed
+    assert_equal 0, TeamMembershipInvite.count
+  end
+
   def test_refuse_changes_invite_status
     team = Team.by(alice).defined_with(slug: 'purple')
     team.save


### PR DESCRIPTION
I'm still not sure how this happens, but we sometimes get a membership invite (confirmed or not),
that still has a membership invitation lying around.

This was raising an exception and failing to confirm the invite.

This adds tests for both of the cases, and does the right thing, adding the user
to the team and deleting the invite.

Fixes #3518