### PR TITLE
Add a mentor recruitment banner

### DIFF
--- a/app/views/application/_navbar.erb
+++ b/app/views/application/_navbar.erb
@@ -1,3 +1,10 @@
+<div id="mentors-banner">
+  <div class="container">
+    <p>Exercism needs your help for the launch of our new site.</p>
+    <a href="http://mentoring.exercism.io">Learn more</a>
+  </div>
+</div>
+
 <nav class="navbar navbar-inverse navbar-default navbar-fixed-top" role="navigation">
   <div class="container">
     <div class="navbar-header">

--- a/public/sass/base/components/banner.scss
+++ b/public/sass/base/components/banner.scss
@@ -1,0 +1,41 @@
+nav {
+    top:54px !important;
+}
+main {
+    margin-top: 54px;
+}
+
+#mentors-banner {
+    position:fixed;
+    top:0;
+    left:0;
+    right:0;
+    background:#D81D4E;
+    color:#fff;
+    padding:10px 0;
+    text-align:center;
+
+    p, a {
+        display:inline-block;
+        font-size:1.15em;
+        font-weight:200;
+        line-height:1;
+    }
+    p {
+    }
+    a {
+        background:#fff;
+        padding:8px 16px;
+        color:#333;
+        font-weight:500;
+        margin-left:10px;
+        border:1px solid #fff;
+        &:hover {
+            text-decoration:none;
+            border-color:#333;
+
+        }
+    }
+
+}
+

--- a/public/sass/base/components/import.scss
+++ b/public/sass/base/components/import.scss
@@ -16,3 +16,6 @@
 @import 'available_exercises_listing';
 @import 'code_blocks';
 @import 'callout';
+
+@import 'banner';
+


### PR DESCRIPTION
We have 1000 submissions a day. Some of those submitters must want to be mentors. But they probably have no idea v2 is a thing. Let's change that.

This PR adds a fixed bar above the navigation bar with a CTA. It's a little ugly, but with 4 weeks to go and a lot of exercism's future success riding on recruiting mentors, I think it's a pragmatic thing to do.

<img width="1262" alt="screen shot 2018-06-12 at 22 59 44" src="https://user-images.githubusercontent.com/286476/41319834-0fb4ef2c-6e95-11e8-9efa-0cc69eb1dd33.png">
