### PR TITLE
fix link to cli

### DIFF
--- a/x/docs/md/track/TRY.md
+++ b/x/docs/md/track/TRY.md
@@ -1,6 +1,6 @@
 ### Try It!
 
-If you've downloaded the [command-line client]('/clients/cli') and have LANGUAGE installed
+If you've downloaded the [command-line client](/clients/cli) and have LANGUAGE installed
 on your machine, then go ahead and fetch the first problem.
 
 ```plain


### PR DESCRIPTION
with quotes it generate link like that "http://exercism.io/languages/rust/'/clients/cli'" but right path is "http://exercism.io/clients/cli"