### PR TITLE
Filter comment history by the submission's track

### DIFF
--- a/app/routes/submissions.rb
+++ b/app/routes/submissions.rb
@@ -15,7 +15,7 @@ module ExercismWeb
 
         title("%s by %s in %s" % [submission.problem.name, submission.user.username, submission.problem.language])
 
-        comment_history = current_user.guest? ? [] : current_user.comments.recent(50)
+        comment_history = current_user.guest? ? [] : current_user.comments.in_track(submission.language).recent(50)
 
         locals = {
           submission: submission,

--- a/lib/exercism/comment.rb
+++ b/lib/exercism/comment.rb
@@ -19,6 +19,7 @@ class Comment < ActiveRecord::Base
   scope :reversed, -> { order(created_at: :desc) }
   scope :received_by, ->(user) { where(submission_id: user.submissions.pluck(:id)) }
   scope :paginate_by_params, ->(params) { paginate(page: params[:page], per_page: params[:per_page] || 10) }
+  scope :in_track, ->(id) { joins(:submission).where("submissions.language" => id) }
 
   scope :except_on_submissions_by, ->(user) { joins(:submission).merge(Submission.not_submitted_by(user)) }
 

--- a/test/exercism/comment_test.rb
+++ b/test/exercism/comment_test.rb
@@ -29,4 +29,16 @@ class CommentTest < Minitest::Test
       assert_equal mentions, usernames.sort
     end
   end
+
+  def test_filter_by_submission_language
+    alice = User.create(username: "alice")
+    s1 = Submission.create(user: alice, language: "python", slug: "one")
+    c1 = Comment.create(user: alice, submission: s1, body: "python comment")
+    s2 = Submission.create(user: alice, language: "ruby", slug: "one")
+    c2 = Comment.create(user: alice, submission: s2, body: "ruby comment")
+
+    comments = alice.comments.in_track("ruby")
+    assert_equal 1, comments.size
+    assert_equal "ruby comment", comments.first.body
+  end
 end


### PR DESCRIPTION
On the submission page we show a 'history' tab, which contains the most recent 50 comments. For people who comment in multiple tracks, this can contain a fair amount of less-relevant content.

The downside is that there might be some comments that people use a lot across all the tracks that they give feedback in. On the upside, it shouldn't be too hard to find that and copy/paste it the first time you need it in a new language track.