### PR TITLE
Add db:migrate step to db:reset

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -48,8 +48,13 @@ namespace :db do
     end
   end
 
-  desc "drop and recreate your database"
-  task reset: %i(drop create)
+  desc "drop and recreate and migrate your database"
+  task reset: %i(drop create migrate) do
+    unless ENV['RACK_ENV'] == 'test'
+      puts "You probably want to seed the database now: bundle exec rake db:seed"
+    end
+  end
+
 
   desc "drop your database"
   task :drop do


### PR DESCRIPTION
When resetting the database you always want to run the db:migrate task to update to the latest schema. This patch adds the migrate step to reset so this will happen automatically for you.

It will then helpfully suggest the next step, which is seeding the database. Unless you are resetting the testing database, where seeding is undesirable.

If you wanted to avoid the migration step you can still run:
```
rake db:drop db:create
```