### PR TITLE
Update rbenv and PostgreSQL steps for Linux

### DIFF
--- a/docs/setting-up-local-development.md
+++ b/docs/setting-up-local-development.md
@@ -71,9 +71,9 @@ These instructions assume you're using a package manager for your OS:
   ```
 - Linux
 
+  - Install `rbenv` using [these instructions](https://github.com/rbenv/rbenv#installation)
+  - Install `rbuild` using [these instructions](https://github.com/rbenv/ruby-build#readme)
   ```
-  $ sudo apt-get update
-  $ sudo apt-get install rbenv ruby-build
   $ rbenv install X.Y.Z
   ```
 
@@ -94,7 +94,7 @@ These instructions assume you're using a package manager for your OS:
 
   ```
   $ sudo apt-get update
-  $ sudo apt-get install postgresql postgresql-contrib
+  $ sudo apt-get install postgresql postgresql-contrib libpq-dev
   ```
 
 #### Installing Node.js (and npm)


### PR DESCRIPTION
Changes are based on Ubuntu but should apply similarly to other distros:
- rbenv is likely to be outdated if installed via apt-get, better to clone from GitHub so that more recent Ruby versions are available via rbenv
- libpq-dev is required for PostgreSQL (specifically for the `pg` gem)