### PR TITLE
Require the english library

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+require "English"
+
 $LOAD_PATH.unshift File.expand_path("./..", __FILE__)
 $LOAD_PATH.unshift File.expand_path("./../lib", __FILE__)
 


### PR DESCRIPTION
In order to reference the long-winded environment variables like LOAD_PATH and
ERROR_INFO we need to explicitly require the English library.

This will fix bugsnag's reporting, since reporting  without English
means that we're reporting ; by definition: not an error.

Resolves #3469