### PR TITLE
Removed language name from submission title.

### DIFF
--- a/app/views/submissions/show.erb
+++ b/app/views/submissions/show.erb
@@ -3,7 +3,6 @@
     <h1 class="pull-left">
       <%= track_icon(submission.track_id, 40) %>
       <%= submission.problem.name %>
-      <i class="text-muted">(<%= submission.problem.language %>)</i>
     </h1>
 
     <div class="pull-right submission-toolbar hidden-xs">


### PR DESCRIPTION
After seeing the language name in the submission title, it seems like the wrong place to put it. Removing it as per discussion in #3531.

Current view looks like this:
![screenshot_20170529_123150](https://cloud.githubusercontent.com/assets/22666187/26557985/f4a8bcfe-446a-11e7-9556-ce5c02088e6c.png)
