### PR TITLE
Team management closing `</div>` bug fix

### DIFF
--- a/app/views/teams/manage.erb
+++ b/app/views/teams/manage.erb
@@ -104,7 +104,9 @@
 
           <%= gravatar_tag manager.avatar_url, size: 20 %>
           <a href="/<%= manager.username %>"><%= manager.username %></a>
+          <% if team.managers.count != 1 && team.managers.first == current_user %>
           </div>
+          <% end %>
         <% end %>
     </div>
   </div>


### PR DESCRIPTION
Addresses #3575. If a Team had only one Manager, the following `<hr>` Members div would be outside of the container div. This PR closes the Manager rows div only when there is more than one manager. (Also, hi, this is my first OSS PR ever!)