### PR TITLE
Increase the database connection pool in production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,6 @@
 postgres: &postgres
   adapter: postgresql
   encoding: unicode
-  pool: 5
   host: <%= ENV["DEV_DATABASE_HOST"] || "localhost" %>
   port: 5432
   username: exercism
@@ -15,6 +14,8 @@ test:
 development:
   <<: *postgres
   database: exercism_development
+  pool: 5
 
 production:
   url: <%= ENV["DATABASE_URL"] %>
+  pool: 16


### PR DESCRIPTION
Based on the puma README (https://github.com/puma/puma#configuration) it looks like the default
max thread count is 16.

According to Heroku's documentation (https://devcenter.heroku.com/articles/concurrency-and-database-connections#threaded-servers)
a reasonable default for Puma is the RAILS_MAX_THREADS value. I didn't find a MAX_THREADS value
for Sinatra, so I'm using Puma's default.

Fixes #3533 (maybe).

/cc @nilbus 