### PR TITLE
Provide a default port, making .env optional

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - db
     command: rackup -s puma -p 4567 --host 0.0.0.0
     ports:
-      - "${EXTERNAL_PORT}:4567"
+      - "${EXTERNAL_PORT-4567}:4567"
     environment:
       # These will ensure that certain development commands which
       # use 'psql' will also include our custom database config.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,46 @@
-app:
-  extends:
-    file: docker/common.yml
-    service: app
-  links:
-    - db
-  command: rackup -s puma -p 4567 --host 0.0.0.0
-  ports:
-    - "${EXTERNAL_PORT}:4567"
-  environment:
-    # These will ensure that certain development commands which
-    # use 'psql' will also include our custom database config.
-    #
-    # For more information, see:
-    # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
-    PGHOST: db
-    PGUSER: exercism
-    PGPASSWORD: apples
+version: '2.1'
+services:
+  app:
+    extends:
+      file: docker/common.yml
+      service: app
+    links:
+      - db
+    command: rackup -s puma -p 4567 --host 0.0.0.0
+    ports:
+      - "${EXTERNAL_PORT}:4567"
+    environment:
+      # These will ensure that certain development commands which
+      # use 'psql' will also include our custom database config.
+      #
+      # For more information, see:
+      # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
+      PGHOST: db
+      PGUSER: exercism
+      PGPASSWORD: apples
 
-    RACK_ENV:
-    DEV_DATABASE_HOST: db
-db:
-  image: postgres:9.4
-  environment:
-    POSTGRES_USER: exercism
-    POSTGRES_PASSWORD: apples
-compass:
-  extends:
-    file: docker/common.yml
-    service: app
-  command: compass watch
+      RACK_ENV:
+      DEV_DATABASE_HOST: db
+  db:
+    image: postgres:9.4
+    environment:
+      POSTGRES_USER: exercism
+      POSTGRES_PASSWORD: apples
+  compass:
+    extends:
+      file: docker/common.yml
+      service: app
+    command: compass watch
 
-# Lineman runs, but it's putting all its compiled code into
-# /frontend/generated, which the Ruby app isn't looking at. On
-# top of that, it doesn't deal with Docker's SIGTERM in a graceful
-# way, which slows down stopping the container, so we'll just leave
-# this whole thing disabled for now.
+  # Lineman runs, but it's putting all its compiled code into
+  # /frontend/generated, which the Ruby app isn't looking at. On
+  # top of that, it doesn't deal with Docker's SIGTERM in a graceful
+  # way, which slows down stopping the container, so we'll just leave
+  # this whole thing disabled for now.
 
-#lineman:
-#  extends:
-#    file: docker/common.yml
-#    service: app
-#  command: lineman run
-#  working_dir: /exercism/frontend
+  #lineman:
+  #  extends:
+  #    file: docker/common.yml
+  #    service: app
+  #  command: lineman run
+  #  working_dir: /exercism/frontend

--- a/docker/README.md
+++ b/docker/README.md
@@ -58,7 +58,13 @@ welcome to give it a shot!
 
 ## Setting up exercism.io
 
-Run:
+First, create an empty `.env` file in the root of your repository. This file
+may be used to pass environment variables to the application, as documented
+below. It may be empty but [must exist][required-env-file].
+
+[required-env-file]: https://github.com/docker/compose/issues/3560
+
+Then run:
 
     docker-compose build
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -58,23 +58,7 @@ welcome to give it a shot!
 
 ## Setting up exercism.io
 
-First, create an `.env` file in the root of your repository with
-the following in it:
-
-```
-EXTERNAL_PORT=4567
-```
-
-You may also want to set up GitHub OAuth as per the instructions in
-[`CONTRIBUTING.md`][], in which case you can add your GitHub OAuth
-credentials, too:
-
-```
-EXERCISM_GITHUB_CLIENT_ID=your_github_oauth_client_id
-EXERCISM_GITHUB_CLIENT_SECRET=your_github_oauth_client_secret
-```
-
-Then run:
+Run:
 
     docker-compose build
 
@@ -87,8 +71,8 @@ Now your database is set up. To get the site up and running, run:
 
     docker-compose up
 
-If you're on Linux, your development instance of exercism.io will be running
-at http://localhost:4567.
+If you're Docker for Mac, or Docker for Windows, or native Linux, your
+development instance of exercism.io will be running at http://localhost:4567.
 
 Otherwise, if you're on a system using Docker Toolbox, your development
 server will actually be running on your Docker Machine VM, *not* on
@@ -100,6 +84,18 @@ go to the IP address you get from running the following command:
 Suppose this command tells you that your Docker Machine VM is at
 192.168.99.100. Then your development instance of exercism.io will be at
 http://192.168.99.100:4567.
+
+## Setting up OAuth
+
+In development mode, the application presents an _Assume_ menu in the
+upper-right-hand corner, allowing you to assume the role of one of several
+preset users.
+
+You may also set up GitHub OAuth as per the instructions in
+[`CONTRIBUTING.md`][], in which case you can add your GitHub OAuth credentials:
+
+    EXERCISM_GITHUB_CLIENT_ID=your_github_oauth_client_id
+    EXERCISM_GITHUB_CLIENT_SECRET=your_github_oauth_client_secret
 
 ## Changing The Port
 

--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,8 +1,10 @@
-app:
-  build: ..
-  env_file: ../.env
-  entrypoint: ruby /exercism/docker/entrypoint.rb
-  volumes:
-    - ..:/exercism
-  environment:
-    HOST_USER: $USER
+version: '2.1'
+services:
+  app:
+    build: ..
+    env_file: ../.env
+    entrypoint: ruby /exercism/docker/entrypoint.rb
+    volumes:
+      - ..:/exercism
+    environment:
+      HOST_USER: $USER


### PR DESCRIPTION
Convention over configuration.

With this first step no longer needed, move OAuth configuration lower in the README, relative to its importance.

Changing the port is already documented. Removed the redundant reference.

Based on #3590 to avoid conflicts.