### PR TITLE
Allow case insensitive tag search in /teams endpoint

### DIFF
--- a/app/routes/teams.rb
+++ b/app/routes/teams.rb
@@ -6,7 +6,7 @@ module ExercismWeb
         please_login
 
         page = params[:page] || 1
-        q = Rack::Utils.escape_html(params["q"])
+        q = Rack::Utils.escape_html(params["q"]).downcase
 
         if q.present?
           tag = Tag.find_by(name: q)

--- a/test/app/teams_test.rb
+++ b/test/app/teams_test.rb
@@ -102,6 +102,18 @@ class TeamsTest < Minitest::Test
     end
   end
 
+  def test_logged_user_can_search_teams_by_case_insensitive_tags
+    Team
+      .by(alice)
+      .defined_with(slug: 'case insensitive team', public: '1', tags: 'insensitive')
+      .save!
+
+    get '/teams', { q: 'INSENSITIVE' }, login(alice)
+
+    assert_equal 200, last_response.status
+    assert_match %r{case insensitive team \(0 members\)}, last_response.body
+  end
+
   def test_user_must_be_on_team_to_view_team_page
     team = Team.by(alice).defined_with(slug: 'abc')
     team.save


### PR DESCRIPTION
Tags are already `downcased` when being persisted, so it makes sense to do the same for the provided term.

Related issue: #3738