### PR TITLE
Add join team description

### DIFF
--- a/app/views/dashboard.erb
+++ b/app/views/dashboard.erb
@@ -89,6 +89,19 @@
     <div class="row">
       <div class="col-md-6">
         <h2>Teams</h2>
+        <h4>Join an existing team</h4>
+        <div class="well">
+          <section class="main">
+            <article class="article-block">
+              <div class="article-contents">
+                <p>To join a public team in Exercism, <a href="/teams">search</a>
+                  for the team by name or by tag.</p>
+                <p>To join a private team, contact a team manager to request membership.</p>
+              </div>
+            </article>
+          </section>
+        </div>
+        <h4>Create a new team</h4>
         <div class="well">
           <section class="main">
             <article class="article-block">

--- a/app/views/site/teams.erb
+++ b/app/views/site/teams.erb
@@ -15,6 +15,15 @@
 
     <article class="article-block">
       <div class="article-contents">
+        <h4 class="header">Joining a Team</h4>
+        <p>To join an existing public team in Exercism, navigate to the <a href="/teams">team search page</a> and search for the team by name or by tag.</p>
+        <p>If you wish to join a private team, contact a manager of the team and request membership in the team.</p>
+      </div>
+    </article>
+    <hr>
+
+    <article class="article-block">
+      <div class="article-contents">
         <h4 class="header">Creating a Team</h4>
         <p>To create a team in Exercism, navigate to your <a href="/account">account settings page</a>.</p>
         <p>Scroll down to the teams section and click "Create a new team".</p>


### PR DESCRIPTION
Resolves #3428

Added descriptions for joining teams in both the `teams/about` page and the `dashboard`.