### PR TITLE
Introduce a base docker image for layer caching purposes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.bundle
+.env
+.git
+.gitignore
+log
+tmp
+vendor

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,7 @@
 log
 tmp
 vendor
+
+# For development build efficiency.
+# Consider restoring this if needed for a production build.
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
   apt-get install -y nodejs postgresql-client && \
   npm install -g lineman
 
-COPY Gemfile Gemfile.lock /exercism/
-
 WORKDIR /exercism
 
+COPY Gemfile Gemfile.lock /exercism/
 RUN bundle install

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,4 @@
+FROM exercism/exercism.io
+
+COPY Gemfile Gemfile.lock /exercism/
+RUN bundle check || bundle install

--- a/bin/setup
+++ b/bin/setup
@@ -17,7 +17,7 @@ fi
 
 # Set up Ruby dependencies via Bundler
 gem install bundler --conservative
-bundle check || bundle install --path=vendor/bundle
+bundle check || bundle install
 
 # Set up the database and add seed data
 bundle exec rake db:from_scratch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,46 @@
-app:
-  extends:
-    file: docker/common.yml
-    service: app
-  links:
-    - db
-  command: rackup -s puma -p 4567 --host 0.0.0.0
-  ports:
-    - "${EXTERNAL_PORT}:4567"
-  environment:
-    # These will ensure that certain development commands which
-    # use 'psql' will also include our custom database config.
-    #
-    # For more information, see:
-    # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
-    PGHOST: db
-    PGUSER: exercism
-    PGPASSWORD: apples
+version: '2.1'
+services:
+  app:
+    extends:
+      file: docker/common.yml
+      service: app
+    links:
+      - db
+    command: rackup -s puma -p 4567 --host 0.0.0.0
+    ports:
+      - "${EXTERNAL_PORT}:4567"
+    environment:
+      # These will ensure that certain development commands which
+      # use 'psql' will also include our custom database config.
+      #
+      # For more information, see:
+      # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
+      PGHOST: db
+      PGUSER: exercism
+      PGPASSWORD: apples
 
-    RACK_ENV:
-    DEV_DATABASE_HOST: db
-db:
-  image: postgres:9.4
-  environment:
-    POSTGRES_USER: exercism
-    POSTGRES_PASSWORD: apples
-compass:
-  extends:
-    file: docker/common.yml
-    service: app
-  command: compass watch
+      RACK_ENV:
+      DEV_DATABASE_HOST: db
+  db:
+    image: postgres:9.4
+    environment:
+      POSTGRES_USER: exercism
+      POSTGRES_PASSWORD: apples
+  compass:
+    extends:
+      file: docker/common.yml
+      service: app
+    command: compass watch
 
-# Lineman runs, but it's putting all its compiled code into
-# /frontend/generated, which the Ruby app isn't looking at. On
-# top of that, it doesn't deal with Docker's SIGTERM in a graceful
-# way, which slows down stopping the container, so we'll just leave
-# this whole thing disabled for now.
+  # Lineman runs, but it's putting all its compiled code into
+  # /frontend/generated, which the Ruby app isn't looking at. On
+  # top of that, it doesn't deal with Docker's SIGTERM in a graceful
+  # way, which slows down stopping the container, so we'll just leave
+  # this whole thing disabled for now.
 
-#lineman:
-#  extends:
-#    file: docker/common.yml
-#    service: app
-#  command: lineman run
-#  working_dir: /exercism/frontend
+  #lineman:
+  #  extends:
+  #    file: docker/common.yml
+  #    service: app
+  #  command: lineman run
+  #  working_dir: /exercism/frontend

--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,8 +1,10 @@
-app:
-  build: ..
-  env_file: ../.env
-  entrypoint: ruby /exercism/docker/entrypoint.rb
-  volumes:
-    - ..:/exercism
-  environment:
-    HOST_USER: $USER
+version: '2.1'
+services:
+  app:
+    build: ..
+    env_file: ../.env
+    entrypoint: ruby /exercism/docker/entrypoint.rb
+    volumes:
+      - ..:/exercism
+    environment:
+      HOST_USER: $USER

--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,7 +1,9 @@
 version: '2.1'
 services:
   app:
-    build: ..
+    build:
+      context: ..
+      dockerfile: Dockerfile.dev
     env_file: ../.env
     entrypoint: ruby /exercism/docker/entrypoint.rb
     volumes:


### PR DESCRIPTION
This will drastically improve docker dev environment initial setup speed.  Rather than building locally, the local docker build (built from Dockerfile.dev) is now based on the public, automated exercism/exercism.io build (built from Dockerfile). With this as a starting point, a developer's `docker-compose build` need only install any new gems that are introduced in the feature branch. With no local changes, a local docker build, excluding download time, now takes approximately 6 seconds, vs. 50 minutes before.

@kytrinyx: Before merging this, you will need to create an Automated Build on Docker Hub. The new `Dockerfile.dev` build depends on this. This will result in Docker Hub hosting and building our Dockerfile each time you push to master on GitHub, such that people can `docker pull exercism/exercism.io`.

1. Visit [https://hub.docker.com/r/exercism/](https://hub.docker.com/r/exercism/).
2. In the top navigation bar, select *Create* > *Create Automated Build*.
3. Select GitHub.
4. Select exercism/exercism.io.
4. Select the exercism namespace if not already selected.
5. Fill a Short Description. Suggested: "exercism.io application development base image"
6. Optional: Limit branches to be built. Customize the branch matching behavior (_Click here to customize_). Leave the default custom behavior (build master only).
7. *Create* the automated build.

Changes:

- .dockerignore vendor/

    Vendored gems make the docker context directory size large (+1.1 G in vendor/), causing longer build times. Additionally, as individual developers, rather than being able to inherit most or all gems from an application base image, we are forced to install the full set of gems when first setting up a development environment.

- .dockerignore node_modules/

    Reduces docker build context size. `node_modules` can get large and adds time to the context upload to the Docker engine. In our development environment, node_modules is mounted from the host with the rest of the application source and will always be present.

- Dockerfile is now used by the automated build to build the exercism/exercism.io base image. See https://hub.docker.com/r/exercism/exercism.io/

- docker-compose builds Dockerfile.dev, which is built FROM the public exercism/exercism.io docker image. This Dockerfile need only contain commands specific to the development environment and changes from the local git repository that need to be built. Presently, it checks for new gems to install.

- Dockerfile: Set WORKDIR before RUN bundle install to invalidate one fewer layer when the bundle is updated.

Based on #3590 to avoid conflicts.