### PR TITLE
Fix uninstall path in Linux CLI installation instructions

### DIFF
--- a/x/docs/md/cli/linux.md
+++ b/x/docs/md/cli/linux.md
@@ -58,10 +58,10 @@ You can now continue by [choosing a language](http://exercism.io/languages).
 
 ### Uninstalling the Exercism CLI
 
-Remove the file from the `~/bin` directory with the following command:
+Remove the file from the `/usr/local/bin` directory with the following command:
 
 ```bash
-rm ~/bin/exercism
+rm /usr/local/bin/exercism
 ```
 
 ### Help


### PR DESCRIPTION
Small fix in uninstall path for Linux CLI. 

I would also update the instructions to mention 
that operations with /usr/local/bin require superuser permissions.

Should I do this in separate PR?

(Also sorry for any contributing mistakes - my first PR for a real project)