### PR TITLE
Only check $flipper feature flags for page requests

### DIFF
--- a/app/routes/profile.rb
+++ b/app/routes/profile.rb
@@ -2,7 +2,7 @@ module ExercismWeb
   module Routes
     class Profile < Core
       before do
-        if $flipper[:advertise_cli_update].enabled?(current_user) && page_request?
+        if page_request? && $flipper[:advertise_cli_update].enabled?(current_user)
           client_version = ClientVersion.new(user: current_user)
           flash.now[:notice] ||= client_version.notice_when_client_outdated
         end


### PR DESCRIPTION
Each page load generates a number of other asset requests, such as
/tracks/elixir/icon. Loading many of these at once, especially across
multiple concurrent users, has sometimes used up all the available
database connections in the DB pool.

The `page_request?` method is proven now and does not need to live behind
a feature flag.