### PR TITLE
Make the comment body non-bindable by Angular

### DIFF
--- a/app/views/submissions/comment.erb
+++ b/app/views/submissions/comment.erb
@@ -19,7 +19,7 @@
       <h5>Select a comment to insert as a starting point</h5>
         <div class="list-group">
           <% locals[:comment_history].each do |comment| %>
-            <button type="button" class="list-group-item history_item">
+            <button type="button" class="list-group-item history_item" ng-non-bindable>
               <%= comment.body %>
             </button>
           <% end %>


### PR DESCRIPTION
This change makes comments containing curly brackets not bindable by Angular.

See: https://docs.angularjs.org/api/ng/directive/ngNonBindable
