### PR TITLE
Upgrade docker-compose format to version 2.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,46 @@
-app:
-  extends:
-    file: docker/common.yml
-    service: app
-  links:
-    - db
-  command: rackup -s puma -p 4567 --host 0.0.0.0
-  ports:
-    - "${EXTERNAL_PORT}:4567"
-  environment:
-    # These will ensure that certain development commands which
-    # use 'psql' will also include our custom database config.
-    #
-    # For more information, see:
-    # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
-    PGHOST: db
-    PGUSER: exercism
-    PGPASSWORD: apples
+version: '2.1'
+services:
+  app:
+    extends:
+      file: docker/common.yml
+      service: app
+    links:
+      - db
+    command: rackup -s puma -p 4567 --host 0.0.0.0
+    ports:
+      - "${EXTERNAL_PORT}:4567"
+    environment:
+      # These will ensure that certain development commands which
+      # use 'psql' will also include our custom database config.
+      #
+      # For more information, see:
+      # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
+      PGHOST: db
+      PGUSER: exercism
+      PGPASSWORD: apples
 
-    RACK_ENV:
-    DEV_DATABASE_HOST: db
-db:
-  image: postgres:9.4
-  environment:
-    POSTGRES_USER: exercism
-    POSTGRES_PASSWORD: apples
-compass:
-  extends:
-    file: docker/common.yml
-    service: app
-  command: compass watch
+      RACK_ENV:
+      DEV_DATABASE_HOST: db
+  db:
+    image: postgres:9.4
+    environment:
+      POSTGRES_USER: exercism
+      POSTGRES_PASSWORD: apples
+  compass:
+    extends:
+      file: docker/common.yml
+      service: app
+    command: compass watch
 
-# Lineman runs, but it's putting all its compiled code into
-# /frontend/generated, which the Ruby app isn't looking at. On
-# top of that, it doesn't deal with Docker's SIGTERM in a graceful
-# way, which slows down stopping the container, so we'll just leave
-# this whole thing disabled for now.
+  # Lineman runs, but it's putting all its compiled code into
+  # /frontend/generated, which the Ruby app isn't looking at. On
+  # top of that, it doesn't deal with Docker's SIGTERM in a graceful
+  # way, which slows down stopping the container, so we'll just leave
+  # this whole thing disabled for now.
 
-#lineman:
-#  extends:
-#    file: docker/common.yml
-#    service: app
-#  command: lineman run
-#  working_dir: /exercism/frontend
+  #lineman:
+  #  extends:
+  #    file: docker/common.yml
+  #    service: app
+  #  command: lineman run
+  #  working_dir: /exercism/frontend

--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,8 +1,10 @@
-app:
-  build: ..
-  env_file: ../.env
-  entrypoint: ruby /exercism/docker/entrypoint.rb
-  volumes:
-    - ..:/exercism
-  environment:
-    HOST_USER: $USER
+version: '2.1'
+services:
+  app:
+    build: ..
+    env_file: ../.env
+    entrypoint: ruby /exercism/docker/entrypoint.rb
+    volumes:
+      - ..:/exercism
+    environment:
+      HOST_USER: $USER


### PR DESCRIPTION
This enables the use of defaults with variable interpolation.

Followed procedure documented at https://docs.docker.com/compose/compose-file/compose-versioning/#version-1-to-2x

Several other Docker-themed PRs are coming shortly, all based on this commit to avoid conflicts.

[Diff with whitespace changes ignored](https://github.com/exercism/exercism.io/pull/3590/files?w=1)