### PR TITLE
Fix broken link in contribute page

### DIFF
--- a/app/views/contribute/index.erb
+++ b/app/views/contribute/index.erb
@@ -139,7 +139,7 @@
           </p>
 
            <p>
-            Check out the section about <a href="https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/implementing-a-completely-new-exercise.md">implementing a new exercise</a> in the Contributing Guide.
+            Check out the section about <a href="https://github.com/exercism/docs/blob/master/you-can-help/make-up-new-exercises.md">implementing a new exercise</a> in the Contributing Guide.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Resolves https://github.com/exercism/exercism.io/issues/3758

A document was moved but the link to that document was not updated,
causing a broken link. This fixes the broken reference.