### PR TITLE
Fix Navigation Bar on iPad (Tablet)

### DIFF
--- a/public/sass/base/themes/exercism.scss
+++ b/public/sass/base/themes/exercism.scss
@@ -337,7 +337,7 @@ $grid-columns:              12 !default;
 $grid-gutter-width:         30px !default;
 // Navbar collapse
 //** Point at which the navbar becomes uncollapsed.
-$grid-float-breakpoint:     $screen-sm-min !default;
+$grid-float-breakpoint:     $screen-md-min !default;
 //** Point at which the navbar begins collapsing.
 $grid-float-breakpoint-max: ($grid-float-breakpoint - 1) !default;
 


### PR DESCRIPTION
It was reported in https://github.com/exercism/exercism.io/issues/3785
that the nav bar was not rendering properly on the iPad.

Looking at the scss rules it looked like the rule to collapse the nav
bar was set to 768px which is the breakpoint for tablets in media
queries. Since it was within that range, that resolution was not
considered when determining if it should collapse the nav bar or not.

Bumping it up to the next breakpoint now collapses the items when
rendered from a tablet.

This resolves https://github.com/exercism/exercism.io/issues/3785

<img width="891" alt="2018-06-14_16-29-39" src="https://user-images.githubusercontent.com/1518902/41443216-6366e344-6ff0-11e8-9d5b-f03cc6175ada.png">
