### PR TITLE
Fix outdated documentation about requesting tracks

### DIFF
--- a/app/views/languages/not_found.erb
+++ b/app/views/languages/not_found.erb
@@ -10,14 +10,8 @@
       </p>
 
       <p>
-        If you'd like to help implement it, then check out the
-        <a href="https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md">Contributing Guide</a>, which
-        is still a bit of a work in progress.
-      </p>
-
-      <p>
-        Email Katrina at <a href="mailto:kytrinyx@exercism.io">kytrinyx@exercism.io</a>,
-        and she'll set up a repository for you.
+        If you'd like to help implement it, then open an issue in
+        <a href="https://github.com/exercism/request-new-language-track">the Request New Language Track repository</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
We used to say 'email katrina'. Now we have a request-new-language-track repo.