### PR TITLE
Update rouge to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     rb-readline (0.5.3)
     redcarpet (3.3.4)
     redis (3.3.3)
-    rouge (2.0.5)
+    rouge (2.0.7)
     rubocop (0.36.0)
       parser (>= 2.3.0.0, < 3.0)
       powerpack (~> 0.1)

--- a/test/fixtures/approvals/markdown_double_braces.approved.txt
+++ b/test/fixtures/approvals/markdown_double_braces.approved.txt
@@ -1,7 +1,7 @@
-<div class="highlight json">
+<div class="highlight plaintext">
 <table style="border-spacing: 0;"><tbody><tr>
 <td class="gutter gl" style="text-align: right;"><pre class="lineno"><a href="#L1">1</a></pre></td>
-<td class="code"><pre><span id="L1"><span class="p">{</span><span class="err">{x:</span><span class="w"> </span><span class="err">y</span><span class="p">}</span><span class="err">}</span>
+<td class="code"><pre><span id="L1">{{x: y}}
 </span></pre></td>
 </tr></tbody></table>
 </div>


### PR DESCRIPTION
This caused an approval test to fail, but the received output actually
looks much more correct than the approved one, so I accepted the change.

Closes #3452
Fixes https://github.com/exercism/xcoq/issues/9
