### PR TITLE
Fix canonical data counter

### DIFF
--- a/app/routes/contribute.rb
+++ b/app/routes/contribute.rb
@@ -16,7 +16,7 @@ module ExercismWeb
           implementations: Trackler.implementations[slug],
           problems: need_canonical,
           active_problems_count: active_problems.size,
-          canonical_problems_count: [active_problems - need_canonical].size
+          canonical_problems_count: (active_problems - need_canonical).size
         }
       end
     end


### PR DESCRIPTION
Resolves https://github.com/exercism/exercism.io/issues/3730

The reason why the counter was always returning 1 as the count of canonical problems extracted was because the result of getting the array difference of `active_problems` and `need_canonical` (_which is also an array_) was enclosed in `[]` and `size` method was called on that element.

This meant that regardless of the result of the array difference, there will always only be one element in the array when calling `size`

This change fixes that issue by changing the delimiter from `[]` to `()` and calling `size`

#### Screenshots
___
![before-change](https://user-images.githubusercontent.com/1518902/39284652-2de840bc-48c9-11e8-8c94-63f0d1b8f7f2.png)

![canonical_data_-_exercism_io](https://user-images.githubusercontent.com/1518902/39284641-24bd11b6-48c9-11e8-9301-5d88662dcb72.png)
