### PR TITLE
Correct layout problems when there is more than one manager for a team

### DIFF
--- a/app/views/teams/manage.erb
+++ b/app/views/teams/manage.erb
@@ -90,24 +90,26 @@
     <br/>
 
     <div class="row">
-      <% team.managers.each do |manager| %>
-        <% if team.managers.count == 1 && team.managers.first == current_user %>
-          <button type="button" class="disabled btn btn-xs btn-danger manager_delete" data-toggle="tooltip" data-placement="bottom" title="You must add another manager before you can remove yourself as the last manager." style="margin: 10px 10px 10px 0">Remove</button>
-        <% else %>
+      <% if team.managers.count == 1 && team.managers.first == current_user %>
+        <div class="col-sm-3">
+          <button type="button" class="disabled btn btn-xs btn-danger manager_delete" data-toggle="tooltip" data-placement="bottom" title="You must add another manager before you can remove yourself as the last manager." style="margin: 10px 10px 10px 0">X</button>
+          <%= gravatar_tag current_user.avatar_url, size: 20 %>
+          <a href="/<%= current_user.username %>"><%= current_user.username %></a>
+        </div>
+      <% else %>
+        <% team.managers.each do |manager| %>
           <div class="col-sm-3">
             <form accept-charset="UTF-8" action="/teams/<%= team.slug %>/managers" method="post" style="display: inline">
               <input type="hidden" name="_method" value="delete" />
               <input type="hidden" name="username" value="<%= manager.username %>" />
               <button type="submit" class="btn btn-xs btn-danger manager_delete" data-username="<%= manager.username %>" style="margin: 10px 10px 10px 0">X</button>
             </form>
-          <% end %>
 
-          <%= gravatar_tag manager.avatar_url, size: 20 %>
-          <a href="/<%= manager.username %>"><%= manager.username %></a>
-          <% if team.managers.count != 1 && team.managers.first == current_user %>
+            <%= gravatar_tag manager.avatar_url, size: 20 %>
+            <a href="/<%= manager.username %>"><%= manager.username %></a>
           </div>
-          <% end %>
         <% end %>
+      <% end %>
     </div>
   </div>
 


### PR DESCRIPTION
When a team has more than a single manager, the page layout gets all sorts of messed up :(

## Before

![image](https://user-images.githubusercontent.com/682860/38877440-b3039182-422c-11e8-8ff8-afedbea4589a.png)

I was able to track this down to a few lines in the [manage.erb](https://github.com/exercism/exercism.io/blob/master/app/views/teams/manage.erb#L107-L109) template.

It was pretty hard to reason about the logic in the template so I broke it up into two scenarios
 - there is a single manager
 - there are more than one managers

There is likely some unnecessary duplication in the html in the view  now (this is my first time working with ruby and `.erb` files) but at least it renders accurately.

I also changed the delete button on the manager to a single `X` instead of `Remove` as it seems more consistent with the rest of the buttons.

## After

![image](https://user-images.githubusercontent.com/682860/38877782-73c46144-422d-11e8-839d-bd516b2f9432.png)
