### PR TITLE
Prevent reflected XSS via unescaped HTML tags in comment history

### DIFF
--- a/app/views/submissions/comment.erb
+++ b/app/views/submissions/comment.erb
@@ -20,7 +20,7 @@
         <div class="list-group">
           <% locals[:comment_history].each do |comment| %>
             <button type="button" class="list-group-item history_item" ng-non-bindable>
-              <%= comment.body %>
+              <%= Rack::Utils.escape_html(comment.body) %>
             </button>
           <% end %>
         </div>


### PR DESCRIPTION
Since exercism doesn't implement CSRF protection, a malicious site could submit comments on behalf of a user containing <script> tags that would execute when rendering that user's comment history. That script could send the user's cookie to a malicious party, who could then impersonate the user on exercism.

This patch escapes HTML in comment history, which in addition to being a security risk can interfere with the proper function of the page.

Fixes #3673