### PR TITLE
Index User lookup by key to address DB connection pool exhaustion

### DIFF
--- a/db/migrate/201707080642_index_users_key.rb
+++ b/db/migrate/201707080642_index_users_key.rb
@@ -1,0 +1,5 @@
+class IndexUsersKey < ActiveRecord::Migration[5.1]
+  def change
+    add_index :users, :key
+  end
+end


### PR DESCRIPTION
I noticed in BugSnag that we were still seeing this error:

    ActiveRecord::ConnectionTimeoutErrorapi/v1/routes/core.rb:46
    could not obtain a connection from the pool within 5.000 seconds (waited 5.567 seconds); all pooled connections were in use

These tracebacks were not originating at many various database calls like I would expect, but rather all at the same one, which indicates to me that this [one call](https://github.com/exercism/exercism.io/blob/master/api/v1/routes/core.rb#L46) is responsible for a large portion of our database time.

```ruby
        def find_user
          User.where(key: params[:key]).first if params[:key]
        end
```

Sure enough, there is no index for this common user lookup. Without it, the DB must scan all 150k users for each user lookup by key.

I think this should help with the ongoing connection pool issue! 🏇 ✨