### PR TITLE
Improve bundle install in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
 WORKDIR /exercism
 
 COPY Gemfile Gemfile.lock /exercism/
+RUN gem install bundler -v $(grep -A1 'BUNDLED WITH' Gemfile.lock | tail -n 1) \
+    || echo 'Gemfile.lock missing BUNDLED WITH'
 RUN bundle install --jobs=20

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
 WORKDIR /exercism
 
 COPY Gemfile Gemfile.lock /exercism/
-RUN bundle install
+RUN bundle install --jobs=20


### PR DESCRIPTION
A couple improvements on the base Docker image build:

- Install the version of bundler specified in Gemfile.lock
- Take advantage of bundler's parallelism