### PR TITLE
Fix explanation of abbreviation API

### DIFF
--- a/app/views/site/how_it_works_newbie.erb
+++ b/app/views/site/how_it_works_newbie.erb
@@ -154,7 +154,7 @@
 
     <div class="col-md-4 hints text-muted">
       <p>
-        <strong>API</strong> stands for <i>Application Programmer's Interface</i>.
+        <strong>API</strong> stands for <i>Application Programming Interface</i>.
         Exercism has an API, which is kind of like a separate website without any HTML. Instead it returns more structured output making it easier to deal with programmatically.
       </p>
     </div>


### PR DESCRIPTION
I believe the P in API is most commonly _programming_ or even _program_, rather than _programmer's_. The latter may not be technically inaccurate, just not the normal definition.