### PR TITLE
Improve setting up local development instructions

### DIFF
--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -42,7 +42,7 @@ Exercism.io depends on the following:
 
 These instructions present two options:
 
-1. Run exercism.io on your computer directly by installing the required software as listed in the following section (Running exercism.io directly on your computer).
+1. Run exercism.io [directly on your computer](#running-exercisimio-directly-on-your-computer).
 2. Run exercism.io [with Docker](#running-exercismio-with-docker).
 
 ### Running exercism.io directly on your computer


### PR DESCRIPTION
While reading the docs, I noticed that we can avoid confusion by linking
to the "Running exercism.io directly on your computer" section directly
instead of stating that the instructions are listed in the section after
it.