### PR TITLE
Word-break links in all comments, fixes #3746

### DIFF
--- a/public/sass/base/components/comment.scss
+++ b/public/sass/base/components/comment.scss
@@ -82,6 +82,10 @@ Styleguide Components - Comment.
     border: 1px solid $gray-lighter;
     border-radius: $border-radius-base;
     @include default-triangle("left");
+
+    p a {
+      word-wrap: break-word;
+    }
   }
   .comment-meta {
     border: 1px solid darken($gray-lighter, 10%);
@@ -103,9 +107,6 @@ Styleguide Components - Comment.
     }
     .comment-body {
       @include default-triangle("right");
-    }
-    .comment-body p a{
-      word-wrap: break-word;
     }
   }
 }


### PR DESCRIPTION
This should fix #3746. The css was already in place for any comments posted by the submitter, it was just scoped to tightly I guess.

**Before**
<img width="736" alt="bildschirmfoto 2018-04-01 um 23 20 19" src="https://user-images.githubusercontent.com/68024/38177521-d1bf0c9e-3603-11e8-86b5-e27cf6259d90.png">
**After**
<img width="590" alt="bildschirmfoto 2018-04-01 um 23 21 25" src="https://user-images.githubusercontent.com/68024/38177523-d6572a0c-3603-11e8-9d83-39bd9b40bbcb.png">
