### PR TITLE
Rake: Don't seed the test database.

### DIFF
--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -23,6 +23,7 @@ namespace :db do
 
   desc "generate seed data"
   task seed: [:connection] do
+    fail "Seeding the test database would cause many tests to fail." if ENV['RACK_ENV'] == 'test'
     require_comments
     config = DB::Config.new
     # rubocop:disable Style/AlignParameters


### PR DESCRIPTION
The tests expect an empty database.
If you seed the test database a lot of tests fail.
This patch aborts the rake task without seeding if it is run against the test database.