### PR TITLE
Docker: Rerun puma/lineman when relevant files change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :test, :development do
 end
 
 group :development do
+  gem 'rerun', require: false
   gem 'rubocop', '0.36.0', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,10 @@ GEM
     kss (0.5.0)
     launchy (2.4.3)
       addressable (~> 2.3)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     metaclass (0.0.4)
@@ -130,6 +134,8 @@ GEM
     rb-readline (0.5.3)
     redcarpet (3.3.4)
     redis (3.3.3)
+    rerun (0.11.0)
+      listen (~> 3.0)
     rouge (2.0.7)
     rubocop (0.36.0)
       parser (>= 2.3.0.0, < 3.0)
@@ -137,6 +143,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
     ruby-progressbar (1.8.0)
+    ruby_dep (1.5.0)
     rubypants (0.6.0)
     rubyzip (1.2.1)
     sass (3.4.21)
@@ -215,6 +222,7 @@ DEPENDENCIES
   rake (~> 10.5.0)
   rb-readline
   redcarpet (~> 3.1)
+  rerun
   rouge (~> 2.0.5)
   rubocop (= 0.36.0)
   sass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '2.1'
+
 services:
   app:
     extends:
@@ -21,6 +22,7 @@ services:
 
       RACK_ENV:
       DEV_DATABASE_HOST: db
+
   db:
     image: postgres:9.4
     volumes:
@@ -28,24 +30,19 @@ services:
     environment:
       POSTGRES_USER: exercism
       POSTGRES_PASSWORD: apples
+
   compass:
     extends:
       file: docker/common.yml
       service: app
     command: compass watch
 
-  # Lineman runs, but it's putting all its compiled code into
-  # /frontend/generated, which the Ruby app isn't looking at. On
-  # top of that, it doesn't deal with Docker's SIGTERM in a graceful
-  # way, which slows down stopping the container, so we'll just leave
-  # this whole thing disabled for now.
-
-  #lineman:
-  #  extends:
-  #    file: docker/common.yml
-  #    service: app
-  #  command: lineman run
-  #  working_dir: /exercism/frontend
+  lineman:
+    extends:
+      file: docker/common.yml
+      service: app
+    command: rerun -b --pattern '{**/*.coffee,**/{script,stats}.js}' -- lineman run
+    working_dir: /exercism/frontend
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       DEV_DATABASE_HOST: db
   db:
     image: postgres:9.4
+    volumes:
+      - pgdata:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: exercism
       POSTGRES_PASSWORD: apples
@@ -44,3 +46,7 @@ services:
   #    service: app
   #  command: lineman run
   #  working_dir: /exercism/frontend
+
+volumes:
+  pgdata:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       service: app
     links:
       - db
-    command: rackup -s puma -p 4567 --host 0.0.0.0
+    command: rerun -b --ignore='{**/*.{scss,css,js,coffee,erb},test/**}' 'puma -p 4567'
     ports:
       - "${EXTERNAL_PORT}:4567"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,46 @@
-app:
-  extends:
-    file: docker/common.yml
-    service: app
-  links:
-    - db
-  command: rackup -s puma -p 4567 --host 0.0.0.0
-  ports:
-    - "${EXTERNAL_PORT}:4567"
-  environment:
-    # These will ensure that certain development commands which
-    # use 'psql' will also include our custom database config.
-    #
-    # For more information, see:
-    # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
-    PGHOST: db
-    PGUSER: exercism
-    PGPASSWORD: apples
+version: '2.1'
+services:
+  app:
+    extends:
+      file: docker/common.yml
+      service: app
+    links:
+      - db
+    command: rackup -s puma -p 4567 --host 0.0.0.0
+    ports:
+      - "${EXTERNAL_PORT}:4567"
+    environment:
+      # These will ensure that certain development commands which
+      # use 'psql' will also include our custom database config.
+      #
+      # For more information, see:
+      # http://www.postgresql.org/docs/8.4/static/libpq-envars.html
+      PGHOST: db
+      PGUSER: exercism
+      PGPASSWORD: apples
 
-    RACK_ENV:
-    DEV_DATABASE_HOST: db
-db:
-  image: postgres:9.4
-  environment:
-    POSTGRES_USER: exercism
-    POSTGRES_PASSWORD: apples
-compass:
-  extends:
-    file: docker/common.yml
-    service: app
-  command: compass watch
+      RACK_ENV:
+      DEV_DATABASE_HOST: db
+  db:
+    image: postgres:9.4
+    environment:
+      POSTGRES_USER: exercism
+      POSTGRES_PASSWORD: apples
+  compass:
+    extends:
+      file: docker/common.yml
+      service: app
+    command: compass watch
 
-# Lineman runs, but it's putting all its compiled code into
-# /frontend/generated, which the Ruby app isn't looking at. On
-# top of that, it doesn't deal with Docker's SIGTERM in a graceful
-# way, which slows down stopping the container, so we'll just leave
-# this whole thing disabled for now.
+  # Lineman runs, but it's putting all its compiled code into
+  # /frontend/generated, which the Ruby app isn't looking at. On
+  # top of that, it doesn't deal with Docker's SIGTERM in a graceful
+  # way, which slows down stopping the container, so we'll just leave
+  # this whole thing disabled for now.
 
-#lineman:
-#  extends:
-#    file: docker/common.yml
-#    service: app
-#  command: lineman run
-#  working_dir: /exercism/frontend
+  #lineman:
+  #  extends:
+  #    file: docker/common.yml
+  #    service: app
+  #  command: lineman run
+  #  working_dir: /exercism/frontend

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,8 +9,11 @@ need a 64-bit machine.
 
 For a basic overview, see [What is Docker?][] on the Docker website.
 
-**Note:** At the present time, developing the front-end via Docker
-isn't working, but this will hopefully be remedied soon.
+When using docker, code changes on your host should go into effect shortly after
+they are made. Changes to `.erb` files go into effect immediately. Changes to
+`.js`, `.coffee` and `scss` files go into effect after a few seconds. Changes to
+`.rb` and other files require restarting the application and bring down the
+application for a few seconds.
 
 ## Installing Docker
 

--- a/docker/common.yml
+++ b/docker/common.yml
@@ -1,8 +1,10 @@
-app:
-  build: ..
-  env_file: ../.env
-  entrypoint: ruby /exercism/docker/entrypoint.rb
-  volumes:
-    - ..:/exercism
-  environment:
-    HOST_USER: $USER
+version: '2.1'
+services:
+  app:
+    build: ..
+    env_file: ../.env
+    entrypoint: ruby /exercism/docker/entrypoint.rb
+    volumes:
+      - ..:/exercism
+    environment:
+      HOST_USER: $USER


### PR DESCRIPTION
With no code reloading functionality in Sinatra, this I think is the next-best thing.

There is necessarily downtime after each `.rb` file change, while puma restarts. Modified `.js`/`.coffee` files take a few seconds to go into effect. Changes to `.erb` files go into effect immediately.

Restarting Lineman is a hack. Lineman really ought to instead be doing its own reloading.  It watches and compiles the files but doesn't put them in the right places to be effective. I have not spent the time to learn lineman well enough to fix it. Instead as a workaround, restart lineman, because starting lineman puts everything in its right place. See https://github.com/exercism/exercism.io/issues/2936#issuecomment-315500149

Based on #3592 to avoid conflicts.