### PR TITLE
Added title text to language icons.

### DIFF
--- a/app/helpers/track_image.rb
+++ b/app/helpers/track_image.rb
@@ -4,7 +4,8 @@ module ExercismWeb
   module Helpers
     module TrackImage
       def track_icon(track_id, size=40)
-        '<img src="/tracks/%s/icon" width="%d" height="%d" alt="">' % [track_id, size, size]
+        language = Trackler.tracks[track_id].language
+        '<img src="/tracks/%s/icon" width="%d" height="%d" alt="%s" title="%s">' % [track_id, size, size, language, language]
       end
     end
   end

--- a/app/views/submissions/show.erb
+++ b/app/views/submissions/show.erb
@@ -3,6 +3,7 @@
     <h1 class="pull-left">
       <%= track_icon(submission.track_id, 40) %>
       <%= submission.problem.name %>
+      <i class="text-muted">(<%= submission.problem.language %>)</i>
     </h1>
 
     <div class="pull-right submission-toolbar hidden-xs">


### PR DESCRIPTION
Resolves exercism/discussions#146

I think that the title text (hover text) for the icons is fine how I've implemented it. I also added the language name in the code/discussion title, but I'm thinking that people might not like it. Most of the time you'll know what language it is already, so it's probably not necessary.

This a screenshot of what it looks like:
![exercism_hover_text](https://cloud.githubusercontent.com/assets/22666187/26523291/1860681e-42da-11e7-9693-c892ac2f91d9.png)
