### PR TITLE
Fix track doc filenames in 'improve this' text

### DIFF
--- a/test/app/languages_test.rb
+++ b/test/app/languages_test.rb
@@ -148,11 +148,7 @@ class LanguagesRoutesTest < Minitest::Test
       "Help us explain this better" => "Request for help is missing",
       "<em>Help us explain this better" => "Request for help is markdown, not HTML",
       "https://github.com/exercism/xfake/issues" => "Issue URL is wrong",
-      # Note. The real file name is actually TESTS.md, because the fixture has a mix of
-      # md and org files. This is on purpose, as we're working on handling this
-      # in Trackler, but the fix isn't in master yet.
-      # Once it lands, we'll need to fix this test test.
-      "https://github.com/exercism/xfake/blob/master/docs/TESTS.org" => "Filename is wrong",
+      "https://github.com/exercism/xfake/blob/master/docs/TESTS.md" => "Filename is wrong",
     }.each do |text, error_message|
       assert last_response.body.include?(text), error_message
     end

--- a/x/docs/md/track/BETTER.md
+++ b/x/docs/md/track/BETTER.md
@@ -1,4 +1,4 @@
 
 ***
 
-_Help us explain this better! File a GitHub issue at REPO/issues if you have suggestions, or submit a patch with improvements to the REPO/blob/master/docs/TOPIC.EXT file._
+_Help us explain this better! File a GitHub issue at REPO/issues if you have suggestions, or submit a patch with improvements to the REPO/blob/master/docs/FILENAME file._

--- a/x/docs/track.rb
+++ b/x/docs/track.rb
@@ -20,7 +20,7 @@ module X
       end
 
       def better(topic)
-        search_and_replace(read('better')).gsub('TOPIC', topic.upcase).gsub('EXT', doc_format)
+        search_and_replace(read('better')).gsub('FILENAME', Trackler::DocFile.find(basename: topic.upcase, track_dir: dir).name)
       end
 
       private


### PR DESCRIPTION
We were previously guessing at the filename based on the topic and the most common file extension.
With the new DocFile implementation, we know the name of each individual file, regardless of what the
most common file extension is.