### PR TITLE
Improve the track documentation section

### DIFF
--- a/app/views/languages/_exercises.erb
+++ b/app/views/languages/_exercises.erb
@@ -1,11 +1,15 @@
-<%= md X::Docs::Track.new(track).exercises %>
+<% if track.planned? %>
+  <p>There are no available exercises in <%= track.language %>. You can <a href="/languages/<%= track.id %>/launch">help launch this track</a>!</p>
+<% else %>
+  <%= md X::Docs::Track.new(track).exercises %>
 
-<h3>Available Exercises</h3>
-<ul class="available_exercises_listing">
-  <% track.implementations.each do |problem| %>
-    <li>
-    <a href="/exercises/<%= track.id %>/<%= problem.slug %>"><%= problem.name %></a>
-    <span class="tagline"><%= problem.blurb %></span>
-    </li>
-  <% end %>
-</ul>
+  <h3>Available Exercises</h3>
+  <ul class="available_exercises_listing">
+    <% track.implementations.each do |problem| %>
+      <li>
+      <a href="/exercises/<%= track.id %>/<%= problem.slug %>"><%= problem.name %></a>
+      <span class="tagline"><%= problem.blurb %></span>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/languages/language.erb
+++ b/app/views/languages/language.erb
@@ -56,11 +56,13 @@
             </a>
           </li>
 
-          <li class="<%= "active" if topic == "help" %>">
-            <a href="<%="/languages/#{track.id}/help"%>">
-              Getting Help
-            </a>
-          </li>
+          <% unless track.planned? %>
+            <li class="<%= "active" if topic == "help" %>">
+              <a href="<%="/languages/#{track.id}/help"%>">
+                Getting Help
+              </a>
+            </li>
+          <% end %>
 
           <li class="<%= "active" if topic == "contribute" %>">
             <a href="<%="/languages/#{track.id}/contribute"%>">

--- a/test/app/languages_test.rb
+++ b/test/app/languages_test.rb
@@ -48,9 +48,8 @@ class LanguagesRoutesTest < Minitest::Test
   end
 
   def test_skip_getting_help_topic_for_tracks_without_exercises
-    skip "this is not currently the case. TODO (in a separate PR)"
     get '/languages/vehicles/help'
-    refute last_response.body.include?("Getting Help")
+    refute last_response.body.include?("Getting Help"), "Help page is incorrectly linked"
   end
 
   def test_redirects_inactive_tracks_to_launch
@@ -101,7 +100,6 @@ class LanguagesRoutesTest < Minitest::Test
   end
 
   def test_when_there_are_no_exercises
-    skip "the page doesn't handle this use case, but should (in a different PR)"
     get '/languages/vehicles/exercises'
     # hard coded HTML, no need to check for markdown.
     text = "There are no available exercises in Transportation Services."
@@ -189,15 +187,14 @@ class LanguagesRoutesTest < Minitest::Test
   end
 
   def test_when_resources_doc_present
-    skip "Need to move the RESOURCES with unknown extention to a different fixture and fix the one in Fake."
     get '/languages/fake/resources'
     {
-      "Fake resources for fake." => "Trackler content is missing",
-      "<p>Fake resources for fake.</p>" => "Trackler content is markdown, not HTML",
+      "Fake resources for Fake!" => "Trackler content is missing",
+      "<p>Fake resources for Fake!</p>" => "Trackler content is markdown, not HTML",
       "Help us explain this better" => "Request for help is missing",
       "<em>Help us explain this better" => "Request for help is markdown, not HTML",
       "https://github.com/exercism/xfake/issues" => "Issue URL is wrong",
-      "https://github.com/exercism/xfake/blob/master/docs/RESOURCES.md" => "Filename is wrong",
+      "https://github.com/exercism/xfake/blob/master/docs/RESOURCES.org" => "Filename is wrong",
     }.each do |text, error_message|
       assert last_response.body.include?(text), error_message
     end


### PR DESCRIPTION
While refactoring I found some rough edges, and added skipped tests for the things I wanted to fix.

This smooths them out, improving the readability and reducing potential confusion:

* don't tell people to ask for help on a track that has no exercises
* explicitly say so in the "exercise list" page if there are no exercises
* add a test for a doc file that we couldn't test with the previous fixtures