### PR TITLE
Clarify introduction to workflow section of contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,8 @@ Help us keep exercism welcoming. Please read and abide by the [Code of Conduct][
 
 ## Submitting Code Changes
 
-These instructions should get you closer to getting a commit into the
-repository.
+If you're new to contributing to open source on GitHub, this next section should help you get started.
+If you get stuck, open an issue to ask us for help and we'll get you sorted out (and improve these instructions).
 
 See the [Setting up Local Development guide][local-dev-env] for more information about how to run exercism.io locally.
 


### PR DESCRIPTION
That helps frame this as details that you may or may not need depending on your experience with GitHub, and also emphasizes that we are happy to help, and that if a person is confused it's probably our fault, not theirs.

I suggested this tweak to the interactive CLI walkthrough, and @kntsoriano suggested it would be a good improvement here as well. I thought so too :-)