### PR TITLE
Use a named Docker volume to better persist data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       DEV_DATABASE_HOST: db
   db:
     image: postgres:9.4
+    volumes:
+      - pgdata:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: exercism
       POSTGRES_PASSWORD: apples
@@ -44,3 +46,7 @@ services:
   #    service: app
   #  command: lineman run
   #  working_dir: /exercism/frontend
+
+volumes:
+  pgdata:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,46 @@
-app:
-  extends:
-    file: docker/common.yml
-    service: app
-  links:
-    - db
-  command: rackup -s puma -p 4567 --host 0.0.0.0
-  ports:
-    - "${EXTERNAL_PORT}:4567"
-  environment:
-    # These will ensure that certain development commands which
-    # use 'psql' will also include our custom database config.
-    #
-    # For more information, see:
-    # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
-    PGHOST: db
-    PGUSER: exercism
-    PGPASSWORD: apples
+version: '2.1'
+services:
+  app:
+    extends:
+      file: docker/common.yml
+      service: app
+    links:
+      - db
+    command: rackup -s puma -p 4567 --host 0.0.0.0
+    ports:
+      - "${EXTERNAL_PORT}:4567"
+    environment:
+      # These will ensure that certain development commands which
+      # use 'psql' will also include our custom database config.
+      #
+      # For more information, see:
+      # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
+      PGHOST: db
+      PGUSER: exercism
+      PGPASSWORD: apples
 
-    RACK_ENV:
-    DEV_DATABASE_HOST: db
-db:
-  image: postgres:9.4
-  environment:
-    POSTGRES_USER: exercism
-    POSTGRES_PASSWORD: apples
-compass:
-  extends:
-    file: docker/common.yml
-    service: app
-  command: compass watch
+      RACK_ENV:
+      DEV_DATABASE_HOST: db
+  db:
+    image: postgres:9.4
+    environment:
+      POSTGRES_USER: exercism
+      POSTGRES_PASSWORD: apples
+  compass:
+    extends:
+      file: docker/common.yml
+      service: app
+    command: compass watch
 
-# Lineman runs, but it's putting all its compiled code into
-# /frontend/generated, which the Ruby app isn't looking at. On
-# top of that, it doesn't deal with Docker's SIGTERM in a graceful
-# way, which slows down stopping the container, so we'll just leave
-# this whole thing disabled for now.
+  # Lineman runs, but it's putting all its compiled code into
+  # /frontend/generated, which the Ruby app isn't looking at. On
+  # top of that, it doesn't deal with Docker's SIGTERM in a graceful
+  # way, which slows down stopping the container, so we'll just leave
+  # this whole thing disabled for now.
 
-#lineman:
-#  extends:
-#    file: docker/common.yml
-#    service: app
-#  command: lineman run
-#  working_dir: /exercism/frontend
+  #lineman:
+  #  extends:
+  #    file: docker/common.yml
+  #    service: app
+  #  command: lineman run
+  #  working_dir: /exercism/frontend

--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,8 +1,10 @@
-app:
-  build: ..
-  env_file: ../.env
-  entrypoint: ruby /exercism/docker/entrypoint.rb
-  volumes:
-    - ..:/exercism
-  environment:
-    HOST_USER: $USER
+version: '2.1'
+services:
+  app:
+    build: ..
+    env_file: ../.env
+    entrypoint: ruby /exercism/docker/entrypoint.rb
+    volumes:
+      - ..:/exercism
+    environment:
+      HOST_USER: $USER


### PR DESCRIPTION
Goal: Keep the database data around beyond the life of the DB container, and automatically attach it to new DB containers.

Without this, `docker-compose down` or otherwise removing the postgres container leaves orphan volumes that will not be reattached automatically.

Based on #3590 to avoid conflicts.