### PR TITLE
Added language name in 'submitted by...' tag

### DIFF
--- a/app/views/submissions/show.erb
+++ b/app/views/submissions/show.erb
@@ -43,7 +43,8 @@
 
     <div class="clearfix"></div>
     <div class="submission-author text-muted">
-      submitted in <%= Trackler.tracks[submission.language].language %> by <%= gravatar_tag submission.user.avatar_url, size: 20 %>
+      submitted in <%= Trackler.tracks[submission.language].language %>
+      by <%= gravatar_tag submission.user.avatar_url, size: 20 %>
       <%= profile_link(submission.user) %>
       <%= ago(submission.created_at) %>
 

--- a/app/views/submissions/show.erb
+++ b/app/views/submissions/show.erb
@@ -43,7 +43,7 @@
 
     <div class="clearfix"></div>
     <div class="submission-author text-muted">
-      submitted by <%= gravatar_tag submission.user.avatar_url, size: 20 %>
+      submitted in <%= Trackler.tracks[submission.language].language %> by <%= gravatar_tag submission.user.avatar_url, size: 20 %>
       <%= profile_link(submission.user) %>
       <%= ago(submission.created_at) %>
 


### PR DESCRIPTION
Added per discussion in #3531.

Submission description now reads `submitted in {{language}} by {{author}} {{date}}`.

This is what it looks like. This still has the language name in the title, but I assume we'll merge #3546 along with this one so it won't be there.
![screenshot_20170529_130704](https://cloud.githubusercontent.com/assets/22666187/26558626/ebfbbd4a-446f-11e7-8870-333b6434ebae.png)
