### PR TITLE
Expanded submission instructions in the 'Try it' section

### DIFF
--- a/x/docs/md/track/TRY.md
+++ b/x/docs/md/track/TRY.md
@@ -25,6 +25,7 @@ exercism submit PATH_TO_YOUR_SOURCE_FILE
 
 If you split your solution into several files or have used additional configuration files, submit them too.
 
-It is fine to submit incomplete solutions. If you are struggling with a problem, submit the solution you currently
-have and then explore other solutions or ask for help from other students in the comments. When you understood the
-problem, rewrite your solution and submit it second time.
+### Are you stuck trying to solve an exercise?
+Submit the unfinished solution and describe in a comment on the website what you tried, and where
+you're stuck. Or jump into the [support chat](https://gitter.im/exercism/support), and we'll try to help you out.
+When you understood the problem, rewrite your solution and submit it second time.

--- a/x/docs/md/track/TRY.md
+++ b/x/docs/md/track/TRY.md
@@ -15,8 +15,15 @@ exercism configure --key=YOUR_EXERCISM_KEY
 ```
 
 When you've written a solution, submit it to the site.
-You'll have to configure the command-line client with your exercism API key before you can submit.
+The solution is a source file, in wich you have written your code
+to pass the test suite of a given problem, so the command to submit it will look like this:
 
 ```plain
-exercism submit PATH_TO_FILE
+exercism submit PATH_TO_YOUR_SOURCE_FILE
 ```
+
+If you have splitted your solution in several files or have used additional configuration files, submit them too.
+
+It is fine to submit incomplete solutions. If you are struggling with a problem, submit the solution you currently
+have and then explore other solutions or ask for help from other students in the comments. When you understood the
+problem, rewrite your solution and submit it second time.

--- a/x/docs/md/track/TRY.md
+++ b/x/docs/md/track/TRY.md
@@ -14,15 +14,16 @@ In order to be able to submit your solution, you'll need to configure the client
 exercism configure --key=YOUR_EXERCISM_KEY
 ```
 
-When you've written a solution, submit it to the site.
-The solution is a source file, in wich you have written your code
-to pass the test suite of a given problem, so the command to submit it will look like this:
+When you've written a solution, a source file to pass the test suite of a problem, submit it to the site.
+You'll have to configure the command-line client with your exercism API key before you can submit.
+
+Submit the solution with the following command:
 
 ```plain
 exercism submit PATH_TO_YOUR_SOURCE_FILE
 ```
 
-If you have splitted your solution in several files or have used additional configuration files, submit them too.
+If you split your solution into several files or have used additional configuration files, submit them too.
 
 It is fine to submit incomplete solutions. If you are struggling with a problem, submit the solution you currently
 have and then explore other solutions or ask for help from other students in the comments. When you understood the


### PR DESCRIPTION
Right now the `Try it!` section does not contain very clear instruction about what file you need to submit to pass the exercise and does not mention that you can submit multiple files, or re-submit your solution.

This PR tries to address this problem.