### PR TITLE
Use URI escaping for GitHub login redirects

### DIFF
--- a/app/routes/sessions.rb
+++ b/app/routes/sessions.rb
@@ -4,13 +4,13 @@ module ExercismWeb
       register ExercismWeb::Routes::GithubCallback
 
       get '/please-login' do
-        erb :"auth/please_login", locals: { return_path: Rack::Utils.escape_html(params[:return_path]) }
+        erb :"auth/please_login", locals: { return_path: URI.escape(params[:return_path]) }
       end
 
       get '/login' do
         q = { client_id: github_client_id }
         if params.key?("return_path")
-          q[:redirect_uri] = [request.base_url, "github", "callback", Rack::Utils.escape_html(params[:return_path])].join("/")
+          q[:redirect_uri] = [request.base_url, "github", "callback"].join("/") + URI.escape(params[:return_path])
         end
         redirect Github.login_url(q)
       end


### PR DESCRIPTION
HTML escaping is all very nice, but it doesn't actually work for URLs.

Closes https://github.com/exercism/exercism.io/issues/3771