### PR TITLE
fix: follow up → follow-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you aren't sure where to open it, then pick this repository. It's as good a s
 
 ## Feeling uncomfortable?
 
-If you need to report a code of conduct violation, please email us at [abuse@exercism.org](mailto:abuse@exercism.org?subject=%5BCoC%5D) and include \[CoC\] in the subject line. We will follow up with you as a priority.
+If you need to report a code of conduct violation, please email us at [abuse@exercism.org](mailto:abuse@exercism.org?subject=%5BCoC%5D) and include \[CoC\] in the subject line. We will follow-up with you as a priority.
 
 ## Where to find the code
 


### PR DESCRIPTION
Sorry to be a pain there.
This was merged already before this was mentioned in the other PR to org-wide-files.

> In this context I believe follow up here acts as a phrasal verb rather than a compound noun. > The compound noun takes a hyphen, but the phrasal verb does not.
> 
> * https://github.com/exercism/org-wide-files/pull/220#issuecomment-1123215664