### PR TITLE
Fix Porting an Exercise Link

### DIFF
--- a/app/views/contribute/index.erb
+++ b/app/views/contribute/index.erb
@@ -157,7 +157,7 @@
           </p>
 
           <p>
-            Check out the <a href="https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/porting-an-exercise.md">detailed guide</a> if you want to give it a try!
+            Check out the <a href="https://github.com/exercism/docs/blob/master/you-can-help/implement-an-exercise-from-specification.md">detailed guide</a> if you want to give it a try!
           </p>
         </div>
       </div>

--- a/app/views/languages/contribute.erb
+++ b/app/views/languages/contribute.erb
@@ -20,7 +20,7 @@
 
         <p>The language icons link to each existing implementation of the problem.</p>
         <p>
-        Once you've picked an exercise, follow the instructions in the <a href="https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/porting-an-exercise.md" target="_blank">Contributing Guide</a> and submit your pull request to the <a href="<%= exercises.repository %>" target="_blank"><%= exercises.language %> track repository</a> on GitHub.
+        Once you've picked an exercise, follow the instructions in the <a href="https://github.com/exercism/docs/blob/master/you-can-help/implement-an-exercise-from-specification.md" target="_blank">Contributing Guide</a> and submit your pull request to the <a href="<%= exercises.repository %>" target="_blank"><%= exercises.language %> track repository</a> on GitHub.
         </p>
       </div>
     </div>

--- a/x/docs/md/track/TODO.md
+++ b/x/docs/md/track/TODO.md
@@ -10,4 +10,4 @@ We also link to all the implementations of each exercise in other languages, whi
 
 Once you've picked an exercise, follow the instructions in [this guide][porting-guide] and submit your pull request to the [LANGUAGE track repository](REPO) on GitHub.
 
-[porting-guide]: https://github.com/exercism/docs/tree/master/contributing-to-language-tracks/porting-an-exercise.md
+[porting-guide]: https://github.com/exercism/docs/blob/master/you-can-help/implement-an-exercise-from-specification.md


### PR DESCRIPTION
### Problem

The following link is pointing to an old docs page:
<img width="809" alt="screen shot 2017-07-24 at 11 22 10 pm" src="https://user-images.githubusercontent.com/2517299/28530649-21df7b44-70c7-11e7-868f-7bdceeafb86a.png">

### Solution

Changes done in this PR:
- [x] Fix `this guide` link from the TODO section of Unimplemented Exercises.
- [x] Fix other instances of the same link all over the app

